### PR TITLE
fix stepper driver always enabled causing motor to run hot

### DIFF
--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -334,7 +334,10 @@ static inline byte checkForStepping(void)
         if(configPage9.iacStepperPower == STEPPER_POWER_WHEN_ACTIVE) 
         { 
           //Disable the DRV8825, but only if we're at the final step in this cycle. 
-          if(idleStepper.targetIdleStep == idleStepper.curIdleStep) { digitalWrite(pinStepperEnable, HIGH); } 
+          if ( (idleStepper.targetIdleStep > (idleStepper.curIdleStep - configPage6.iacStepHyster)) && (idleStepper.targetIdleStep < (idleStepper.curIdleStep + configPage6.iacStepHyster)) ) //Hysteresis check
+          { 
+            digitalWrite(pinStepperEnable, HIGH); 
+          } 
         }
       }
     }


### PR DESCRIPTION
Currently when using "Stepper Open Loop", the DRV8825 often remains enabled even though Stepper Power is set "When Active" which causes the stepper motor to run unnecessarily hot.  Specifically,  the idle step hysteresis [when Minimum Steps > 1] is not accounted for when determining if the final step of the cycle has been reached so the DRV8825 ENABLE pin often never transitions from LOW to HIGH.