### PR TITLE
Stall reset changes

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -244,7 +244,7 @@ void processSerialCommand(void)
       break;
 
     case 'b': // New EEPROM burn command to only burn a single page at a time 
-      if( (micros() > deferEEPROMWritesUntil)) { writeConfig(serialPayload[2]); } //Read the table number and perform burn. Note that byte 1 in the array is unused
+      if( (micros() - lastEEPROMDeferTime > EEPROM_DEFER_DELAY)) { writeConfig(serialPayload[2]); } //Read the table number and perform burn. Note that byte 1 in the array is unused
       else { BIT_SET(currentStatus.status4, BIT_STATUS4_BURNPENDING); }
       
       sendSerialReturnCode(SERIAL_RC_BURN_OK);
@@ -419,7 +419,7 @@ void processSerialCommand(void)
         setPageValue(currentPage, (valueOffset + i), serialPayload[7 + i]);
       }
       
-      deferEEPROMWritesUntil = micros() + EEPROM_DEFER_DELAY;
+      lastEEPROMDeferTime = micros();
       
       sendSerialReturnCode(SERIAL_RC_OK);
       

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -63,7 +63,6 @@ void loggerPrimaryISR(void);
 void loggerSecondaryISR(void);
 
 inline void resetDecoderState();
-inline bool isDecoderStalled();
 
 //All of the below are the 6 required functions for each decoder / pattern
 void triggerSetup_missingTooth(void);
@@ -277,6 +276,26 @@ extern uint16_t ignition7EndTooth;
 extern uint16_t ignition8EndTooth;
 
 extern int16_t toothAngles[24]; //An array for storing fixed tooth angles. Currently sized at 24 for the GM 24X decoder, but may grow later if there are other decoders that use this style
+
+/**
+ * Returns true if the decoder has stalled. Returns false if the decoder has not stalled.
+ * Stalling is determined by looking at how long ago the last tooth was seen.
+ * The delay varies between decoders and can change from tooth to tooth.
+ * This function must always be called with interrupts disabled
+ */
+inline bool isDecoderStalled() {
+  bool decoderStalled;
+
+  uint32_t timeToLastTooth = (MICROS_SAFE_OR_TEST_INJECTION - toothLastToothTime);
+  if ( timeToLastTooth > MAX_STALL_TIME ) {
+    decoderStalled = true;
+  }
+  else {
+    decoderStalled = false;
+  }
+
+  return decoderStalled;
+}
 
 //Used for identifying long and short pulses on the 4G63 (And possibly other) trigger patterns
 #define LONG 0;

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -62,6 +62,8 @@ extern bool decoderHasFixedCrankingTiming;
 void loggerPrimaryISR(void);
 void loggerSecondaryISR(void);
 
+extern void resetDecoderState();
+
 //All of the below are the 6 required functions for each decoder / pattern
 void triggerSetup_missingTooth(void);
 void triggerPri_missingTooth(void);

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -62,7 +62,8 @@ extern bool decoderHasFixedCrankingTiming;
 void loggerPrimaryISR(void);
 void loggerSecondaryISR(void);
 
-extern void resetDecoderState();
+inline void resetDecoderState();
+inline bool isDecoderStalled();
 
 //All of the below are the 6 required functions for each decoder / pattern
 void triggerSetup_missingTooth(void);

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -279,9 +279,29 @@ static inline int crankingGetRPM(byte totalTeeth, uint16_t degreesOver)
 }
 
 /**
+ * Returns true if the decoder has stalled. Returns false if the decoder has not stalled.
+ * Stalling is determined by looking at how long ago the last tooth was seen.
+ * The delay varies between decoders and can change from tooth to tooth.
+ * This function must always be called with interrupts disabled
+ */
+inline bool isDecoderStalled() {
+  bool decoderStalled;
+
+  uint32_t timeToLastTooth = (micros_safe() - toothLastToothTime);
+  if ( timeToLastTooth > MAX_STALL_TIME ) {
+    decoderStalled = true;
+  }
+  else {
+    decoderStalled = false;
+  }
+
+  return decoderStalled;
+}
+
+/**
  * Resets most decoder variables
  */
