### PR TITLE
add codespell CI action

### DIFF
--- a/.github/workflows/codespell-ignored-words.txt
+++ b/.github/workflows/codespell-ignored-words.txt
@@ -1,0 +1,6 @@
+fram
+iterm
+ntegral
+numer
+numers
+wel

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,31 @@
+name: Run codespell
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # codespell is not installed in the runner by default
+    - name: install codespell
+      run:   |
+          sudo apt update
+          sudo apt install codespell
+
+    - name: identify codespell
+      run: codespell --version
+
+    # If count >0 will trigger a workflow failure, else success
+    - name: run codespell
+      run: codespell --ignore-words=./.github/workflows/codespell-ignored-words.txt --count ./speeduino/

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -26,6 +26,12 @@ jobs:
     - name: identify codespell
       run: codespell --version
 
+    # use latest available dictionaries
+    - name: update dictionary
+      run:    |
+          curl --output-dir /tmp --remote-name https://raw.githubusercontent.com/codespell-project/codespell/master/codespell_lib/data/dictionary.txt
+          curl --output-dir /tmp --remote-name https://raw.githubusercontent.com/codespell-project/codespell/master/codespell_lib/data/dictionary_rare.txt
+
     # If count >0 will trigger a workflow failure, else success
     - name: run codespell
-      run: codespell --ignore-words=./.github/workflows/codespell-ignored-words.txt --count ./speeduino/
+      run: codespell --dictionary=/tmp/dictionary.txt --dictionary=/tmp/dictionary_rare.txt --ignore-words=./.github/workflows/codespell-ignored-words.txt --count ./speeduino/


### PR DESCRIPTION
Adds CI action to run codespell against the master branch.

Pulls in latest codespell dictionaries.
Ignore list at `.github/workflows/codespell-ignored-words.txt`