### PR TITLE
No longer create ignition schedules during clear flood

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -946,7 +946,7 @@ struct config4 {
   byte triggerTeeth;  ///< The full count of teeth on the trigger wheel if there were no gaps
   byte triggerMissingTeeth; ///< The size of the tooth gap (ie number of missing teeth)
   byte crankRPM;      ///< RPM below which the engine is considered to be cranking
-  byte floodClear;    ///< TPS (raw adc count? % ?) value that triggers flood clear mode (No fuel whilst cranking, See @ref correctionFloodClear())
+  byte floodClear;    ///< TPS (raw adc count? % ?) value that triggers flood clear mode (No fuel or ignition whilst cranking, See @ref correctionFloodClear())
   byte SoftRevLim;    ///< Soft rev limit (RPM/100)
   byte SoftLimRetard; ///< Amount soft limit (ignition) retard (degrees)
   byte SoftLimMax;    ///< Time the soft limit can run (units 0.1S)

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -609,19 +609,21 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule1.startCompare = IGN1_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule1.endScheduleSetByDecoder == false) { ignitionSchedule1.endCompare = ignitionSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.startCompare);
-    ignitionSchedule1.Status = PENDING; //Turn this schedule on
-    ignitionSchedule1.schedulesSet++;
-    interrupts();
-    IGN1_TIMER_ENABLE();
+    if  (currentStatus.TPS < configPage4.floodClear){ 
+      ignitionSchedule1.startCompare = IGN1_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
+      if(ignitionSchedule1.endScheduleSetByDecoder == false) { ignitionSchedule1.endCompare = ignitionSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+      SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.startCompare);
+      ignitionSchedule1.Status = PENDING; //Turn this schedule on
+      ignitionSchedule1.schedulesSet++;
+      interrupts();
+      IGN1_TIMER_ENABLE();
+    }
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if (timeout < MAX_TIMER_PERIOD)
+    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
       ignitionSchedule1.nextStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule1.nextEndCompare = ignitionSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -658,19 +660,21 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule2.startCompare = IGN2_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule2.endScheduleSetByDecoder == false) { ignitionSchedule2.endCompare = ignitionSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.startCompare);
-    ignitionSchedule2.Status = PENDING; //Turn this schedule on
-    ignitionSchedule2.schedulesSet++;
-    interrupts();
-    IGN2_TIMER_ENABLE();
+    if  (currentStatus.TPS < configPage4.floodClear){ 
+      ignitionSchedule2.startCompare = IGN2_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
+      if(ignitionSchedule2.endScheduleSetByDecoder == false) { ignitionSchedule2.endCompare = ignitionSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+      SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.startCompare);
+      ignitionSchedule2.Status = PENDING; //Turn this schedule on
+      ignitionSchedule2.schedulesSet++;
+      interrupts();
+      IGN2_TIMER_ENABLE();
+    }
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if (timeout < MAX_TIMER_PERIOD)
+    if ((timeout < MAX_TIMER_PERIOD) &&  (currentStatus.TPS < configPage4.floodClear))
     {
       ignitionSchedule2.nextStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule2.nextEndCompare = ignitionSchedule2.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -693,19 +697,21 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule3.startCompare = IGN3_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule3.endScheduleSetByDecoder == false) { ignitionSchedule3.endCompare = ignitionSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.startCompare);
-    ignitionSchedule3.Status = PENDING; //Turn this schedule on
-    ignitionSchedule3.schedulesSet++;
-    interrupts();
-    IGN3_TIMER_ENABLE();
+    if  (currentStatus.TPS < configPage4.floodClear){ 
+      ignitionSchedule3.startCompare = IGN3_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
+      if(ignitionSchedule3.endScheduleSetByDecoder == false) { ignitionSchedule3.endCompare = ignitionSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+      SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.startCompare);
+      ignitionSchedule3.Status = PENDING; //Turn this schedule on
+      ignitionSchedule3.schedulesSet++;
+      interrupts();
+      IGN3_TIMER_ENABLE();
+    }
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if (timeout < MAX_TIMER_PERIOD)
+    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
       ignitionSchedule3.nextStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule3.nextEndCompare = ignitionSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -728,19 +734,21 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule4.startCompare = IGN4_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.startCompare);