-void resetDecoderState() {
+inline void resetDecoderState() {
   //Decoder output variables
   toothLastToothTime = 0;
   toothLastMinusOneToothTime = 0;

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -279,26 +279,6 @@ static inline int crankingGetRPM(byte totalTeeth, uint16_t degreesOver)
 }
 
 /**
- * Returns true if the decoder has stalled. Returns false if the decoder has not stalled.
- * Stalling is determined by looking at how long ago the last tooth was seen.
- * The delay varies between decoders and can change from tooth to tooth.
- * This function must always be called with interrupts disabled
- */
-inline bool isDecoderStalled() {
-  bool decoderStalled;
-
-  uint32_t timeToLastTooth = (micros_safe() - toothLastToothTime);
-  if ( timeToLastTooth > MAX_STALL_TIME ) {
-    decoderStalled = true;
-  }
-  else {
-    decoderStalled = false;
-  }
-
-  return decoderStalled;
-}
-
-/**
  * Resets most decoder variables
  */
 inline void resetDecoderState() {

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -289,7 +289,7 @@ inline void resetDecoderState() {
   BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
   currentStatus.startRevolutions = 0;
   triggerToothAngle = 0;
-  triggerToothAngleIsCorrect = false;
+  BIT_CLEAR(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT);
   revolutionTime = 0;
   MAX_STALL_TIME = 500000UL; // Default 0,5 seconds
 

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -279,6 +279,29 @@ static inline int crankingGetRPM(byte totalTeeth, uint16_t degreesOver)
 }
 
 /**
+ * Resets most decoder variables
+ */
+void resetDecoderState() {
+  //Decoder output variables
+  toothLastToothTime = 0;
+  toothLastMinusOneToothTime = 0;
+  currentStatus.hasSync = false;
+  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
+  currentStatus.startRevolutions = 0;
+  triggerToothAngle = 0;
+  triggerToothAngleIsCorrect = false;
+  revolutionTime = 0;
+  MAX_STALL_TIME = 500000UL; // Default 0,5 seconds
+
+  //Common decoder shared variables
+  toothOneTime = 0;
+  toothOneMinusOneTime = 0;
+  toothLastSecToothTime = 0;
+  toothSystemCount = 0;
+  secondaryToothCount = 0;
+}
+
+/**
 On decoders that are enabled for per tooth based timing adjustments, this function performs the timer compare changes on the schedules themselves
 For each ignition channel, a check is made whether we're at the relevant tooth and whether that ignition schedule is currently running
 Only if both these conditions are met will the schedule be updated with the latest timing information.

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -447,6 +447,16 @@ This is so we can use an unsigned byte (0-255) to represent temperature ranges f
 #define LOGGER_FILENAMING_DATETIME      1
 #define LOGGER_FILENAMING_SEQENTIAL     2
 
+#ifdef UNIT_TEST
+  extern unsigned long micros_safe_injection;
+  #define MICROS_SAFE_OR_TEST_INJECTION micros_safe_injection
+  extern unsigned long micros_injection;
+  #define MICROS_OR_TEST_INJECTION micros_injection
+#else
+  #define MICROS_SAFE_OR_TEST_INJECTION micros_safe()
+  #define MICROS_OR_TEST_INJECTION micros()
+#endif
+
 extern const char TSfirmwareVersion[] PROGMEM;
 
 extern const byte data_structure_version; //This identifies the data structure when reading / writing. Now in use: CURRENT_DATA_VERSION (migration on-the fly) ?

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -599,7 +599,6 @@ extern volatile uint8_t compositeLogHistory[TOOTH_LOG_SIZE];
 extern volatile bool fpPrimed; //Tracks whether or not the fuel pump priming has been completed yet
 extern volatile bool injPrimed; //Tracks whether or not the injector priming has been completed yet
 extern volatile unsigned int toothHistoryIndex;
-extern unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 extern volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
 //The below shouldn't be needed and probably should be cleaned up, but the Atmel SAM (ARM) boards use a specific type for the trigger edge values rather than a simple byte/int
 #if defined(CORE_SAMD21)

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -139,7 +139,6 @@ volatile uint8_t compositeLogHistory[TOOTH_LOG_SIZE];
 volatile bool fpPrimed = false; ///< Tracks whether or not the fuel pump priming has been completed yet
 volatile bool injPrimed = false; ///< Tracks whether or not the injectors priming has been completed yet
 volatile unsigned int toothHistoryIndex = 0; ///< Current index to @ref toothHistory array
-unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
 #if defined(CORE_SAMD21)
   PinStatus primaryTriggerEdge;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -3,6 +3,11 @@
  */
 #include "globals.h"
 
+#ifdef UNIT_TEST
+  unsigned long micros_safe_injection;
+  unsigned long micros_injection;
+#endif
+
 const char TSfirmwareVersion[] PROGMEM = "Speeduino";
 
 const byte data_structure_version = 2; //This identifies the data structure when reading / writing. (outdated ?)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -430,7 +430,6 @@ void initialiseAll(void)
     }
 
     //Initial values for loop times
-    currentLoopTime = micros_safe();
     mainLoopCount = 0;
 
     currentStatus.nSquirts = configPage2.nCylinders / configPage2.divider; //The number of squirts being requested. This is manually overridden below for sequential setups (Due to TS req_fuel calc limitations)

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -179,12 +179,6 @@ void loop(void)
             }
           }
       #endif
