### PR TITLE
Performance: use cached values instead of recalculating

### DIFF
--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -887,10 +887,10 @@ void nitrousControl(void)
     if( (isArmed == true) && (currentStatus.coolant > (configPage10.n2o_minCLT - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.TPS > configPage10.n2o_minTPS) && (currentStatus.O2 < configPage10.n2o_maxAFR) && (currentStatus.MAP < (uint16_t)(configPage10.n2o_maxMAP * 2)) )
     {
       //Config page values are divided by 100 to fit within a byte. Multiply them back out to real values. 
-      uint16_t realStage1MinRPM = (uint16_t)configPage10.n2o_stage1_minRPM * 100;
-      uint16_t realStage1MaxRPM = (uint16_t)configPage10.n2o_stage1_maxRPM * 100;
-      uint16_t realStage2MinRPM = (uint16_t)configPage10.n2o_stage2_minRPM * 100;
-      uint16_t realStage2MaxRPM = (uint16_t)configPage10.n2o_stage2_maxRPM * 100;
+      uint16_t realStage1MinRPM = (uint16_t)configPage10.n2o_stage1.minRPM * 100;
+      uint16_t realStage1MaxRPM = (uint16_t)configPage10.n2o_stage1.maxRPM * 100;
+      uint16_t realStage2MinRPM = (uint16_t)configPage10.n2o_stage2.minRPM * 100;
+      uint16_t realStage2MaxRPM = (uint16_t)configPage10.n2o_stage2.maxRPM * 100;
 
       //The nitrous state is set to 0 and then the subsequent stages are added
       // OFF    = 0

--- a/speeduino/bit_manip.h
+++ b/speeduino/bit_manip.h
@@ -1,0 +1,21 @@
+#pragma once
+
+/**
+ * @file
+ * @brief Bit twiddling macros
+ */
+
+/** @brief Set bit b (0-7) in byte a */
+#define BIT_SET(var,pos) ((var) |= (1U<<(pos)))
+
+/** @brief Clear bit b (0-7) in byte a */
+#define BIT_CLEAR(var,pos) ((var) &= ~(1U<<(pos)))
+
+/** @brief Is bit pos (0-7) in byte var set? */
+#define BIT_CHECK(var,pos) !!((var) & (1U<<(pos)))
+
+/** @brief Toggle the value of bit pos (0-7) in byte var */
+#define BIT_TOGGLE(var,pos) ((var)^= 1UL << (pos))
+
+/** @brief Set the value ([0,1], [true, false]) of bit pos (0-7) in byte var */
+#define BIT_WRITE(var, pos, bitvalue) ((bitvalue) ? BIT_SET((var), (pos)) : BIT_CLEAR((var), (pos)))

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -854,11 +854,11 @@ int8_t correctionNitrous(int8_t advance)
     //Check which stage is running (if any)
     if( (currentStatus.nitrous_status == NITROUS_STAGE1) || (currentStatus.nitrous_status == NITROUS_BOTH) )
     {
-      ignNitrous -= configPage10.n2o_stage1_retard;
+      ignNitrous -= configPage10.n2o_stage1.retard;
     }
     if( (currentStatus.nitrous_status == NITROUS_STAGE2) || (currentStatus.nitrous_status == NITROUS_BOTH) )
     {
-      ignNitrous -= configPage10.n2o_stage2_retard;
+      ignNitrous -= configPage10.n2o_stage2.retard;
     }
   }
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1182,6 +1182,14 @@ struct config9 {
   } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
 #endif
 
+struct nitrous_stage_settings {
+  byte minRPM; //Byte 81
+  byte maxRPM; //Byte 82
+  byte adderMin; //Byte 83
+  byte adderMax; //Byte 84
+  byte retard; //Byte 85  
+};
+
 /** Page 10 - No specific purpose. Created initially for the cranking enrich curve.
 192 bytes long.
 See ini file for further info (Config Page 11 in the ini).
@@ -1226,20 +1234,12 @@ struct config10 {
   byte n2o_stage1_pin : 6;
   byte n2o_pin_polarity : 1;
   byte n2o_stage1_unused : 1;
-  byte n2o_stage1_minRPM; //Byte 81
-  byte n2o_stage1_maxRPM; //Byte 82
-  byte n2o_stage1_adderMin; //Byte 83
-  byte n2o_stage1_adderMax; //Byte 84
-  byte n2o_stage1_retard; //Byte 85
+  nitrous_stage_settings n2o_stage1;
 
   //Byte 86
   byte n2o_stage2_pin : 6;
   byte n2o_stage2_unused : 2;
-  byte n2o_stage2_minRPM; //Byte 87
-  byte n2o_stage2_maxRPM; //Byte 88
-  byte n2o_stage2_adderMin; //Byte 89
-  byte n2o_stage2_adderMax; //Byte 90
-  byte n2o_stage2_retard; //Byte 91
+  nitrous_stage_settings n2o_stage2;
 
   //Byte 92
   byte knock_mode : 2;

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -30,6 +30,7 @@
 #include <assert.h>
 #include "src/FastCRC/FastCRC.h"
 #include "statuses.h"
+#include "load_source.h"
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
   #define BOARD_MAX_DIGITAL_PINS 54 //digital pins +1
@@ -156,11 +157,6 @@
 
 #define MS_IN_MINUTE 60000
 #define US_IN_MINUTE 60000000
-
-//Define the load algorithm
-#define LOAD_SOURCE_MAP         0
-#define LOAD_SOURCE_TPS         1
-#define LOAD_SOURCE_IMAPEMAP    2
 
 //Define bit positions within engine variable
 #define BIT_ENGINE_RUN      0   // Engine running
@@ -632,7 +628,7 @@ struct config2 {
   byte crkngAddCLTAdv : 1;
   byte includeAFR : 1; //< Enable AFR compensation ? (See also @ref config2.incorporateAFR)
   byte hardCutType : 1;
-  byte ignAlgorithm : 3;
+  LoadSource ignAlgorithm : 3;
   byte indInjAng : 1;
   byte injOpen;     ///< Injector opening time (ms * 10)
   uint16_t injAng[4];
@@ -644,7 +640,7 @@ struct config2 {
   byte nCylinders : 4; ///< Number of cylinders
 
   //config2 in ini
-  byte fuelAlgorithm : 3;///< Fuel algorithm - 0=Manifold pressure/MAP (LOAD_SOURCE_MAP, default, proven), 1=Throttle/TPS (LOAD_SOURCE_TPS), 2=IMAP/EMAP (LOAD_SOURCE_IMAPEMAP)
+  LoadSource fuelAlgorithm : 3;///< Fuel algorithm - 0=Manifold pressure/MAP (LOAD_SOURCE_MAP, default, proven), 1=Throttle/TPS (LOAD_SOURCE_TPS), 2=IMAP/EMAP (LOAD_SOURCE_IMAPEMAP)
   byte fixAngEnable : 1; ///< Whether fixed/locked timing is enabled (0=disable, 1=enable, See @ref configPage4.FixAng)
   byte nInjectors : 4;   ///< Number of injectors
 
@@ -1128,7 +1124,7 @@ struct config10 {
   byte knock_recoveryStep; //Byte 121
 
   //Byte 122
-  byte fuel2Algorithm : 3;
+  LoadSource fuel2Algorithm : 3;
   byte fuel2Mode : 3;
   byte fuel2SwitchVariable : 2;
 
@@ -1201,7 +1197,7 @@ struct config10 {
   byte fuelTempValues[6]; //180
 
   //Byte 186
-  byte spark2Algorithm : 3;
+  LoadSource spark2Algorithm : 3;
   byte spark2Mode : 3;
   byte spark2SwitchVariable : 2;
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -29,6 +29,7 @@
 #include "table3d.h"
 #include <assert.h>
 #include "src/FastCRC/FastCRC.h"
+#include "statuses.h"
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
   #define BOARD_MAX_DIGITAL_PINS 54 //digital pins +1
@@ -149,13 +150,6 @@
 //This can only be included after the above section
 #include BOARD_H //Note that this is not a real file, it is defined in globals.h. 
 
-//Handy bitsetting macros
-#define BIT_SET(a,b) ((a) |= (1U<<(b)))
-#define BIT_CLEAR(a,b) ((a) &= ~(1U<<(b)))
-#define BIT_CHECK(var,pos) !!((var) & (1U<<(pos)))
-#define BIT_TOGGLE(var,pos) ((var)^= 1UL << (pos))
-#define BIT_WRITE(var, pos, bitvalue) ((bitvalue) ? BIT_SET((var), (pos)) : BIT_CLEAR((var), (pos)))
-
 #define CRANK_ANGLE_MAX (max(CRANK_ANGLE_MAX_IGN, CRANK_ANGLE_MAX_INJ))
 
 #define interruptSafe(c) (noInterrupts(); {c} interrupts();) //Wraps any code between nointerrupt and interrupt calls
@@ -213,15 +207,6 @@
 #define BIT_TIMER_15HZ            3
 #define BIT_TIMER_30HZ            4
 #define BIT_TIMER_1KHZ            7
-
-#define BIT_STATUS3_RESET_PREVENT 0 //Indicates whether reset prevention is enabled
-#define BIT_STATUS3_NITROUS       1
-#define BIT_STATUS3_FUEL2_ACTIVE  2
-#define BIT_STATUS3_VSS_REFRESH   3
-#define BIT_STATUS3_HALFSYNC      4 //shows if there is only sync from primary trigger, but not from secondary.
-#define BIT_STATUS3_NSQUIRTS1     5
-#define BIT_STATUS3_NSQUIRTS2     6
-#define BIT_STATUS3_NSQUIRTS3     7
 
 #define BIT_STATUS4_WMI_EMPTY     0 //Indicates whether the WMI tank is empty
 #define BIT_STATUS4_VVT1_ERROR    1 //VVT1 cam angle within limits or not
@@ -606,132 +591,6 @@ extern volatile byte LOOP_TIMER;
 #define pinIsSensor(pin)    ( ((pin) == pinCLT) || ((pin) == pinIAT) || ((pin) == pinMAP) || ((pin) == pinTPS) || ((pin) == pinO2) || ((pin) == pinBat) || (((pin) == pinFlex) && (configPage2.flexEnabled != 0)) )
 //#define pinIsUsed(pin)      ( pinIsSensor((pin)) || pinIsOutput((pin)) || pinIsReserved((pin)) )
 
-
-/** The status struct with current values for all 'live' variables.
-* In current version this is 64 bytes. Instantiated as global currentStatus.
-* int *ADC (Analog-to-digital value / count) values contain the "raw" value from AD conversion, which get converted to
-* unit based values in similar variable(s) without ADC part in name (see sensors.ino for reading of sensors).
-*/
-struct statuses {
-  volatile bool hasSync; /**< Flag for crank/cam position being known by decoders (See decoders.ino).
-    This is used for sanity checking e.g. before logging tooth history or reading some sensors and computing readings. */
-  uint16_t RPM;   ///< RPM - Current Revs per minute
-  byte RPMdiv100; ///< RPM value scaled (divided by 100) to fit a byte (0-255, e.g. 12000 => 120)
-  long longRPM;   ///< RPM as long int (gets assigned to / maintained in statuses.RPM as well)
-  int mapADC;
-  int baroADC;
-  long MAP;     ///< Manifold absolute pressure. Has to be a long for PID calcs (Boost control)
-  int16_t EMAP; ///< EMAP ... (See @ref config6.useEMAP for EMAP enablement)
-  int16_t EMAPADC;
-  byte baro;   ///< Barometric pressure is simply the initial MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
-  byte TPS;    /**< The current TPS reading (0% - 100%). Is the tpsADC value after the calibration is applied */
-  byte tpsADC; /**< byte (valued: 0-255) representation of the TPS. Downsampled from the original 10-bit (0-1023) reading, but before any calibration is applied */
-  int16_t tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Note that is signed value, because TPSdot can be also negative */
-  byte TPSlast; /**< The previous TPS reading */
-  int16_t mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Note that is signed value, because MAPdot can be also negative */
-  volatile int rpmDOT; /**< RPM delta over time (RPM increase / s ?) */
-  byte VE;     /**< The current VE value being used in the fuel calculation. Can be the same as VE1 or VE2, or a calculated value of both. */
-  byte VE1;    /**< The VE value from fuel table 1 */
-  byte VE2;    /**< The VE value from fuel table 2, if in use (and required conditions are met) */
-  byte O2;     /**< Primary O2 sensor reading */
-  byte O2_2;   /**< Secondary O2 sensor reading */
-  int coolant; /**< Coolant temperature reading */
-  int cltADC;
-  int IAT;     /**< Inlet air temperature reading */
-  int iatADC;
-  int batADC;
-  int O2ADC;
-  int O2_2ADC;
-  int dwell;          ///< dwell (coil primary winding/circuit on) time (in ms * 10 ? See @ref correctionsDwell)
-  volatile int16_t actualDwell;    ///< actual dwell time if new ignition mode is used (in uS)
-  byte dwellCorrection; /**< The amount of correction being applied to the dwell time (in unit ...). */
-  byte battery10;     /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */
-  int8_t advance;     /**< The current advance value being used in the spark calculation. Can be the same as advance1 or advance2, or a calculated value of both */
-  int8_t advance1;    /**< The advance value from ignition table 1 */
-  int8_t advance2;    /**< The advance value from ignition table 2 */
-  uint16_t corrections; /**< The total current corrections % amount */
-  uint16_t AEamount;    /**< The amount of acceleration enrichment currently being applied. 100=No change. Varies above 255 */
-  byte egoCorrection; /**< The amount of closed loop AFR enrichment currently being applied */
-  byte wueCorrection; /**< The amount of warmup enrichment currently being applied */
-  byte batCorrection; /**< The amount of battery voltage enrichment currently being applied */
-  byte iatCorrection; /**< The amount of inlet air temperature adjustment currently being applied */
-  byte baroCorrection; /**< The amount of correction being applied for the current baro reading */
-  byte launchCorrection;   /**< The amount of correction being applied if launch control is active */
-  byte flexCorrection;     /**< Amount of correction being applied to compensate for ethanol content */
-  byte fuelTempCorrection; /**< Amount of correction being applied to compensate for fuel temperature */
-  int8_t flexIgnCorrection;/**< Amount of additional advance being applied based on flex. Note the type as this allows for negative values */
-  byte afrTarget;    /**< Current AFR Target looked up from AFR target table (x10 ? See @ref afrTable)*/
-  byte CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
-  bool idleUpActive; /**< Whether the externally controlled idle up is currently active */
-  bool CTPSActive;   /**< Whether the externally controlled closed throttle position sensor is currently active */
-  volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
-  volatile int8_t fuelTemp;
-  unsigned long AEEndTime; /**< The target end time used whenever AE (acceleration enrichment) is turned on */
-  volatile byte status1; ///< Status bits (See BIT_STATUS1_* defines on top of this file)
-  volatile byte spark;   ///< Spark status/control indicator bits (launch control, boost cut, spark errors, See BIT_SPARK_* defines)
-  volatile byte spark2;  ///< Spark 2 ... (See also @ref config10 spark2* members and BIT_SPARK2_* defines)
-  uint8_t engine; ///< Engine status bits (See BIT_ENGINE_* defines on top of this file)
-  unsigned int PW1; ///< In uS
-  unsigned int PW2; ///< In uS
-  unsigned int PW3; ///< In uS
-  unsigned int PW4; ///< In uS
-  unsigned int PW5; ///< In uS
-  unsigned int PW6; ///< In uS
-  unsigned int PW7; ///< In uS
-  unsigned int PW8; ///< In uS
-  volatile byte runSecs; /**< Counter of seconds since cranking commenced (Maxes out at 255 to prevent overflow) */
-  volatile byte secl; /**< Counter incrementing once per second. Will overflow after 255 and begin again. This is used by TunerStudio to maintain comms sync */
-  volatile uint32_t loopsPerSecond; /**< A performance indicator showing the number of main loops that are being executed each second */ 
-  bool launchingSoft; /**< Indicator showing whether soft launch control adjustments are active */
-  bool launchingHard; /**< Indicator showing whether hard launch control adjustments are active */
-  uint16_t freeRAM;
-  unsigned int clutchEngagedRPM; /**< The RPM at which the clutch was last depressed. Used for distinguishing between launch control and flat shift */ 
-  bool flatShiftingHard;
-  volatile uint32_t startRevolutions; /**< A counter for how many revolutions have been completed since sync was achieved. */
-  uint16_t boostTarget;
-  byte testOutputs;   ///< Test Output bits (only first bit used/tested ?)
-  bool testActive;    // Not in use ? Replaced by testOutputs ?
-  uint16_t boostDuty; ///< Boost Duty percentage value * 100 to give 2 points of precision
-  byte idleLoad;      ///< Either the current steps or current duty cycle for the idle control
-  uint16_t canin[16]; ///< 16bit raw value of selected canin data for channels 0-15
-  uint8_t current_caninchannel = 0; /**< Current CAN channel, defaults to 0 */
-  uint16_t crankRPM = 400; /**< The actual cranking RPM limit. This is derived from the value in the config page, but saves us multiplying it every time it's used (Config page value is stored divided by 10) */
-  volatile byte status3; ///< Status bits (See BIT_STATUS3_* defines on top of this file)
-  int16_t flexBoostCorrection; /**< Amount of boost added based on flex */
-  byte nitrous_status;
-  byte nSquirts;  ///< Number of injector squirts per cycle (per injector)
-  byte nChannels; /**< Number of fuel and ignition channels.  */
-  int16_t fuelLoad;
-  int16_t fuelLoad2;
-  int16_t ignLoad;
-  int16_t ignLoad2;
-  bool fuelPumpOn; /**< Indicator showing the current status of the fuel pump */
-  volatile byte syncLossCounter;
-  byte knockRetard;
-  bool knockActive;
-  bool toothLogEnabled;
-  byte compositeTriggerUsed; // 0 means composite logger disabled, 2 means use secondary input (1st cam), 3 means use tertiary input (2nd cam), 4 means log both cams together
-  int16_t vvt1Angle; //Has to be a long for PID calcs (CL VVT control)
-  byte vvt1TargetAngle;
-  long vvt1Duty; //Has to be a long for PID calcs (CL VVT control)
-  uint16_t injAngle;
-  byte ASEValue;
-  uint16_t vss;      /**< Current speed reading. Natively stored in kph and converted to mph in TS if required */
-  bool idleUpOutputActive; /**< Whether the idle up output is currently active */
-  byte gear;         /**< Current gear (Calculated from vss) */
-  byte fuelPressure; /**< Fuel pressure in PSI */
-  byte oilPressure;  /**< Oil pressure in PSI */
-  byte engineProtectStatus;
-  byte fanDuty;
-  byte wmiPW;
-  volatile byte status4; ///< Status bits (See BIT_STATUS4_* defines on top of this file)
-  int16_t vvt2Angle; //Has to be a long for PID calcs (CL VVT control)
-  byte vvt2TargetAngle;
-  long vvt2Duty; //Has to be a long for PID calcs (CL VVT control)
-  byte outputsStatus;
-  byte TS_SD_Status; //TunerStudios SD card status
-  byte airConStatus;
-};
 
 /** Page 2 of the config - mostly variables that are required for fuel.
  * These are "non-live" EFI setting, engine and "system" variables that remain fixed once sent

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -154,7 +154,7 @@
 #define BIT_CLEAR(a,b) ((a) &= ~(1U<<(b)))
 #define BIT_CHECK(var,pos) !!((var) & (1U<<(pos)))
 #define BIT_TOGGLE(var,pos) ((var)^= 1UL << (pos))
-#define BIT_WRITE(var, pos, bitvalue) ((bitvalue) ? BIT_SET((var), (pos)) : bitClear((var), (pos)))
+#define BIT_WRITE(var, pos, bitvalue) ((bitvalue) ? BIT_SET((var), (pos)) : BIT_CLEAR((var), (pos)))
 
 #define CRANK_ANGLE_MAX (max(CRANK_ANGLE_MAX_IGN, CRANK_ANGLE_MAX_INJ))
 

--- a/speeduino/load_source.h
+++ b/speeduino/load_source.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "statuses.h"
+
+/** \enum LoadSource
+ * @brief The load source for various tables
+ * */
+enum LoadSource {
+  /** Manifold Absolute Pressure (MAP). Aka Intake MAP (IMAP). 
+   * I.e. a pressure sensor that reads the pressure (positive or negative) 
+   * in the intake manifold */
+  LOAD_SOURCE_MAP,
+  /** Throttle Position Sensor (TPS)*/
+  LOAD_SOURCE_TPS,
+  /** Ratio of intake pressure to exhaust pressure.
+   * A variation of the standard MAP that uses the ratio of inlet manifold pressure to exhaust manifold pressure,
+   * something that is particularly useful on turbo engines. */
+  LOAD_SOURCE_IMAPEMAP
+};
+
+/**
+ * @brief Get the load value, based the supplied algorithm
+ * 
+ * @param algorithm The load algrithom
+ * @return The load.
+ */
+static inline int16_t getLoad(LoadSource algorithm, const statuses &current) {
+  if (algorithm == LOAD_SOURCE_TPS)
+  {
+    //Alpha-N
+    return current.TPS * 2;
+  }
+  else if (algorithm == LOAD_SOURCE_IMAPEMAP)
+  {
+    //IMAP / EMAP
+    return ((int16_t)current.MAP * 100U) / current.EMAP;
+  }
+  // LOAD_SOURCE_MAP (the default). Aka Speed Density
+  return current.MAP;
+}

--- a/speeduino/load_source.h
+++ b/speeduino/load_source.h
@@ -33,8 +33,9 @@ static inline int16_t getLoad(LoadSource algorithm, const statuses &current) {
   else if (algorithm == LOAD_SOURCE_IMAPEMAP)
   {
     //IMAP / EMAP
-    return ((int16_t)current.MAP * 100U) / current.EMAP;
+    return ((int16_t)current.MAP * 100) / current.EMAP;
+  } else {
+    // LOAD_SOURCE_MAP (the default). Aka Speed Density
+    return (int16_t)current.MAP;
   }
-  // LOAD_SOURCE_MAP (the default). Aka Speed Density
-  return current.MAP;
 }

--- a/speeduino/secondaryTables.ino
+++ b/speeduino/secondaryTables.ino
@@ -1,6 +1,7 @@
 #include "globals.h"
 #include "secondaryTables.h"
 #include "corrections.h"
+#include "load_source.h"
 
 void calculateSecondaryFuel(void)
 {
@@ -167,26 +168,8 @@ void calculateSecondarySpark(void)
  */
 byte getVE2(void)
 {
-  byte tempVE = 100;
-  if( configPage10.fuel2Algorithm == LOAD_SOURCE_MAP)
-  {
-    //Speed Density
-    currentStatus.fuelLoad2 = currentStatus.MAP;
-  }
-  else if (configPage10.fuel2Algorithm == LOAD_SOURCE_TPS)
-  {
-    //Alpha-N
-    currentStatus.fuelLoad2 = currentStatus.TPS * 2;
-  }
-  else if (configPage10.fuel2Algorithm == LOAD_SOURCE_IMAPEMAP)
-  {
-    //IMAP / EMAP
-    currentStatus.fuelLoad2 = (currentStatus.MAP * 100) / currentStatus.EMAP;
-  }
-  else { currentStatus.fuelLoad2 = currentStatus.MAP; } //Fallback position
-  tempVE = get3DTableValue(&fuelTable2, currentStatus.fuelLoad2, currentStatus.RPM); //Perform lookup into fuel map for RPM vs MAP value
-
-  return tempVE;
+  currentStatus.fuelLoad2 = getLoad(configPage10.fuel2Algorithm, currentStatus);
+  return get3DTableValue(&fuelTable2, currentStatus.fuelLoad2, currentStatus.RPM); //Perform lookup into fuel map for RPM vs MAP value
 }
 
 /**
@@ -196,26 +179,6 @@ byte getVE2(void)
  */
 byte getAdvance2(void)
 {
-  byte tempAdvance = 0;
-  if (configPage10.spark2Algorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
-  {
-    //Speed Density
-    currentStatus.ignLoad2 = currentStatus.MAP;
-  }
-  else if(configPage10.spark2Algorithm == LOAD_SOURCE_TPS)
-  {
-    //Alpha-N
-    currentStatus.ignLoad2 = currentStatus.TPS * 2;
-
-  }
-  else if (configPage10.spark2Algorithm == LOAD_SOURCE_IMAPEMAP)
-  {
-    //IMAP / EMAP
-    currentStatus.ignLoad2 = (currentStatus.MAP * 100) / currentStatus.EMAP;
-  }
-  else { currentStatus.ignLoad2 = currentStatus.MAP; }
-  tempAdvance = get3DTableValue(&ignitionTable2, currentStatus.ignLoad2, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
-  tempAdvance = correctionsIgn(tempAdvance);
-
-  return tempAdvance;
+  currentStatus.ignLoad2 = getLoad(configPage10.spark2Algorithm, currentStatus);
+  return correctionsIgn(get3DTableValue(&ignitionTable2, currentStatus.ignLoad2, currentStatus.RPM) - OFFSET_IGNITION); //As above, but for ignition advance
 }

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -18,7 +18,7 @@
 void setup(void);
 void loop(void);
 uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
-void calculateStaging(uint16_t primaryPW, uint16_t pwLimit);
+void setPulseWidths(uint16_t primaryPW, uint16_t pwLimit);
 void checkLaunchAndFlatShift();
 
 extern uint16_t req_fuel_uS; /**< The required fuel variable (As calculated by TunerStudio) in uS */

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -18,8 +18,6 @@
 void setup(void);
 void loop(void);
 uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
-byte getVE1(void);
-byte getAdvance1(void);
 void calculateStaging(uint32_t);
 void checkLaunchAndFlatShift();
 

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -18,7 +18,7 @@
 void setup(void);
 void loop(void);
 uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
-void calculateStaging(uint32_t);
+void calculateStaging(uint16_t primaryPW, uint16_t pwLimit);
 void checkLaunchAndFlatShift();
 
 extern uint16_t req_fuel_uS; /**< The required fuel variable (As calculated by TunerStudio) in uS */

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -72,6 +72,41 @@ inline uint16_t applyFuelTrimToPW(trimTable3d *pTrimTable, int16_t fuelLoad, int
     return currentPW;
 }
 
+
+void applyFuelTrims(void) {
+  if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage6.fuelTrimEnabled > 0) && (configPage10.stagingEnabled == false)) { 
+    switch (configPage2.nCylinders) {
+    case 8:
+#if INJ_CHANNELS >= 8
+      currentStatus.PW8 = applyFuelTrimToPW(&trim8Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW8);
+      currentStatus.PW7 = applyFuelTrimToPW(&trim7Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW7);
+#endif
+       [[fallthrough]];
+    case 6:
+ #if INJ_CHANNELS >= 6
+      currentStatus.PW6 = applyFuelTrimToPW(&trim6Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW6);
+      currentStatus.PW5 = applyFuelTrimToPW(&trim5Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW5);
+#endif
+       [[fallthrough]];
+    case 4:
+      currentStatus.PW4 = applyFuelTrimToPW(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW4);
+       [[fallthrough]];
+    case 3:
+      currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
+       [[fallthrough]];
+    case 2:
+      currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
+       [[fallthrough]];
+    case 1:
+      currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
+      break;
+
+    default:
+      break;
+    }
+  }
+}
+
 static uint16_t applyNitrousStage(uint16_t pulseWidth, const nitrous_stage_settings &stage) {
   int16_t adderRange = (stage.maxRPM - stage.minRPM) * 100;
   int16_t adderPercent = ((currentStatus.RPM - (stage.minRPM * 100)) * 100) / adderRange; //The percentage of the way through the RPM range
@@ -504,12 +539,7 @@ void loop(void)
           //injector2StartAngle = calculateInjector2StartAngle(PWdivTimerPerDegree);
           injector2StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel2InjDegrees, currentStatus.injAngle);
           
-          if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage6.fuelTrimEnabled > 0) )
-          {
-            currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
-            currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
-          }
-          else if( (configPage10.stagingEnabled == true) && (BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE) == true) )
+          if( (configPage10.stagingEnabled == true) && (BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE) == true) )
           {
             PWdivTimerPerDegree = div(currentStatus.PW3, timePerDegree).quot; //Need to redo this for PW3 as it will be dramatically different to PW1 when staging
             injector3StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel1InjDegrees, currentStatus.injAngle);
