### PR TITLE
Fix analog pin selection

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1529,7 +1529,7 @@ page = 15
     requiresPowerCycle = wmiIndicatorPolarity
     requiresPowerCycle = vvtCLminDuty
     requiresPowerCycle = vvtCLmaxDuty
-
+    requiresPowerCycle = wmiEnabledPin
     requiresPowerCycle = caninput_sel0a
     requiresPowerCycle = caninput_sel0b
     requiresPowerCycle = caninput_sel1a
@@ -1563,7 +1563,7 @@ page = 15
     requiresPowerCycle = caninput_sel15a
     requiresPowerCycle = caninput_sel15b
     requiresPowerCycle = outputPin
-
+    requiresPowerCycle = ignBypassPin
     requiresPowerCycle = airConEnable
     requiresPowerCycle = airConCompPin
     requiresPowerCycle = airConReqPin
@@ -1572,11 +1572,17 @@ page = 15
     requiresPowerCycle = airConCompPol
     requiresPowerCycle = airConFanPol
     requiresPowerCycle = airConFanEnabled
-
+    requiresPowerCycle = tachoPin
     requiresPowerCycle = fuelPressureEnable
     requiresPowerCycle = oilPressureEnable
     requiresPowerCycle = fuelPressurePin
     requiresPowerCycle = oilPressurePin
+    requiresPowerCycle = spark2InputPin
+    requiresPowerCycle = vvt1Pin
+    requiresPowerCycle = vvt2Pin
+    requiresPowerCycle = onboard_log_trigger_Epin
+    requiresPowerCycle = idleUpPin
+    requiresPowerCycle = idleUpOutputPin
 
     defaultValue = pinLayout,   1
     defaultValue = TrigPattern, 0

--- a/speeduino/utilities.ino
+++ b/speeduino/utilities.ino
@@ -32,7 +32,9 @@ For **analog pins**, it will translate them into the correct internal pin number
 byte pinTranslate(byte rawPin)
 {
   byte outputPin = rawPin;
-  if(rawPin > BOARD_MAX_DIGITAL_PINS) { outputPin = A8 + (outputPin - BOARD_MAX_DIGITAL_PINS - 1); }
+  // The pin list on speeduino.ini is: all_IO_Pins = "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
+  // If the selected pin is bigger than 54 or bigger than BOARD_MAX_DIGITAL_PINS, the output pin will be analog pin starting from A8. A8 = rawPin 55.
+  if(rawPin > (BOARD_MAX_DIGITAL_PINS || 54)) { outputPin = A8 + (outputPin - 55); }
 
   return outputPin;
 }

--- a/speeduino/utilities.ino
+++ b/speeduino/utilities.ino
@@ -34,7 +34,7 @@ byte pinTranslate(byte rawPin)
   byte outputPin = rawPin;
   // The pin list on speeduino.ini is: all_IO_Pins = "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
   // If the selected pin is bigger than 54 or bigger than BOARD_MAX_DIGITAL_PINS, the output pin will be analog pin starting from A8. A8 = rawPin 55.
-  if(rawPin > (BOARD_MAX_DIGITAL_PINS || 54)) { outputPin = A8 + (outputPin - 55); }
+  if( (rawPin > BOARD_MAX_DIGITAL_PINS) || (rawPin > 54) ) { outputPin = A8 + (outputPin - 55); }
 
   return outputPin;
 }


### PR DESCRIPTION
The  `pinTranslate` -function doesn't really work for anything other than Arduino Mega. The digital pins part is ok, but for STM32 and Teensy, it gives out wrong analog pin. So for example if you try to use analog input as secondary spark table switch, it wont work on STM32/Teensy. Other thing is that this function is only called at the initialization, so all the inputs that use this function need to be on the `requiresPowerCycle` -list on speeduino.ini, for the analog input pin selections to work properly. This PR fixes these problems.  