### PR TITLE
Fix Arduino IDE 2.2.1 Compilation error when using Arduino Mega 

### DIFF
--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -24,11 +24,8 @@
     #define EEPROM_LIB_H <EEPROM.h>
     typedef int eeprom_address_t;
   #endif
-  #ifdef PLATFORMIO
-    #define RTC_LIB_H <TimeLib.h>
-  #else
-    #define RTC_LIB_H <Time.h>
-  #endif
+  #define RTC_LIB_H <TimeLib.h>
+  
   void initBoard(void);
   uint16_t freeRam(void);
   void doSystemReset(void);


### PR DESCRIPTION
On a fresh Arduino 2.2.1 IDE install, when using Arduino Mega in the boards manager. I get a 

```
speeduino/speeduino/board_avr2560.h:30:23: fatal error: Time.h: No such file or directory
     #define RTC_LIB_H <Time.h>

compilation terminated.

exit status 1

Compilation error: Time.h: No such file or directory
```

From v1.6.1 of Michael Margolis Time library programs should include TimeLib.h. This PR fixes this error for the latest Arduino IDE.