@@ -528,10 +558,6 @@ void loop(void)
           
           if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage6.fuelTrimEnabled > 0) )
           {
-            currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
-            currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
-            currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
-
             #if INJ_CHANNELS >= 6
               if( (configPage10.stagingEnabled == true) && (BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE) == true) )
               {
@@ -573,14 +599,6 @@ void loop(void)
                 injector8StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel4InjDegrees, currentStatus.injAngle);
               }
             #endif
-
-            if(configPage6.fuelTrimEnabled > 0)
-            {
-              currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
-              currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
-              currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
-              currentStatus.PW4 = applyFuelTrimToPW(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW4);
-            }
           }
           else if( (configPage10.stagingEnabled == true) && (BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE) == true) )
           {
@@ -626,16 +644,6 @@ void loop(void)
               injector5StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel5InjDegrees, currentStatus.injAngle);
               injector6StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel6InjDegrees, currentStatus.injAngle);
 
-              if(configPage6.fuelTrimEnabled > 0)
-              {
-                currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
-                currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
-                currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
-                currentStatus.PW4 = applyFuelTrimToPW(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW4);
-                currentStatus.PW5 = applyFuelTrimToPW(&trim5Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW5);
-                currentStatus.PW6 = applyFuelTrimToPW(&trim6Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW6);
-              }
-
               //Staging is possible with sequential on 8 channel boards by using outputs 7 + 8 for the staged injectors
               #if INJ_CHANNELS >= 8
                 if( (configPage10.stagingEnabled == true) && (BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE) == true) )
