### PR TITLE
Replace toothLastMinusOneToothTime calculations with lastGap

### DIFF
--- a/speeduino/crankMaths.ino
+++ b/speeduino/crankMaths.ino
@@ -40,7 +40,7 @@ unsigned long angleToTime(int16_t angle, byte method)
         if(BIT_CHECK(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT))
         {
           noInterrupts();
-          unsigned long toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
+          unsigned long toothTime = lastGap;
           uint16_t tempTriggerToothAngle = triggerToothAngle; // triggerToothAngle is set by interrupts
           interrupts();
           
@@ -76,7 +76,7 @@ uint16_t timeToAngle(unsigned long time, byte method)
         if(BIT_CHECK(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT))
         {
           noInterrupts();
-          unsigned long toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
+          unsigned long toothTime = lastGap;
           uint16_t tempTriggerToothAngle = triggerToothAngle; // triggerToothAngle is set by interrupts
           interrupts();
 
@@ -143,14 +143,13 @@ void doCrankSpeedCalcs(void)
       {
         //If we can, attempt to get the timePerDegree by comparing the times of the last two teeth seen. This is only possible for evenly spaced teeth
         noInterrupts();
-        if( (BIT_CHECK(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT)) && (toothLastToothTime > toothLastMinusOneToothTime) && (abs(currentStatus.rpmDOT) > 30) )
+        if( (BIT_CHECK(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT)) && (lastGap > 0) && (abs(currentStatus.rpmDOT) > 30) )
         {
           //noInterrupts();
-          unsigned long tempToothLastToothTime = toothLastToothTime;
-          unsigned long tempToothLastMinusOneToothTime = toothLastMinusOneToothTime;
+          unsigned long tempLastGap = lastGap;
           uint16_t tempTriggerToothAngle = triggerToothAngle;
           interrupts();
-          timePerDegreex16 = (unsigned long)( (tempToothLastToothTime - tempToothLastMinusOneToothTime)*16) / tempTriggerToothAngle;
+          timePerDegreex16 = (unsigned long)(tempLastGap*16) / tempTriggerToothAngle;
           timePerDegree = timePerDegreex16 / 16;
         }
         else

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -241,7 +241,6 @@ extern volatile unsigned long toothSystemLastToothTime; //As below, but used for
 extern volatile unsigned long toothLastToothTime; //The time (micros()) that the last tooth was registered
 extern volatile unsigned long toothLastSecToothTime; //The time (micros()) that the last tooth was registered on the secondary input
 extern volatile unsigned long toothLastThirdToothTime; //The time (micros()) that the last tooth was registered on the second cam input
-extern volatile unsigned long toothLastMinusOneToothTime; //The time (micros()) that the tooth before the last tooth was registered
 extern volatile unsigned long toothLastMinusOneSecToothTime; //The time (micros()) that the tooth before the last tooth was registered on secondary input
 extern volatile unsigned long targetGap2;
 

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -4407,11 +4407,11 @@ void triggerSec_NGC68(void)
 
   if ( curGap2 > triggerSecFilterTime )
   {
-    if ( toothLastSecToothTime > 0 && toothLastToothTime > 0 && toothLastMinusOneToothTime > 0 ) //Make sure we have enough tooth information to calculate tooth lengths
+    if ( toothLastSecToothTime > 0 && lastGap > 0 ) //Make sure we have enough tooth information to calculate tooth lengths
     {
       /* Cam wheel can have a single tooth in a group which can screw up the "targetgap" calculations
          Instead use primary wheel tooth gap as comparison as those values are always correct. 2.1 primary teeth are the same duration as one secondary tooth. */
-      if (curGap2 >= (3 * (toothLastToothTime - toothLastMinusOneToothTime) ) ) // Check if we have a bigger gap, that is missing teeth
+      if (curGap2 >= lastGap * 3 ) // Check if we have a bigger gap, that is missing teeth
       {
         //toothSystemCount > 0 means we have cam sync and identifies which group we have synced with
         //toothAngles is reused to store the cam pattern
@@ -4637,7 +4637,7 @@ void triggerPri_Vmax(void)
             triggerToothAngle = 70;
             setFilter(curGap);//Angle to this tooth is 70, next is in 70. No need to compensate.
           }
-          toothLastMinusOneToothTime = toothLastToothTime;
+          if (toothLastToothTime > 0) { lastGap = curGap; }
           toothLastToothTime = curTime;
           if (triggerFilterTime > 50000){//The first pulse seen 
             triggerFilterTime = 0;
@@ -4697,13 +4697,13 @@ uint16_t getRPM_Vmax(void)
     {
       int tempToothAngle;
       unsigned long toothTime;
-      if ( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { tempRPM = 0; }
+      if ( lastGap == 0 ) { tempRPM = 0; }
       else
       {
         noInterrupts();
         tempToothAngle = triggerToothAngle;
         revolutionTime = (toothOneTime - toothOneMinusOneTime); //The time in uS that one revolution would take at current speed (The time tooth 1 was last seen, minus the time it was seen prior to that)
-        toothTime = (toothLastToothTime - toothLastMinusOneToothTime); 
+        toothTime = lastGap; 
         interrupts();
         toothTime = toothTime * 36;
         tempRPM = ((unsigned long)tempToothAngle * 6000000UL) / toothTime;

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -982,7 +982,7 @@ void triggerPri_BasicDistributor(void)
       else { checkPerToothTiming(crankAngle, toothCurrentCount); }
     }
 
-    toothLastMinusOneToothTime = toothLastToothTime;
+    if (toothLastToothTime > 0) { lastGap = curGap; }
     toothLastToothTime = curTime;
   } //Trigger filter
 }
@@ -1070,13 +1070,12 @@ void triggerSetup_GM7X(void)
 
 void triggerPri_GM7X(void)
 {
-    lastGap = curGap;
     curTime = micros();
     curGap = curTime - toothLastToothTime;
     toothCurrentCount++; //Increment the tooth counter
     BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
 
-    if( (toothLastToothTime > 0) && (toothLastMinusOneToothTime > 0) )
+    if( lastGap > 0 )
     {
       if( toothCurrentCount > 7 )
       {
@@ -1122,7 +1121,7 @@ void triggerPri_GM7X(void)
       } 
     }
 
-    toothLastMinusOneToothTime = toothLastToothTime;
+    if (toothLastToothTime > 0) { lastGap = curGap; }
     toothLastToothTime = curTime;
 
 
@@ -1259,7 +1258,7 @@ void triggerPri_4G63(void)
     BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
     triggerFilterTime = curGap >> 2; //This only applies during non-sync conditions. If there is sync then triggerFilterTime gets changed again below with a better value.
 
-    toothLastMinusOneToothTime = toothLastToothTime;
+    if (toothLastToothTime > 0) { lastGap = curGap; }
     toothLastToothTime = curTime;
 
     toothCurrentCount++;
@@ -1528,12 +1527,12 @@ uint16_t getRPM_4G63(void)
     {
       int tempToothAngle;
       unsigned long toothTime;
-      if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { tempRPM = 0; }
+      if( lastGap == 0 ) { tempRPM = 0; }
       else
       {
         noInterrupts();
         tempToothAngle = triggerToothAngle;
-        toothTime = (toothLastToothTime - toothLastMinusOneToothTime); //Note that trigger tooth angle changes between 70 and 110 depending on the last tooth that was seen (or 70/50 for 6 cylinders)
+        toothTime = lastGap; //Note that trigger tooth angle changes between 70 and 110 depending on the last tooth that was seen (or 70/50 for 6 cylinders)
         interrupts();
         toothTime = toothTime * 36;
         tempRPM = ((unsigned long)tempToothAngle * 6000000UL) / toothTime;
@@ -1809,7 +1808,7 @@ void triggerPri_Jeep2000(void)
 
       BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
 
-      toothLastMinusOneToothTime = toothLastToothTime;
+      if (toothLastToothTime > 0) { lastGap = curGap; }
       toothLastToothTime = curTime;
     } //Trigger filter
   } //Sync check

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -3723,6 +3723,8 @@ void triggerPri_420a(void)
     toothCurrentCount++; //Increment the tooth counter
     BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
 
+    if( lastGap == 0 ) { curGap = 0; }
+
     if( (toothCurrentCount > 16) && (currentStatus.hasSync == true) )
     {
       //Means a complete rotation has occurred.

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -3378,7 +3378,7 @@ void triggerSetup_ThirtySixMinus222(void)
   BIT_CLEAR(decoderState, BIT_DECODER_2ND_DERIV);
   BIT_CLEAR(decoderState, BIT_DECODER_IS_SEQUENTIAL);
   checkSyncToothCount = (configPage4.triggerTeeth) >> 1; //50% of the total teeth.
-  toothLastMinusOneToothTime = 0;
+  lastGap = 0;
   toothCurrentCount = 0;
   toothOneTime = 0;
   toothOneMinusOneTime = 0;
@@ -3397,10 +3397,10 @@ void triggerPri_ThirtySixMinus222(void)
      //Begin the missing tooth detection
      //If the time between the current tooth and the last is greater than 2x the time between the last tooth and the tooth before that, we make the assertion that we must be at the first tooth after a gap
      //toothSystemCount is used to keep track of which missed tooth we're on. It will be set to 1 if that last tooth seen was the middle one in the -2-2 area. At all other times it will be 0
-     if(toothSystemCount == 0) { targetGap = ((toothLastToothTime - toothLastMinusOneToothTime)) * 2; } //Multiply by 2 (Checks for a gap 2x greater than the last one)
+     if(toothSystemCount == 0) { targetGap = lastGap * 2; } //Multiply by 2 (Checks for a gap 2x greater than the last one)
 
 
-     if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { curGap = 0; }
+     if(toothLastToothTime == 0) { curGap = 0; }
 
      if ( (curGap > targetGap) )
      {
@@ -3462,7 +3462,7 @@ void triggerPri_ThirtySixMinus222(void)
        toothSystemCount = 0;
      }
 
-     toothLastMinusOneToothTime = toothLastToothTime;
+     if (toothLastToothTime > 0) { lastGap = curGap; }
      toothLastToothTime = curTime;
 
      //EXPERIMENTAL!
@@ -3560,7 +3560,7 @@ void triggerSetup_ThirtySixMinus21(void)
   BIT_CLEAR(decoderState, BIT_DECODER_2ND_DERIV);
   BIT_CLEAR(decoderState, BIT_DECODER_IS_SEQUENTIAL);
   checkSyncToothCount = (configPage4.triggerTeeth) >> 1; //50% of the total teeth.
-  toothLastMinusOneToothTime = 0;
+  lastGap = 0;
   toothCurrentCount = 0;
   toothOneTime = 0;
   toothOneMinusOneTime = 0;
@@ -3579,10 +3579,10 @@ void triggerPri_ThirtySixMinus21(void)
      //Begin the missing tooth detection
      //If the time between the current tooth and the last is greater than 2x the time between the last tooth and the tooth before that, we make the assertion that we must be at the first tooth after a gap
     
-     targetGap2 = (3 * (toothLastToothTime - toothLastMinusOneToothTime)) ; //Multiply by 3 (Checks for a gap 3x greater than the last one)
+     targetGap2 = 3 * lastGap; //Multiply by 3 (Checks for a gap 3x greater than the last one)
      targetGap = targetGap2 >> 1;  //Multiply by 1.5 (Checks for a gap 1.5x greater than the last one) (Uses bitshift to divide by 2 as in the missing tooth decoder)
 
-     if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { curGap = 0; }
+     if(toothLastToothTime == 0) { curGap = 0; }
 
      if ( (curGap > targetGap) )
      {
@@ -3623,7 +3623,7 @@ void triggerPri_ThirtySixMinus21(void)
 
      }
 
-     toothLastMinusOneToothTime = toothLastToothTime;
+     if (toothLastToothTime > 0) { lastGap = curGap; }
      toothLastToothTime = curTime;
 
      //EXPERIMENTAL!

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -264,10 +264,10 @@ static inline int crankingGetRPM(byte totalTeeth, uint16_t degreesOver)
   uint16_t tempRPM = 0;
   if( (currentStatus.startRevolutions >= configPage4.StgCycles) && ((currentStatus.hasSync == true) || BIT_CHECK(currentStatus.status3, BIT_STATUS3_HALFSYNC)) )
   {
-    if( (toothLastToothTime > 0) && (toothLastMinusOneToothTime > 0) && (toothLastToothTime > toothLastMinusOneToothTime) )
+    if( lastGap > 0 )
     {
       noInterrupts();
-      revolutionTime = (toothLastToothTime - toothLastMinusOneToothTime) * totalTeeth;
+      revolutionTime = lastGap * totalTeeth;
       interrupts();
       if(degreesOver == 720) { revolutionTime = revolutionTime / 2; }
       tempRPM = (US_IN_MINUTE / revolutionTime);

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -206,7 +206,6 @@ void loop(void)
       currentStatus.VE2 = 0;
       toothLastToothTime = 0;
       toothLastSecToothTime = 0;
-      //toothLastMinusOneToothTime = 0;
       currentStatus.hasSync = false;
       BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
       currentStatus.runSecs = 0; //Reset the counter for number of seconds running.

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -205,6 +205,7 @@ void loop(void)
       currentStatus.VE = 0;
       currentStatus.VE2 = 0;
       toothLastToothTime = 0;
+      lastGap = 0;
       toothLastSecToothTime = 0;
       currentStatus.hasSync = false;
       BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1103,7 +1103,7 @@ void loop(void)
           if(ignition1EndAngle > crankAngle) { uSToEnd = fastDegreesToUS( (ignition1EndAngle - crankAngle) ); }
           else { uSToEnd = fastDegreesToUS( (360 + ignition1EndAngle - crankAngle) ); }
           //*********
-          //uSToEnd = ((ignition1EndAngle - crankAngle) * (toothLastToothTime - toothLastMinusOneToothTime)) / triggerToothAngle;
+          //uSToEnd = ((ignition1EndAngle - crankAngle) * lastGap) / triggerToothAngle;
           //*********
 
           refreshIgnitionSchedule1( uSToEnd + fixedCrankingOverride );

--- a/test/test_misc2/tests_crankmaths.cpp
+++ b/test/test_misc2/tests_crankmaths.cpp
@@ -27,7 +27,7 @@ void test_crankmaths_angletotime_revolution_execute() {
 void test_crankmaths_angletotime_tooth_execute() {
   crankmaths_tooth_testdata *testdata = crankmaths_tooth_testdata_current;
   triggerToothAngle = testdata->triggerToothAngle;
-  toothLastToothTime = toothLastMinusOneToothTime + testdata->toothTime;
+  lastGap = testdata->toothTime;
   TEST_ASSERT_EQUAL(testdata->expected, angleToTime(testdata->angle, CRANKMATH_METHOD_INTERVAL_TOOTH));
 }
 
@@ -76,7 +76,6 @@ void testCrankMaths()
   };
   // The same for all tests
   BIT_SET(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT);
-  toothLastMinusOneToothTime = 200000;
 
   for (auto testdata : crankmaths_tooth_testdatas) {
     crankmaths_tooth_testdata_current = &testdata;


### PR DESCRIPTION
toothLastMinusOneToothTime is only used to calculate the gap between the last two triggers/edges/teeth and this is done in quite a few places throughout the code. Use lastGap variable instead and set it to the almost always already calculated curGap.

All patterns have been tested for basic sync/rpm readings with the following exceptions:
Jeep 2000 not in ardustim, untested
Harley EVO not in ardustim, untested
36-2-1 not in ardustim, untested (but similar decoder 36-2-2-2 works)
Mazda AU does not sync on master

Bench-tested 0.4.3d with Ardu-Stim:
Basic Distributor gives ~0,65% loops/sec increase across the RPM range
Missing Tooth 60-2 gives loops/sec increase of 0,8% at 1000RPM and 2,4% at 6000RPM.

4 bytes less memory but 66 bytes larger firmware.