### PR TITLE
Make build-test CI run on fixes branches

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -2,9 +2,10 @@ name: Build Firmware
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, '*-fixes' ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -13,6 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Cache pip
       uses: actions/cache@v4
       with:
@@ -20,6 +22,7 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+
     - name: Cache PlatformIO
       uses: actions/cache@v4
       with:
@@ -44,7 +47,7 @@ jobs:
       run: platformio run -e black_F407VE -e BlackPill_F401CC -e BlackPill_F411CE_USB
 
     - name: Upload to Speeduino server
-      if: github.event_name != 'pull_request' && github.repository_owner == 'noisymime'
+      if: github.event_name != 'pull_request' && github.repository_owner == 'noisymime' && github.ref_name == 'master'
       env:
         WEB_PWD: ${{ secrets.WEB_PWD }}
       run: |
@@ -54,7 +57,7 @@ jobs:
         curl -v --tlsv1.2 --ipv4 --user "speeduino_firmware@speeduino.com:$WEB_PWD" --basic -T "./.pio/build/teensy36/firmware.hex" "https://speeduino.com:2078/teensy36/master-teensy36.hex"
         curl -v --tlsv1.2 --ipv4 --user "speeduino_firmware@speeduino.com:$WEB_PWD" --basic -T "./.pio/build/teensy41/firmware.hex" "https://speeduino.com:2078/teensy41/master-teensy41.hex"
         curl -v --tlsv1.2 --ipv4 --user "speeduino_firmware@speeduino.com:$WEB_PWD" --basic -T "./.pio/build/black_F407VE/firmware.bin" "https://speeduino.com:2078/stm32f407/master-stm32f407.bin"
-        curl --tlsv1.2 --ipv4 --user "speeduino_firmware@speeduino.com:$WEB_PWD" --basic -T "./reference/speeduino.ini" "https://speeduino.com:2078/master.ini"
+        curl -v --tlsv1.2 --ipv4 --user "speeduino_firmware@speeduino.com:$WEB_PWD" --basic -T "./reference/speeduino.ini" "https://speeduino.com:2078/master.ini"
 
     - name: Discord Notification (Build Failed)
       uses: rjstone/discord-webhook-notify@v1

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -47,7 +47,7 @@ jobs:
       run: platformio run -e black_F407VE -e BlackPill_F401CC -e BlackPill_F411CE_USB
 
     - name: Upload to Speeduino server
-      if: github.event_name != 'pull_request' && github.repository_owner == 'noisymime' && github.ref_name == 'master'
+      if: github.event_name != 'pull_request' && github.repository_owner == 'speeduino' && github.ref_name == 'master'
       env:
         WEB_PWD: ${{ secrets.WEB_PWD }}
       run: |
@@ -61,7 +61,7 @@ jobs:
 
     - name: Discord Notification (Build Failed)
       uses: rjstone/discord-webhook-notify@v1
-      if: failure() && github.event_name != 'pull_request' && github.repository_owner == 'noisymime'
+      if: failure() && github.event_name != 'pull_request' && github.repository_owner == 'speeduino'
       with:
           severity: error
           avatarUrl: https://avatars.githubusercontent.com/u/9919?v=4&size=48

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -25,13 +25,13 @@ jobs:
         working-directory: "." # default is .
 
     - name: Setup git config
-      if: github.repository_owner == 'noisymime'
+      if: github.repository_owner == 'speeduino'
       run: |
         git config --global user.name "GitHub Actions Bot"
         git config --global user.email "<>"
 
     - name: Commit updated Doxygen documentation
-      if: github.event_name != 'pull_request' && github.repository_owner == 'noisymime'
+      if: github.event_name != 'pull_request' && github.repository_owner == 'speeduino'
       env:
         GH_DOXYGEN: ${{ secrets.GH_DOXYGEN }}
       run: |

--- a/.github/workflows/misra.yml
+++ b/.github/workflows/misra.yml
@@ -40,7 +40,7 @@ jobs:
         ls $GITHUB_WORKSPACE/misra/.results/
         
     - name: Save output to Gist
-      if: github.event_name != 'pull_request' && github.repository_owner == 'noisymime'
+      if: github.event_name != 'pull_request' && github.repository_owner == 'speeduino'
       env:
         MISRA_GIST: ${{ secrets.MISRA_GIST }}
         VIOLATIONS: ${{ env.VIOLATIONS }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     # Only try to run hardware unit tests on the upstream repository
-    if: github.repository_owner == 'noisymime'
+    if: github.repository_owner == 'speeduino'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/upload-ini.yml
+++ b/.github/workflows/upload-ini.yml
@@ -21,7 +21,7 @@ jobs:
 
   upload:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'noisymime'
+    if: github.repository_owner == 'speeduino'
     needs: validate
 
     steps:


### PR DESCRIPTION
Currently, build testing is not running on fixes branches, it's probably a good idea to have it run there too.

You need to make sure the firmware uploads are still working in the master branch with this filter, I can't test that part.
`&& github.ref_name == 'master'`