@@ -676,18 +684,6 @@ void loop(void)
               injector6StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel6InjDegrees, currentStatus.injAngle);
               injector7StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel7InjDegrees, currentStatus.injAngle);
               injector8StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel8InjDegrees, currentStatus.injAngle);
-
-              if(configPage6.fuelTrimEnabled > 0)
-              {
-                currentStatus.PW1 = applyFuelTrimToPW(&trim1Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW1);
-                currentStatus.PW2 = applyFuelTrimToPW(&trim2Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW2);
-                currentStatus.PW3 = applyFuelTrimToPW(&trim3Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW3);
-                currentStatus.PW4 = applyFuelTrimToPW(&trim4Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW4);
-                currentStatus.PW5 = applyFuelTrimToPW(&trim5Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW5);
-                currentStatus.PW6 = applyFuelTrimToPW(&trim6Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW6);
-                currentStatus.PW7 = applyFuelTrimToPW(&trim7Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW7);
-                currentStatus.PW8 = applyFuelTrimToPW(&trim8Table, currentStatus.fuelLoad, currentStatus.RPM, currentStatus.PW8);
-              }
             }
             else
             {
@@ -1622,10 +1618,10 @@ void calculateStaging(uint32_t pwLimit)
     if(maxInjOutputs >= 8) { currentStatus.PW8 = currentStatus.PW1; }
     else { currentStatus.PW8 = 0; }
 
-    BIT_CLEAR(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE); //Clear the staging active flag
-    
+    BIT_CLEAR(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE); //Clear the staging active flag    
   } 
 