-          
-    if(currentLoopTime > micros_safe())
-    {
-      //Occurs when micros() has overflowed
-      deferEEPROMWritesUntil = 0; //Required to ensure that EEPROM writes are not deferred indefinitely
-    }
 
     currentLoopTime = micros_safe();
     unsigned long timeToLastTooth = (currentLoopTime - toothLastToothTime);
@@ -301,7 +295,7 @@ void loop(void)
       // Air conditioning control
       airConControl();
 
-      //if( (isEepromWritePending() == true) && (serialReceivePending == false) && (micros() > deferEEPROMWritesUntil)) { writeAllConfig(); } //Used for slower EEPROM writes (Currently this runs in the 30Hz block)
+      //if( (isEepromWritePending() == true) && (serialReceivePending == false) && (micros() - lastEEPROMDeferTime > EEPROM_DEFER_DELAY)) { writeAllConfig(); } //Used for slower EEPROM writes (Currently this runs in the 30Hz block)
       
       currentStatus.vss = getSpeed();
       currentStatus.gear = getGear();
@@ -334,7 +328,7 @@ void loop(void)
       #endif
 
       //Check for any outstanding EEPROM writes.
-      if( (isEepromWritePending() == true) && (serialReceivePending == false) && (micros() > deferEEPROMWritesUntil)) { writeAllConfig(); } 
+      if( (isEepromWritePending() == true) && (serialReceivePending == false) && (micros() - lastEEPROMDeferTime > EEPROM_DEFER_DELAY)) { writeAllConfig(); } 
     }
     if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_4HZ))
     {

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -180,10 +180,8 @@ void loop(void)
           }
       #endif
 
-    currentLoopTime = micros_safe();
     noInterrupts(); // Make sure we can reset everything before any other interrupts fire. It's also required for the isDecoderStalled function.