-    ignitionSchedule4.Status = PENDING; //Turn this schedule on
-    ignitionSchedule4.schedulesSet++;
-    interrupts();
-    IGN4_TIMER_ENABLE();
+    if  (currentStatus.TPS < configPage4.floodClear){ 
+      ignitionSchedule4.startCompare = IGN4_COUNTER + timeout_timer_compare;
+      if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+      SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.startCompare);
+      ignitionSchedule4.Status = PENDING; //Turn this schedule on
+      ignitionSchedule4.schedulesSet++;
+      interrupts();
+      IGN4_TIMER_ENABLE();
+    }
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if (timeout < MAX_TIMER_PERIOD)
+    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
       ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule4.nextEndCompare = ignitionSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -762,20 +770,22 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
-    noInterrupts();
-    ignitionSchedule5.startCompare = IGN5_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule5.endScheduleSetByDecoder == false) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    SET_COMPARE(IGN5_COMPARE, ignitionSchedule5.startCompare);
-    ignitionSchedule5.Status = PENDING; //Turn this schedule on
-    ignitionSchedule5.schedulesSet++;
-    interrupts();
-    IGN5_TIMER_ENABLE();
+    if  (currentStatus.TPS < configPage4.floodClear){ 
+      noInterrupts();
+      ignitionSchedule5.startCompare = IGN5_COUNTER + timeout_timer_compare;
+      if(ignitionSchedule5.endScheduleSetByDecoder == false) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+      SET_COMPARE(IGN5_COMPARE, ignitionSchedule5.startCompare);
+      ignitionSchedule5.Status = PENDING; //Turn this schedule on
+      ignitionSchedule5.schedulesSet++;
+      interrupts();
+      IGN5_TIMER_ENABLE();
+    }
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if (timeout < MAX_TIMER_PERIOD)
+    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
       ignitionSchedule5.nextStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule5.nextEndCompare = ignitionSchedule5.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -797,20 +807,22 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
-    noInterrupts();
-    ignitionSchedule6.startCompare = IGN6_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule6.endScheduleSetByDecoder == false) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    SET_COMPARE(IGN6_COMPARE, ignitionSchedule6.startCompare);
-    ignitionSchedule6.Status = PENDING; //Turn this schedule on
-    ignitionSchedule6.schedulesSet++;
-    interrupts();
-    IGN6_TIMER_ENABLE();
+    if  (currentStatus.TPS < configPage4.floodClear){ 
+      noInterrupts();
+      ignitionSchedule6.startCompare = IGN6_COUNTER + timeout_timer_compare;
+      if(ignitionSchedule6.endScheduleSetByDecoder == false) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+      SET_COMPARE(IGN6_COMPARE, ignitionSchedule6.startCompare);
+      ignitionSchedule6.Status = PENDING; //Turn this schedule on
+      ignitionSchedule6.schedulesSet++;
+      interrupts();
+      IGN6_TIMER_ENABLE();
+    }
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if (timeout < MAX_TIMER_PERIOD)
+    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
       ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule6.nextEndCompare = ignitionSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -832,20 +844,22 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