+  applyFuelTrims();
 }
 
 void checkLaunchAndFlatShift()

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -60,14 +60,14 @@ uint32_t rollingCutLastRev = 0; /**< Tracks whether we're on the same or a diffe
 uint16_t staged_req_fuel_mult_pri = 0;
 uint16_t staged_req_fuel_mult_sec = 0;   
 
-inline uint16_t applyFuelTrimToPW(trimTable3d *pTrimTable, int16_t fuelLoad, int16_t RPM, uint16_t currentPW)
+static inline uint16_t applyFuelTrimToPW(trimTable3d *pTrimTable, int16_t fuelLoad, int16_t RPM, uint16_t currentPW)
 {
     unsigned long pw1percent = 100 + get3DTableValue(pTrimTable, fuelLoad, RPM) - OFFSET_FUELTRIM;
     if (pw1percent != 100) { return div100(uint32_t(pw1percent * currentPW)); }
     return currentPW;
 }
 
-void applyFuelTrims(void) {
+static inline void applyFuelTrims(void) {
   if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage6.fuelTrimEnabled > 0) && (configPage10.stagingEnabled == false)) { 
     switch (configPage2.nCylinders) {
     case 8:
@@ -111,14 +111,14 @@ void setup(void)
   initialiseAll();
 }
 
-static uint16_t applyNitrousStage(uint16_t pulseWidth, const nitrous_stage_settings &stage) {
+static inline uint16_t applyNitrousStage(uint16_t pulseWidth, const nitrous_stage_settings &stage) {
   int16_t adderRange = (stage.maxRPM - stage.minRPM) * 100;
   int16_t adderPercent = ((currentStatus.RPM - (stage.minRPM * 100)) * 100) / adderRange; //The percentage of the way through the RPM range
   adderPercent = 100 - adderPercent; //Flip the percentage as we go from a higher adder to a lower adder as the RPMs rise
   return pulseWidth + (stage.adderMax + percentage(adderPercent, (stage.adderMin - stage.adderMax))) * 100; //Calculate the above percentage of the calculated ms value.
 }
 
-static uint16_t applyNitrous(uint16_t pulseWidth) {
+static inline uint16_t applyNitrous(uint16_t pulseWidth) {
   //Manual adder for nitrous. These are not in correctionsFuel() because they are direct adders to the ms value, not % based
   if( (currentStatus.nitrous_status == NITROUS_STAGE1) || (currentStatus.nitrous_status == NITROUS_BOTH) )
   { 
@@ -167,7 +167,7 @@ static inline bool testAndSwap(_INT &value, _INT newValue) {
  * @param changeTracker Bit map of relevant data change flags
  * @return Modified change tracker
  */