-    unsigned long timeToLastTooth = (currentLoopTime - toothLastToothTime);
-    if ( (timeToLastTooth < MAX_STALL_TIME) || (toothLastToothTime > currentLoopTime) ) //Check how long ago the last tooth was seen compared to now. If it was more than half a second ago then the engine is probably stopped. toothLastToothTime can be greater than currentLoopTime if a pulse occurs between getting the latest time and doing the comparison
+    if ( isDecoderStalled() == false ) //Check how long ago the last tooth was seen compared to now.
     { //Engine is not stalled so continue as normal
       interrupts();
       currentStatus.longRPM = getRPM(); //Long RPM is included here

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -198,15 +198,7 @@ void loop(void)
       currentStatus.PW1 = 0;
       currentStatus.VE = 0;
       currentStatus.VE2 = 0;
-      toothLastToothTime = 0;
-      toothLastSecToothTime = 0;
-      //toothLastMinusOneToothTime = 0;
-      currentStatus.hasSync = false;
-      BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
       currentStatus.runSecs = 0; //Reset the counter for number of seconds running.
-      currentStatus.startRevolutions = 0;
-      toothSystemCount = 0;
-      secondaryToothCount = 0;
       MAPcurRev = 0;
       MAPcount = 0;
       currentStatus.rpmDOT = 0;
@@ -222,6 +214,7 @@ void loop(void)
       BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ASE); //Same as above except for ASE status
       BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ACC); //Same as above but the accel enrich (If using MAP accel enrich a stall will cause this to trigger)
       BIT_CLEAR(currentStatus.engine, BIT_ENGINE_DCC); //Same as above but the decel enleanment
+      resetDecoderState();
       //This is a safety check. If for some reason the interrupts have got screwed up (Leading to 0rpm), this resets them.
       //It can possibly be run much less frequently.
       //This should only be run if the high speed logger are off because it will change the trigger interrupts back to defaults rather than the logger versions

--- a/speeduino/storage.cpp
+++ b/speeduino/storage.cpp
@@ -28,7 +28,7 @@ A full copy of the license may be found in the projects root directory
 #define EEPROM_LAST_BARO              (EEPROM_CALIBRATION_O2_BINS-1)
 
 