-    noInterrupts();
-    ignitionSchedule7.startCompare = IGN7_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule7.endScheduleSetByDecoder == false) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    SET_COMPARE(IGN7_COMPARE, ignitionSchedule7.startCompare);
-    ignitionSchedule7.Status = PENDING; //Turn this schedule on
-    ignitionSchedule7.schedulesSet++;
-    interrupts();
-    IGN7_TIMER_ENABLE();
+    if  (currentStatus.TPS < configPage4.floodClear){ 
+      noInterrupts();
+      ignitionSchedule7.startCompare = IGN7_COUNTER + timeout_timer_compare;
+      if(ignitionSchedule7.endScheduleSetByDecoder == false) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+      SET_COMPARE(IGN7_COMPARE, ignitionSchedule7.startCompare);
+      ignitionSchedule7.Status = PENDING; //Turn this schedule on
+      ignitionSchedule7.schedulesSet++;
+      interrupts();
+      IGN7_TIMER_ENABLE();
+    }
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if (timeout < MAX_TIMER_PERIOD)
+    if ((timeout < MAX_TIMER_PERIOD) &&  (currentStatus.TPS < configPage4.floodClear))
     {
       ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule7.nextEndCompare = ignitionSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -867,20 +881,22 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
-    noInterrupts();
-    ignitionSchedule8.startCompare = IGN8_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule8.endScheduleSetByDecoder == false) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    SET_COMPARE(IGN8_COMPARE, ignitionSchedule8.startCompare);
-    ignitionSchedule8.Status = PENDING; //Turn this schedule on
-    ignitionSchedule8.schedulesSet++;
-    interrupts();
-    IGN8_TIMER_ENABLE();
+    if  (currentStatus.TPS < configPage4.floodClear){ 
+      noInterrupts();
+      ignitionSchedule8.startCompare = IGN8_COUNTER + timeout_timer_compare;
+      if(ignitionSchedule8.endScheduleSetByDecoder == false) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+      SET_COMPARE(IGN8_COMPARE, ignitionSchedule8.startCompare);
+      ignitionSchedule8.Status = PENDING; //Turn this schedule on
+      ignitionSchedule8.schedulesSet++;
+      interrupts();
+      IGN8_TIMER_ENABLE();
+    }
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if (timeout < MAX_TIMER_PERIOD)
+    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
       ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule8.nextEndCompare = ignitionSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE(duration);

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -609,7 +609,7 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     // If doing floodClear do not set ignition schedule
-    if  (currentStatus.TPS < configPage4.floodClear){ 
+    if (!(currentStatus.TPS > configPage4.floodClear) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))){
       noInterrupts();
       ignitionSchedule1.startCompare = IGN1_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
       if(ignitionSchedule1.endScheduleSetByDecoder == false) { ignitionSchedule1.endCompare = ignitionSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
@@ -624,7 +624,7 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
+    if ((timeout < MAX_TIMER_PERIOD) && !((currentStatus.TPS > configPage4.floodClear) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))))
     {
       ignitionSchedule1.nextStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule1.nextEndCompare = ignitionSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -661,7 +661,7 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     // If doing floodClear do not set ignition schedule
-    if  (currentStatus.TPS < configPage4.floodClear){ 
+    if (!(currentStatus.TPS > configPage4.floodClear) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))){
       noInterrupts();
       ignitionSchedule2.startCompare = IGN2_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
       if(ignitionSchedule2.endScheduleSetByDecoder == false) { ignitionSchedule2.endCompare = ignitionSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
@@ -676,7 +676,7 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if ((timeout < MAX_TIMER_PERIOD) &&  (currentStatus.TPS < configPage4.floodClear))
+    if ((timeout < MAX_TIMER_PERIOD) && !((currentStatus.TPS > configPage4.floodClear) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))))
     {
       ignitionSchedule2.nextStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule2.nextEndCompare = ignitionSchedule2.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -699,7 +699,7 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     // If doing floodClear do not set ignition schedule
-    if  (currentStatus.TPS < configPage4.floodClear){ 
+    if (!(currentStatus.TPS > configPage4.floodClear) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))){
       noInterrupts();
       ignitionSchedule3.startCompare = IGN3_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
       if(ignitionSchedule3.endScheduleSetByDecoder == false) { ignitionSchedule3.endCompare = ignitionSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
@@ -714,7 +714,7 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
+    if ((timeout < MAX_TIMER_PERIOD) && !((currentStatus.TPS > configPage4.floodClear) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))))
     {
       ignitionSchedule3.nextStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule3.nextEndCompare = ignitionSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -737,7 +737,7 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     // If doing floodClear do not set ignition schedule
-    if  (currentStatus.TPS < configPage4.floodClear){ 
+    if (!(currentStatus.TPS > configPage4.floodClear) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))){
       noInterrupts();
       ignitionSchedule4.startCompare = IGN4_COUNTER + timeout_timer_compare;
       if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
@@ -752,7 +752,7 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
+    if ((timeout < MAX_TIMER_PERIOD) && !((currentStatus.TPS > configPage4.floodClear) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))))
     {
       ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule4.nextEndCompare = ignitionSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -775,7 +775,7 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     // If doing floodClear do not set ignition schedule
-    if  (currentStatus.TPS < configPage4.floodClear){ 
+    if (!(currentStatus.TPS > configPage4.floodClear) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))){ 
       noInterrupts();
       ignitionSchedule5.startCompare = IGN5_COUNTER + timeout_timer_compare;
       if(ignitionSchedule5.endScheduleSetByDecoder == false) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
@@ -790,7 +790,7 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
+    if ((timeout < MAX_TIMER_PERIOD) && !((currentStatus.TPS > configPage4.floodClear) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))))
     {
       ignitionSchedule5.nextStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule5.nextEndCompare = ignitionSchedule5.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -814,7 +814,7 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
 
 
     // If doing floodClear do not set ignition schedule
-    if  (currentStatus.TPS < configPage4.floodClear){ 
+    if (!(currentStatus.TPS > configPage4.floodClear) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))){
       noInterrupts();
       ignitionSchedule6.startCompare = IGN6_COUNTER + timeout_timer_compare;
       if(ignitionSchedule6.endScheduleSetByDecoder == false) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
@@ -829,7 +829,7 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
+    if ((timeout < MAX_TIMER_PERIOD) && !((currentStatus.TPS > configPage4.floodClear) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))))
     {
       ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule6.nextEndCompare = ignitionSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -852,7 +852,7 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     // If doing floodClear do not set ignition schedule
-    if  (currentStatus.TPS < configPage4.floodClear){ 
+    if (!(currentStatus.TPS > configPage4.floodClear) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))){
       noInterrupts();
       ignitionSchedule7.startCompare = IGN7_COUNTER + timeout_timer_compare;
       if(ignitionSchedule7.endScheduleSetByDecoder == false) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
@@ -867,7 +867,7 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if ((timeout < MAX_TIMER_PERIOD) &&  (currentStatus.TPS < configPage4.floodClear))
+    if ((timeout < MAX_TIMER_PERIOD) && !((currentStatus.TPS > configPage4.floodClear) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))))
     {
       ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule7.nextEndCompare = ignitionSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
@@ -890,7 +890,7 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     // If doing floodClear do not set ignition schedule
-    if  (currentStatus.TPS < configPage4.floodClear){ 
+    if (!(currentStatus.TPS > configPage4.floodClear) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))){
       noInterrupts();
       ignitionSchedule8.startCompare = IGN8_COUNTER + timeout_timer_compare;
       if(ignitionSchedule8.endScheduleSetByDecoder == false) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
@@ -905,7 +905,7 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
+    if ((timeout < MAX_TIMER_PERIOD) && !((currentStatus.TPS > configPage4.floodClear) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK))))
     {
       ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule8.nextEndCompare = ignitionSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE(duration);

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -608,8 +608,9 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
-    noInterrupts();
+    // If doing floodClear do not set ignition schedule
     if  (currentStatus.TPS < configPage4.floodClear){ 
+      noInterrupts();
       ignitionSchedule1.startCompare = IGN1_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
       if(ignitionSchedule1.endScheduleSetByDecoder == false) { ignitionSchedule1.endCompare = ignitionSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
       SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.startCompare);
@@ -621,7 +622,7 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
   }
   else
   {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
+    //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
@@ -659,8 +660,9 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
-    noInterrupts();
+    // If doing floodClear do not set ignition schedule
     if  (currentStatus.TPS < configPage4.floodClear){ 
+      noInterrupts();
       ignitionSchedule2.startCompare = IGN2_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
       if(ignitionSchedule2.endScheduleSetByDecoder == false) { ignitionSchedule2.endCompare = ignitionSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
       SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.startCompare);
@@ -672,7 +674,7 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
   }
   else
   {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
+    //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if ((timeout < MAX_TIMER_PERIOD) &&  (currentStatus.TPS < configPage4.floodClear))
     {
@@ -696,8 +698,9 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
-    noInterrupts();
+    // If doing floodClear do not set ignition schedule
     if  (currentStatus.TPS < configPage4.floodClear){ 
+      noInterrupts();
       ignitionSchedule3.startCompare = IGN3_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
       if(ignitionSchedule3.endScheduleSetByDecoder == false) { ignitionSchedule3.endCompare = ignitionSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
       SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.startCompare);
@@ -709,7 +712,7 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
   }
   else
   {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
+    //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
@@ -733,8 +736,9 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
-    noInterrupts();
+    // If doing floodClear do not set ignition schedule
     if  (currentStatus.TPS < configPage4.floodClear){ 
+      noInterrupts();
       ignitionSchedule4.startCompare = IGN4_COUNTER + timeout_timer_compare;
       if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
       SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.startCompare);
@@ -746,7 +750,7 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
   }
   else
   {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
+    //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
@@ -770,6 +774,7 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
+    // If doing floodClear do not set ignition schedule
     if  (currentStatus.TPS < configPage4.floodClear){ 
       noInterrupts();
       ignitionSchedule5.startCompare = IGN5_COUNTER + timeout_timer_compare;
@@ -783,7 +788,7 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
   }
   else
   {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
+    //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
@@ -807,6 +812,8 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
+
+    // If doing floodClear do not set ignition schedule
     if  (currentStatus.TPS < configPage4.floodClear){ 
       noInterrupts();
       ignitionSchedule6.startCompare = IGN6_COUNTER + timeout_timer_compare;
@@ -820,7 +827,7 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
   }
   else
   {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
+    //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {
@@ -844,6 +851,7 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
+    // If doing floodClear do not set ignition schedule
     if  (currentStatus.TPS < configPage4.floodClear){ 
       noInterrupts();
       ignitionSchedule7.startCompare = IGN7_COUNTER + timeout_timer_compare;
@@ -857,7 +865,7 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
   }
   else
   {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
+    //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if ((timeout < MAX_TIMER_PERIOD) &&  (currentStatus.TPS < configPage4.floodClear))
     {
@@ -881,6 +889,7 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
     if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when applied causing erratic behaviour such as erroneous sparking.
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
+    // If doing floodClear do not set ignition schedule
     if  (currentStatus.TPS < configPage4.floodClear){ 
       noInterrupts();
       ignitionSchedule8.startCompare = IGN8_COUNTER + timeout_timer_compare;
@@ -894,7 +903,7 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
   }
   else
   {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
+    //If the schedule is already running, we can set the next schedule so it is ready to go, unless we are doing floodClear
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if ((timeout < MAX_TIMER_PERIOD) && (currentStatus.TPS < configPage4.floodClear))
     {

--- a/test/test_schedules/test_status_off_to_pending.cpp
+++ b/test/test_schedules/test_status_off_to_pending.cpp
@@ -138,6 +138,87 @@ void test_status_off_to_pending_ign8(void)
 }
 #endif
 
+//Tests for validating the floodClear procedure
+void test_status_off_to_pending_ign1_flood(void)
+{
+    initialiseSchedulers();
+    currentStatus.engine = BIT_ENGINE_CRANK;
+    currentStatus.TPS = configPage4.floodClear + 1;
+    setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule1.Status);
+}
+
+void test_status_off_to_pending_ign2_flood(void)
+{
+    initialiseSchedulers();
+    currentStatus.engine = BIT_ENGINE_CRANK;
+    currentStatus.TPS = configPage4.floodClear + 1;
+    setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule2.Status);
+}
+
+void test_status_off_to_pending_ign3_flood(void)
+{
+    initialiseSchedulers();
+    currentStatus.engine = BIT_ENGINE_CRANK;
+    currentStatus.TPS = configPage4.floodClear + 1;
+    setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule3.Status);
+}
+
+void test_status_off_to_pending_ign4_flood(void)
+{
+    initialiseSchedulers();
+    currentStatus.engine = BIT_ENGINE_CRANK;
+    currentStatus.TPS = configPage4.floodClear + 1;
+    setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule4.Status);
+}
+
+#if IGN_CHANNELS >= 5
+void test_status_off_to_pending_ign5_flood(void)
+{
+    initialiseSchedulers();
+    currentStatus.engine = BIT_ENGINE_CRANK;
+    currentStatus.TPS = configPage4.floodClear + 1;
+    setIgnitionSchedule5(emptyCallback, TIMEOUT, DURATION, emptyCallback);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule5.Status);
+}
+#endif
+
+#if IGN_CHANNELS >= 6
+void test_status_off_to_pending_ign6_flood(void)
+{
+    initialiseSchedulers();
+    currentStatus.engine = BIT_ENGINE_CRANK;
+    currentStatus.TPS = configPage4.floodClear + 1;
+    setIgnitionSchedule6(emptyCallback, TIMEOUT, DURATION, emptyCallback);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule6.Status);
+}
+#endif
+
+#if IGN_CHANNELS >= 7
+void test_status_off_to_pending_ign7_flood(void)
+{
+    initialiseSchedulers();
+    currentStatus.engine = BIT_ENGINE_CRANK;
+    currentStatus.TPS = configPage4.floodClear + 1;
+    setIgnitionSchedule7(emptyCallback, TIMEOUT, DURATION, emptyCallback);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule7.Status);
+}
+#endif
+
+#if IGN_CHANNELS >= 8
+void test_status_off_to_pending_ign8_flood(void)
+{
+    initialiseSchedulers();
+    currentStatus.engine = BIT_ENGINE_CRANK;
+    currentStatus.TPS = configPage4.floodClear + 1;
+    setIgnitionSchedule8(emptyCallback, TIMEOUT, DURATION, emptyCallback);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule8.Status);
+}
+#endif
+
 void test_status_off_to_pending(void)
 {
     RUN_TEST(test_status_off_to_pending_inj1);
@@ -161,16 +242,24 @@ void test_status_off_to_pending(void)
     RUN_TEST(test_status_off_to_pending_ign2);
     RUN_TEST(test_status_off_to_pending_ign3);
     RUN_TEST(test_status_off_to_pending_ign4);
+    RUN_TEST(test_status_off_to_pending_ign1_flood);
+    RUN_TEST(test_status_off_to_pending_ign2_flood);
+    RUN_TEST(test_status_off_to_pending_ign3_flood);
+    RUN_TEST(test_status_off_to_pending_ign4_flood);
 #if IGN_CHANNELS >= 5    
     RUN_TEST(test_status_off_to_pending_ign5);
+    RUN_TEST(test_status_off_to_pending_ign5_flood);
 #endif
 #if IGN_CHANNELS >= 6
     RUN_TEST(test_status_off_to_pending_ign6);
+    RUN_TEST(test_status_off_to_pending_ign6_flood);
 #endif
 #if IGN_CHANNELS >= 7
     RUN_TEST(test_status_off_to_pending_ign7);
+    RUN_TEST(test_status_off_to_pending_ign7_flood);
 #endif
 #if IGN_CHANNELS >= 8
     RUN_TEST(test_status_off_to_pending_ign8);
+    RUN_TEST(test_status_off_to_pending_ign8_flood);
 #endif
 }


### PR DESCRIPTION
This should address #1054. Added checks in both blocks of setIgnitionN functions to skip setting a schedule if the TPS is above the clearFlood threshold.