-byte setVE(byte changeTracker)
+static inline byte setVE(byte changeTracker)
 {
   BIT_WRITE(changeTracker, BIT_LOOP_FUELLOAD_CHANGED, testAndSwap(currentStatus.fuelLoad, getLoad(configPage2.fuelAlgorithm, currentStatus)));
   currentStatus.VE1 = get3DTableValue(&fuelTable, currentStatus.fuelLoad, currentStatus.RPM); //Perform lookup into fuel map for RPM vs MAP value
@@ -187,7 +187,7 @@ byte setVE(byte changeTracker)
  * @param changeTracker Bit map of relevant data change flags
  * @return Modified change tracker
  */
-byte setAdvance(byte changeTracker)
+static inline byte setAdvance(byte changeTracker)
 {
   BIT_WRITE(changeTracker, BIT_LOOP_IGNLOAD_CHANGED, testAndSwap(currentStatus.ignLoad, getLoad(configPage2.ignAlgorithm, currentStatus)));
   currentStatus.advance1 = correctionsIgn(get3DTableValue(&ignitionTable, currentStatus.ignLoad, currentStatus.RPM) - OFFSET_IGNITION); //As above, but for ignition advance
@@ -202,7 +202,7 @@ byte setAdvance(byte changeTracker)
   return changeTracker;
 }
 
-uint16_t getPwLimit(void) {
+static inline uint16_t getPwLimit(void) {
   uint32_t pwLimit = percentage(configPage2.dutyLim, revolutionTime); //The pulsewidth limit is determined to be the duty cycle limit (Eg 85%) by the total time it takes to perform 1 revolution
   
   if (configPage2.strokes == FOUR_STROKE) { 
@@ -213,7 +213,7 @@ uint16_t getPwLimit(void) {
   return pwLimit / currentStatus.nSquirts; 
 }
 
-static uint16_t getDwell(void) {
+static inline uint16_t getDwell(void) {
   // Dwell is stored as ms * 10. ie Dwell of 4.3ms would be 43 in configPage4. This number therefore needs to be multiplied by 100 to get dwell in uS
   uint16_t dwell = 0;
   if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) ) {

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -45,6 +45,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "SD_logger.h"
 #include "schedule_calcs.h"
 #include "auxiliaries.h"
+#include "load_source.h"
 #include RTC_LIB_H //Defined in each boards .h file
 #include BOARD_H //Note that this is not a real file, it is defined in globals.h. 
 
@@ -1265,24 +1266,8 @@ uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen)
  */
 byte getVE1(void)
 {
-  byte tempVE = 100;
-  if (configPage2.fuelAlgorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
-  {
-    //Speed Density
-    currentStatus.fuelLoad = currentStatus.MAP;
-  }
-  else if (configPage2.fuelAlgorithm == LOAD_SOURCE_TPS)
-  {
-    //Alpha-N
-    currentStatus.fuelLoad = currentStatus.TPS * 2;
-  }
-  else if (configPage2.fuelAlgorithm == LOAD_SOURCE_IMAPEMAP)
-  {
-    //IMAP / EMAP
-    currentStatus.fuelLoad = (currentStatus.MAP * 100) / currentStatus.EMAP;
-  }
-  else { currentStatus.fuelLoad = currentStatus.MAP; } //Fallback position
-  tempVE = get3DTableValue(&fuelTable, currentStatus.fuelLoad, currentStatus.RPM); //Perform lookup into fuel map for RPM vs MAP value
+  currentStatus.fuelLoad = getLoad(configPage2.fuelAlgorithm, currentStatus);
+  byte tempVE = get3DTableValue(&fuelTable, currentStatus.fuelLoad, currentStatus.RPM); //Perform lookup into fuel map for RPM vs MAP value
 
   return tempVE;
 }
@@ -1294,24 +1279,8 @@ byte getVE1(void)
  */
 byte getAdvance1(void)
 {
-  byte tempAdvance = 0;
-  if (configPage2.ignAlgorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
-  {
-    //Speed Density
-    currentStatus.ignLoad = currentStatus.MAP;
-  }
-  else if(configPage2.ignAlgorithm == LOAD_SOURCE_TPS)
-  {
-    //Alpha-N
-    currentStatus.ignLoad = currentStatus.TPS * 2;
-
-  }
-  else if (configPage2.fuelAlgorithm == LOAD_SOURCE_IMAPEMAP)
-  {
-    //IMAP / EMAP
-    currentStatus.ignLoad = (currentStatus.MAP * 100) / currentStatus.EMAP;
-  }
-  tempAdvance = get3DTableValue(&ignitionTable, currentStatus.ignLoad, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
+  currentStatus.ignLoad = getLoad(configPage2.ignAlgorithm, currentStatus);
+  byte tempAdvance = get3DTableValue(&ignitionTable, currentStatus.ignLoad, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
   tempAdvance = correctionsIgn(tempAdvance);
 
   return tempAdvance;

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -174,7 +174,7 @@ static inline byte setVE(byte changeTracker)
     currentStatus.VE1 = get3DTableValue(&fuelTable, currentStatus.fuelLoad, currentStatus.RPM); //Perform lookup into fuel map for RPM vs MAP value
     currentStatus.VE = currentStatus.VE1; //Set the final VE value to be VE 1 as a default. This may be changed in the section below
   }
-  
+
   calculateSecondaryFuel();
 
   return changeTracker;
@@ -588,7 +588,7 @@ void loop(void)
 
       // For performance reasons, skip recalculating injection schedules if possible
       if (recalcInjectionSchedules(changeTracker)) {
-        calculateStaging(primaryPulseWidth, getPwLimit());
+        setPulseWidths(primaryPulseWidth, getPwLimit());
       }
 
       //***********************************************************************************************
@@ -1457,7 +1457,7 @@ void calculateIgnitionAngles(int dwellAngle)
   }
 }
 
-void calculateStaging(uint16_t primaryPW, uint16_t pwLimit)
+void setPulseWidths(uint16_t primaryPW, uint16_t pwLimit)
 {
   BIT_CLEAR(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE); //Clear the staging active flag
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -456,7 +456,16 @@ static inline void calculateInjectionAngles(uint16_t pwAngle, uint16_t injAngle)
  * - Can be tested for certain frequency interval being expired by (eg) BIT_CHECK(LOOP_TIMER, BIT_TIMER_15HZ)
  * 
  */
-void loop(void)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+// Sometimes loop() is inlined by LTO & sometimes not
+// When not inlined, there is a huge difference in stack usage: 60+ bytes
+// That eats into available RAM.
+// Adding __attribute__((always_inline)) forces the LTO process to inline.
+//
+// Since the function is declared in an Arduino header, we can't change
+// it to inline, so we need to suppress the resulting warning.
+void __attribute__((always_inline)) loop(void)
 {
       mainLoopCount++;
       LOOP_TIMER = TIMER_mask;
@@ -1272,6 +1281,9 @@ void loop(void)
       BIT_CLEAR(currentStatus.status3, BIT_STATUS3_RESET_PREVENT);
     }
 } //loop()
+
+#pragma GCC diagnostic pop
+
 #endif //Unit test guard
 
 /**

--- a/speeduino/statuses.h
+++ b/speeduino/statuses.h
@@ -1,0 +1,146 @@
+
+#pragma once
+
+#include <stdint.h>
+#include "bit_manip.h"
+
+using byte = uint8_t;
+
+#define BIT_STATUS3_RESET_PREVENT 0 //Indicates whether reset prevention is enabled
+#define BIT_STATUS3_NITROUS       1
+#define BIT_STATUS3_FUEL2_ACTIVE  2
+#define BIT_STATUS3_VSS_REFRESH   3
+#define BIT_STATUS3_HALFSYNC      4 //shows if there is only sync from primary trigger, but not from secondary.
+#define BIT_STATUS3_NSQUIRTS1     5
+#define BIT_STATUS3_NSQUIRTS2     6
+#define BIT_STATUS3_NSQUIRTS3     7
+
+/** The status struct with current values for all 'live' variables.
+* In current version this is 64 bytes. Instantiated as global currentStatus.
+* int *ADC (Analog-to-digital value / count) values contain the "raw" value from AD conversion, which get converted to
+* unit based values in similar variable(s) without ADC part in name (see sensors.ino for reading of sensors).
+*/
+struct statuses {
+  volatile bool hasSync; /**< Flag for crank/cam position being known by decoders (See decoders.ino).
+    This is used for sanity checking e.g. before logging tooth history or reading some sensors and computing readings. */
+  uint16_t RPM;   ///< RPM - Current Revs per minute
+  byte RPMdiv100; ///< RPM value scaled (divided by 100) to fit a byte (0-255, e.g. 12000 => 120)
+  long longRPM;   ///< RPM as long int (gets assigned to / maintained in statuses.RPM as well)
+  int mapADC;
+  int baroADC;
+  long MAP;     ///< Manifold absolute pressure. Has to be a long for PID calcs (Boost control)
+  int16_t EMAP; ///< EMAP ... (See @ref config6.useEMAP for EMAP enablement)
+  int16_t EMAPADC;
+  byte baro;   ///< Barometric pressure is simply the initial MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
+  byte TPS;    /**< The current TPS reading (0% - 100%). Is the tpsADC value after the calibration is applied */
+  byte tpsADC; /**< byte (valued: 0-255) representation of the TPS. Downsampled from the original 10-bit (0-1023) reading, but before any calibration is applied */
+  int16_t tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Note that is signed value, because TPSdot can be also negative */
+  byte TPSlast; /**< The previous TPS reading */
+  int16_t mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Note that is signed value, because MAPdot can be also negative */
+  volatile int rpmDOT; /**< RPM delta over time (RPM increase / s ?) */
+  byte VE;     /**< The current VE value being used in the fuel calculation. Can be the same as VE1 or VE2, or a calculated value of both. */
+  byte VE1;    /**< The VE value from fuel table 1 */
+  byte VE2;    /**< The VE value from fuel table 2, if in use (and required conditions are met) */
+  byte O2;     /**< Primary O2 sensor reading */
+  byte O2_2;   /**< Secondary O2 sensor reading */
+  int coolant; /**< Coolant temperature reading */
+  int cltADC;
+  int IAT;     /**< Inlet air temperature reading */
+  int iatADC;
+  int batADC;
+  int O2ADC;
+  int O2_2ADC;
+  int dwell;          ///< dwell (coil primary winding/circuit on) time (in ms * 10 ? See @ref correctionsDwell)
+  volatile int16_t actualDwell;    ///< actual dwell time if new ignition mode is used (in uS)
+  byte dwellCorrection; /**< The amount of correction being applied to the dwell time (in unit ...). */
+  byte battery10;     /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */
+  int8_t advance;     /**< The current advance value being used in the spark calculation. Can be the same as advance1 or advance2, or a calculated value of both */
+  int8_t advance1;    /**< The advance value from ignition table 1 */
+  int8_t advance2;    /**< The advance value from ignition table 2 */
+  uint16_t corrections; /**< The total current corrections % amount */
+  uint16_t AEamount;    /**< The amount of acceleration enrichment currently being applied. 100=No change. Varies above 255 */
+  byte egoCorrection; /**< The amount of closed loop AFR enrichment currently being applied */
+  byte wueCorrection; /**< The amount of warmup enrichment currently being applied */
+  byte batCorrection; /**< The amount of battery voltage enrichment currently being applied */
+  byte iatCorrection; /**< The amount of inlet air temperature adjustment currently being applied */
+  byte baroCorrection; /**< The amount of correction being applied for the current baro reading */
+  byte launchCorrection;   /**< The amount of correction being applied if launch control is active */
+  byte flexCorrection;     /**< Amount of correction being applied to compensate for ethanol content */
+  byte fuelTempCorrection; /**< Amount of correction being applied to compensate for fuel temperature */
+  int8_t flexIgnCorrection;/**< Amount of additional advance being applied based on flex. Note the type as this allows for negative values */
+  byte afrTarget;    /**< Current AFR Target looked up from AFR target table (x10 ? See @ref afrTable)*/
+  byte CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
+  bool idleUpActive; /**< Whether the externally controlled idle up is currently active */
+  bool CTPSActive;   /**< Whether the externally controlled closed throttle position sensor is currently active */
+  volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
+  volatile int8_t fuelTemp;
+  unsigned long AEEndTime; /**< The target end time used whenever AE (acceleration enrichment) is turned on */
+  volatile byte status1; ///< Status bits (See BIT_STATUS1_* defines on top of this file)
+  volatile byte spark;   ///< Spark status/control indicator bits (launch control, boost cut, spark errors, See BIT_SPARK_* defines)
+  volatile byte spark2;  ///< Spark 2 ... (See also @ref config10 spark2* members and BIT_SPARK2_* defines)
+  uint8_t engine; ///< Engine status bits (See BIT_ENGINE_* defines on top of this file)
+  unsigned int PW1; ///< In uS
+  unsigned int PW2; ///< In uS
+  unsigned int PW3; ///< In uS
+  unsigned int PW4; ///< In uS
+  unsigned int PW5; ///< In uS
+  unsigned int PW6; ///< In uS
+  unsigned int PW7; ///< In uS
+  unsigned int PW8; ///< In uS
+  volatile byte runSecs; /**< Counter of seconds since cranking commenced (Maxes out at 255 to prevent overflow) */
+  volatile byte secl; /**< Counter incrementing once per second. Will overflow after 255 and begin again. This is used by TunerStudio to maintain comms sync */
+  volatile uint32_t loopsPerSecond; /**< A performance indicator showing the number of main loops that are being executed each second */ 
+  bool launchingSoft; /**< Indicator showing whether soft launch control adjustments are active */
+  bool launchingHard; /**< Indicator showing whether hard launch control adjustments are active */
+  uint16_t freeRAM;
+  unsigned int clutchEngagedRPM; /**< The RPM at which the clutch was last depressed. Used for distinguishing between launch control and flat shift */ 
+  bool flatShiftingHard;
+  volatile uint32_t startRevolutions; /**< A counter for how many revolutions have been completed since sync was achieved. */
+  uint16_t boostTarget;
+  byte testOutputs;   ///< Test Output bits (only first bit used/tested ?)
+  bool testActive;    // Not in use ? Replaced by testOutputs ?
+  uint16_t boostDuty; ///< Boost Duty percentage value * 100 to give 2 points of precision
+  byte idleLoad;      ///< Either the current steps or current duty cycle for the idle control
+  uint16_t canin[16]; ///< 16bit raw value of selected canin data for channels 0-15
+  uint8_t current_caninchannel = 0; /**< Current CAN channel, defaults to 0 */
+  uint16_t crankRPM = 400; /**< The actual cranking RPM limit. This is derived from the value in the config page, but saves us multiplying it every time it's used (Config page value is stored divided by 10) */
+  volatile byte status3; ///< Status bits (See BIT_STATUS3_* defines on top of this file)
+  int16_t flexBoostCorrection; /**< Amount of boost added based on flex */
+  byte nitrous_status;
+  byte nSquirts;  ///< Number of injector squirts per cycle (per injector)
+  byte nChannels; /**< Number of fuel and ignition channels.  */
+  int16_t fuelLoad;
+  int16_t fuelLoad2;
+  int16_t ignLoad;
+  int16_t ignLoad2;
+  bool fuelPumpOn; /**< Indicator showing the current status of the fuel pump */
+  volatile byte syncLossCounter;
+  byte knockRetard;
+  bool knockActive;
+  bool toothLogEnabled;
+  byte compositeTriggerUsed; // 0 means composite logger disabled, 2 means use secondary input (1st cam), 3 means use tertiary input (2nd cam), 4 means log both cams together
+  int16_t vvt1Angle; //Has to be a long for PID calcs (CL VVT control)
+  byte vvt1TargetAngle;
+  long vvt1Duty; //Has to be a long for PID calcs (CL VVT control)
+  uint16_t injAngle;
+  byte ASEValue;
+  uint16_t vss;      /**< Current speed reading. Natively stored in kph and converted to mph in TS if required */
+  bool idleUpOutputActive; /**< Whether the idle up output is currently active */
+  byte gear;         /**< Current gear (Calculated from vss) */
+  byte fuelPressure; /**< Fuel pressure in PSI */
+  byte oilPressure;  /**< Oil pressure in PSI */
+  byte engineProtectStatus;
+  byte fanDuty;
+  byte wmiPW;
+  volatile byte status4; ///< Status bits (See BIT_STATUS4_* defines on top of this file)
+  int16_t vvt2Angle; //Has to be a long for PID calcs (CL VVT control)
+  byte vvt2TargetAngle;
+  long vvt2Duty; //Has to be a long for PID calcs (CL VVT control)
+  byte outputsStatus;
+  byte TS_SD_Status; //TunerStudios SD card status
+  byte airConStatus;
+};
+
+static inline bool HasAnySync(const statuses &status) {
+  return status.hasSync || BIT_CHECK(status.status3, BIT_STATUS3_HALFSYNC);
+}

--- a/speeduino/statuses.h
+++ b/speeduino/statuses.h
@@ -50,7 +50,7 @@ struct statuses {
   int batADC;
   int O2ADC;
   int O2_2ADC;
-  int dwell;          ///< dwell (coil primary winding/circuit on) time (in ms * 10 ? See @ref correctionsDwell)
+  uint16_t dwell;          ///< dwell (coil primary winding/circuit on) time (in ms * 10 ? See @ref correctionsDwell)
   volatile int16_t actualDwell;    ///< actual dwell time if new ignition mode is used (in uS)
   byte dwellCorrection; /**< The amount of correction being applied to the dwell time (in unit ...). */
   byte battery10;     /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -142,8 +142,8 @@ void doUpdates(void)
   if (readEEPROMVersion() == 8)
   {
     //May 2018 adds separate load sources for fuel and ignition. Copy the existing load algorithm into Both
-    configPage2.fuelAlgorithm = configPage2.legacyMAP; //Was configPage2.unused2_38c
-    configPage2.ignAlgorithm = configPage2.legacyMAP; //Was configPage2.unused2_38c
+    configPage2.fuelAlgorithm = (LoadSource)configPage2.legacyMAP; //Was configPage2.unused2_38c
+    configPage2.ignAlgorithm = (LoadSource)configPage2.legacyMAP; //Was configPage2.unused2_38c
 
     //Add option back in for open or closed loop boost. For all current configs to use closed
     configPage4.boostType = 1;

--- a/test/test_fuel/test_staging.cpp
+++ b/test/test_fuel/test_staging.cpp
@@ -46,7 +46,7 @@ void test_Staging_Off(void)
   configPage10.stagingEnabled = false;
 
   //90% duty cycle at 6000rpm
-  calculateStaging(1000U, 9000U);
+  setPulseWidths(1000U, 9000U);
   TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
 }
 
@@ -59,7 +59,7 @@ void test_Staging_4cyl_Auto_Inactive(void)
   configPage10.stagingEnabled = true;
   configPage10.stagingMode = STAGING_MODE_AUTO;
 
-  calculateStaging(3000, 9000); //90% duty cycle at 6000rpm
+  setPulseWidths(3000, 9000); //90% duty cycle at 6000rpm
   //PW 1 and 2 should be normal, 3 and 4 should be 0 as that testPW is below the pwLimit
   //PW1/2 should be (PW - openTime) * staged_req_fuel_mult_pri = (3000 - 1000) * 3.0 = 6000
   TEST_ASSERT_EQUAL(6000, currentStatus.PW1);
@@ -82,7 +82,7 @@ void test_Staging_4cyl_Table_Inactive(void)
   //For this test it doesn't matter what the X and Y axis are, as the table is all 0 values
   for(byte x=0; x<64; x++) { stagingTable.values.values[x] = 0; }
 
-  calculateStaging(3000, 9000); //90% duty cycle at 6000rpm
+  setPulseWidths(3000, 9000); //90% duty cycle at 6000rpm
   //PW 1 and 2 should be normal, 3 and 4 should be 0 as that testPW is below the pwLimit
   //PW1/2 should be (PW - openTime) * staged_req_fuel_mult_pri = (3000 - 1000) * 3.0 = 6000
   TEST_ASSERT_EQUAL(7000, currentStatus.PW1);
@@ -101,7 +101,7 @@ void test_Staging_4cyl_Auto_50pct(void)
   configPage10.stagingEnabled = true;
   configPage10.stagingMode = STAGING_MODE_AUTO;
 
-  calculateStaging(9000, 9000); //90% duty cycle at 6000rpm
+  setPulseWidths(9000, 9000); //90% duty cycle at 6000rpm
 
   //PW 1 and 2 should be maxed out at the pwLimit, 3 and 4 should be based on their relative size
   TEST_ASSERT_EQUAL(9000, currentStatus.PW1); //PW1/2 run at maximum available limit
@@ -120,7 +120,7 @@ void test_Staging_4cyl_Auto_33pct(void)
   configPage10.stagingEnabled = true;
   configPage10.stagingMode = STAGING_MODE_AUTO;
   
-  calculateStaging(7000, 9000); //90% duty cycle at 6000rpm
+  setPulseWidths(7000, 9000); //90% duty cycle at 6000rpm
   
   //PW 1 and 2 should be maxed out at the pwLimit, 3 and 4 should be based on their relative size
   TEST_ASSERT_EQUAL(9000, currentStatus.PW1); //PW1/2 run at maximum available limit
@@ -148,7 +148,7 @@ void test_Staging_4cyl_Table_50pct(void)
   currentStatus.RPM += 1;
   currentStatus.fuelLoad += 1;
 
-  calculateStaging(3000, 9000); //90% duty cycle at 6000rpm
+  setPulseWidths(3000, 9000); //90% duty cycle at 6000rpm
 
   TEST_ASSERT_EQUAL(4000, currentStatus.PW1);
   TEST_ASSERT_EQUAL(4000, currentStatus.PW2);

--- a/test/test_fuel/test_staging.cpp
+++ b/test/test_fuel/test_staging.cpp
@@ -45,25 +45,21 @@ void test_Staging_Off(void)
   BIT_SET(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE);
   configPage10.stagingEnabled = false;
 
-  uint32_t pwLimit = 9000; //90% duty cycle at 6000rpm
-  calculateStaging(pwLimit);
+  //90% duty cycle at 6000rpm
+  calculateStaging(1000U, 9000U);
   TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
 }
 
 void test_Staging_4cyl_Auto_Inactive(void)
 {
   test_Staging_setCommon();
-  uint16_t testPW = 3000;
 
   BIT_SET(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE);
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
   configPage10.stagingMode = STAGING_MODE_AUTO;
-  currentStatus.PW1 = testPW; //Over open time but below the pwLimit set below
 
-
-  uint32_t pwLimit = 9000; //90% duty cycle at 6000rpm
-  calculateStaging(pwLimit);
+  calculateStaging(3000, 9000); //90% duty cycle at 6000rpm
   //PW 1 and 2 should be normal, 3 and 4 should be 0 as that testPW is below the pwLimit
   //PW1/2 should be (PW - openTime) * staged_req_fuel_mult_pri = (3000 - 1000) * 3.0 = 6000
   TEST_ASSERT_EQUAL(6000, currentStatus.PW1);
@@ -76,21 +72,17 @@ void test_Staging_4cyl_Auto_Inactive(void)
 void test_Staging_4cyl_Table_Inactive(void)
 {
   test_Staging_setCommon();
-  uint16_t testPW = 3000;
 
   BIT_SET(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE);
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
   configPage10.stagingMode = STAGING_MODE_TABLE;
-  currentStatus.PW1 = testPW; //Over open time but below the pwLimit set below
 
   //Load the staging table with all 0
   //For this test it doesn't matter what the X and Y axis are, as the table is all 0 values
   for(byte x=0; x<64; x++) { stagingTable.values.values[x] = 0; }
 
-
-  uint32_t pwLimit = 9000; //90% duty cycle at 6000rpm
-  calculateStaging(pwLimit);
+  calculateStaging(3000, 9000); //90% duty cycle at 6000rpm
   //PW 1 and 2 should be normal, 3 and 4 should be 0 as that testPW is below the pwLimit
   //PW1/2 should be (PW - openTime) * staged_req_fuel_mult_pri = (3000 - 1000) * 3.0 = 6000
   TEST_ASSERT_EQUAL(7000, currentStatus.PW1);
@@ -103,20 +95,17 @@ void test_Staging_4cyl_Table_Inactive(void)
 void test_Staging_4cyl_Auto_50pct(void)
 {
   test_Staging_setCommon();
-  uint16_t testPW = 9000;
 
   BIT_CLEAR(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE);
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
   configPage10.stagingMode = STAGING_MODE_AUTO;
-  currentStatus.PW1 = testPW; //Over open time but below the pwLimit set below
 
+  calculateStaging(9000, 9000); //90% duty cycle at 6000rpm
 
-  uint32_t pwLimit = 9000; //90% duty cycle at 6000rpm
-  calculateStaging(pwLimit);
   //PW 1 and 2 should be maxed out at the pwLimit, 3 and 4 should be based on their relative size
-  TEST_ASSERT_EQUAL(pwLimit, currentStatus.PW1); //PW1/2 run at maximum available limit
-  TEST_ASSERT_EQUAL(pwLimit, currentStatus.PW2);
+  TEST_ASSERT_EQUAL(9000, currentStatus.PW1); //PW1/2 run at maximum available limit
+  TEST_ASSERT_EQUAL(9000, currentStatus.PW2);
   TEST_ASSERT_EQUAL(9000, currentStatus.PW3);
   TEST_ASSERT_EQUAL(9000, currentStatus.PW4);
   TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
@@ -125,20 +114,17 @@ void test_Staging_4cyl_Auto_50pct(void)
 void test_Staging_4cyl_Auto_33pct(void)
 {
   test_Staging_setCommon();
-  uint16_t testPW = 7000;
 
   BIT_CLEAR(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE);
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
   configPage10.stagingMode = STAGING_MODE_AUTO;
-  currentStatus.PW1 = testPW; //Over open time but below the pwLimit set below
-
-
-  uint32_t pwLimit = 9000; //90% duty cycle at 6000rpm
-  calculateStaging(pwLimit);
+  
+  calculateStaging(7000, 9000); //90% duty cycle at 6000rpm
+  
   //PW 1 and 2 should be maxed out at the pwLimit, 3 and 4 should be based on their relative size
-  TEST_ASSERT_EQUAL(pwLimit, currentStatus.PW1); //PW1/2 run at maximum available limit
-  TEST_ASSERT_EQUAL(pwLimit, currentStatus.PW2);
+  TEST_ASSERT_EQUAL(9000, currentStatus.PW1); //PW1/2 run at maximum available limit
+  TEST_ASSERT_EQUAL(9000, currentStatus.PW2);
   TEST_ASSERT_EQUAL(6000, currentStatus.PW3);
   TEST_ASSERT_EQUAL(6000, currentStatus.PW4);
   TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
@@ -147,25 +133,22 @@ void test_Staging_4cyl_Auto_33pct(void)
 void test_Staging_4cyl_Table_50pct(void)
 {
   test_Staging_setCommon();
-  uint16_t testPW = 3000;
 
   BIT_CLEAR(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE);
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
   configPage10.stagingMode = STAGING_MODE_TABLE;
-  currentStatus.PW1 = testPW; //Over open time but below the pwLimit set below
 
   //Load the staging table with all 0
   //For this test it doesn't matter what the X and Y axis are, as the table is all 50 values
   for(byte x=0; x<64; x++) { stagingTable.values.values[x] = 50; }
 
 
-  uint32_t pwLimit = 9000; //90% duty cycle at 6000rpm
   //Need to change the lookup values so we don't get a cached value
   currentStatus.RPM += 1;
   currentStatus.fuelLoad += 1;
 
-  calculateStaging(pwLimit);
+  calculateStaging(3000, 9000); //90% duty cycle at 6000rpm
 
   TEST_ASSERT_EQUAL(4000, currentStatus.PW1);
   TEST_ASSERT_EQUAL(4000, currentStatus.PW2);


### PR DESCRIPTION
In `loop()`, only recalculate pulse widths, injection angles and ignition angles when the inputs to those calculations have changed. Otherwise use the values from the previous iteration of `loop()`.

Exact speed up varies dependent on tune & rpm. Testing between 3900 & 4100 RPM shows a 15% to 40%+ speed up in loop/s on Mega2560 (tested under various combinations of spark mode, fuel trims etc.).

Log comparison below is 4 cylinder, 60-2 missing tooth, full sequential fuel + fuel trims, sequential spark and RPM 1000 to 12000:
![avoid_calcs](https://github.com/noisymime/speeduino/assets/13982343/f3e711d8-c2b6-4a97-8034-2ad0add3f0e0)