-uint32_t deferEEPROMWritesUntil = 0;
+uint32_t lastEEPROMDeferTime;
 
 bool isEepromWritePending(void)
 {

--- a/speeduino/storage.h
+++ b/speeduino/storage.h
@@ -142,7 +142,7 @@ uint32_t readCalibrationCRC32(uint8_t calibrationPageNum);
 uint16_t getEEPROMSize(void);
 bool isEepromWritePending(void);
 
-extern uint32_t deferEEPROMWritesUntil;
+extern uint32_t lastEEPROMDeferTime;
 
 #define EEPROM_CONFIG1_MAP    3
 #define EEPROM_CONFIG2_START  291

--- a/test/test_decoders/isDecoderStalled/isDecoderStalled.cpp
+++ b/test/test_decoders/isDecoderStalled/isDecoderStalled.cpp
@@ -1,0 +1,76 @@
+#include <decoders.h>
+#include <globals.h>
+#include <unity.h>
+#include "decoders.h"
+
+#ifndef UNIT_TEST 
+  extern unsigned long micros_safe_injection; // Hack so that vscode sees the variable
+#endif
+
+struct isDecoderStalled_testdata {
+  unsigned long micros;
+  unsigned long toothLastToothTime;
+  bool expected;
+} *isDecoderStalled_testdata_current;
+
+void testIsDecoderStalled_runTest() {
+  isDecoderStalled_testdata *testdata = isDecoderStalled_testdata_current;
+
+  micros_safe_injection = testdata->micros;
+  toothLastToothTime = testdata->toothLastToothTime;
+
+  if (testdata->expected) {
+    TEST_ASSERT_TRUE(isDecoderStalled());
+  }
+  else {
+    TEST_ASSERT_FALSE(isDecoderStalled());
+  }
+}
+
+void testIsDecoderStalled() {
+  MAX_STALL_TIME = 50000;
+
+  const byte testNameLength = 200;
+  char testName[testNameLength];
+
+  const isDecoderStalled_testdata isDecoderStalled_testdatas[] = {
+
+    // Should stall. Tooth was recorded longer ago than MAX_STALL_TIME.
+    { .micros = 0UL,       .toothLastToothTime = 0UL - MAX_STALL_TIME - 1,       .expected = true },
+    { .micros = 20000UL,   .toothLastToothTime = 20000UL - MAX_STALL_TIME - 1,   .expected = true },
+    { .micros = 1000000UL, .toothLastToothTime = 1000000UL - MAX_STALL_TIME - 1, .expected = true },
+    { .micros = ULONG_MAX, .toothLastToothTime = ULONG_MAX - MAX_STALL_TIME - 1, .expected = true },
+
+    // Should not stall. Tooth was recorded just before.
+    { .micros = 0UL,       .toothLastToothTime = 0UL - 1,       .expected = false },
+    { .micros = 20000UL,   .toothLastToothTime = 20000UL - 1,   .expected = false },
+    { .micros = 1000000UL, .toothLastToothTime = 1000000UL - 1, .expected = false },
+    { .micros = ULONG_MAX, .toothLastToothTime = ULONG_MAX - 1, .expected = false },
+
+    // Should not stall. Tooth was recorded at the same time (but just before).
+    { .micros = 0UL,       .toothLastToothTime = 0UL,       .expected = false },
+    { .micros = 20000UL,   .toothLastToothTime = 20000UL,   .expected = false },
+    { .micros = 1000000UL, .toothLastToothTime = 1000000UL, .expected = false },
+    { .micros = ULONG_MAX, .toothLastToothTime = ULONG_MAX, .expected = false },
+
+    // Should stall. Tooth was recorded after function call. Is not possible as isDecoderStalled must have interrupts disabled before being called.
+    { .micros = 0UL,       .toothLastToothTime = 0UL + 1,       .expected = true },
+    { .micros = 20000UL,   .toothLastToothTime = 20000UL + 1,   .expected = true },
+    { .micros = 1000000UL, .toothLastToothTime = 1000000UL + 1, .expected = true },
+    { .micros = ULONG_MAX, .toothLastToothTime = ULONG_MAX + 1, .expected = true },
+
+    // Should stall. Tooth was recorded after function call. Is not possible as isDecoderStalled must have interrupts disabled before being called.
+    { .micros = 0UL,       .toothLastToothTime = 0UL + MAX_STALL_TIME + 1,       .expected = true },
+    { .micros = 20000UL,   .toothLastToothTime = 20000UL + MAX_STALL_TIME + 1,   .expected = true },
+    { .micros = 1000000UL, .toothLastToothTime = 1000000UL + MAX_STALL_TIME + 1, .expected = true },
+    { .micros = ULONG_MAX, .toothLastToothTime = ULONG_MAX + MAX_STALL_TIME + 1, .expected = true },
+
+  };
+
+  for (auto testdata : isDecoderStalled_testdatas) {
+    isDecoderStalled_testdata_current = &testdata;
+    snprintf(testName, testNameLength, "isDecoderStalled / micros %lu / lastTooth %lu ", testdata.micros, testdata.toothLastToothTime);
+    UnityDefaultTestRun(testIsDecoderStalled_runTest, testName, __LINE__);
+  }
+
+}

--- a/test/test_decoders/isDecoderStalled/isDecoderStalled.h
+++ b/test/test_decoders/isDecoderStalled/isDecoderStalled.h
@@ -1,0 +1,1 @@
+void testIsDecoderStalled();

--- a/test/test_decoders/test_decoders.cpp
+++ b/test/test_decoders/test_decoders.cpp
@@ -5,6 +5,7 @@
 
 #include "missing_tooth/missing_tooth.h"
 #include "dual_wheel/dual_wheel.h"
+#include "isDecoderStalled/isDecoderStalled.h"
 
 void setup()
 {
@@ -18,6 +19,7 @@ void setup()
 
     testMissingTooth();
     testDualWheel();
+    testIsDecoderStalled();
 
     UNITY_END(); // stop unit testing
 }


### PR DESCRIPTION
Move decoder stall checks and decoder variable resets to decoders.ino as separate functions. Primary purposes are for clarity and to allow for unit testing.

Also prevents interrupts when stall checking and resetting to prevent interrupt race issues.

Working as expected when bench-testing. 4 bytes reduced heap memory and 72 bytes smaller firmware. Loops/sec unchanged.