### PR TITLE
Added Trigger for the Yamaha XTZ750

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -191,6 +191,7 @@
     #define trigger_Rover				        = 25
     #define trigger_K6A  				        = 26
     #define trigger_HondaJ32            = 27
+    #define trigger_XTZ750              = 28
 
 [Constants]
 
@@ -512,7 +513,7 @@ page = 4
       TrigEdge   = bits,   U08,      5,[0:0],    "RISING", "FALLING"
       TrigSpeed  = bits,   U08,      5,[1:1],    "Crank Speed", "Cam Speed"
       IgInv      = bits,   U08,      5,[2:2],    "Going Low",        "Going High"
-      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Ford ST170", "DRZ400", "Chrysler NGC", "Yamaha Vmax 1990+", "Renix", "Rover MEMS", "K6A", "Honda J32", "INVALID", "INVALID", "INVALID", "INVALID"
+      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Ford ST170", "DRZ400", "Chrysler NGC", "Yamaha Vmax 1990+", "Renix", "Rover MEMS", "K6A", "Honda J32", "XTZ 750", "INVALID", "INVALID", "INVALID"
       TrigEdgeSec= bits,   U08,      6,[0:0],    "RISING", "FALLING"
       fuelPumpPin= bits  , U08,      6,[1:6],    "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
       useResync  = bits,   U08,      6,[7:7],    "No",        "Yes"

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -5995,5 +5995,164 @@ void triggerSetEndTeeth_SuzukiK6A(void)
   { tempIgnitionEndTooth = 7; } // didn't find a match, use tooth 7 as it must be greater than 7 but less than 1.  
   ignition3EndTooth = tempIgnitionEndTooth;
 }
+
+
+
+
+/** Yamaha XTZ750 1989+ with 4 uneven teeth, triggering on the wide lobe.
+Within the decoder code, the sync tooth is referred to as tooth #1. Derived from Harley and made to work on the Yamaha XTZ.
+Trigger is based on 'CHANGE' so we get a signal on the up and downward edges of the lobe. This is required to identify the wide lobe.
+* @defgroup dec_xtzV1 Yamaha XTZ V1
+* @{
+*/
+void triggerSetup_XTZ(void)
+{
+  triggerToothAngle = 0; // The number of degrees that passes from tooth to tooth, ev. 0. It alternates uneven
+  BIT_CLEAR(decoderState, BIT_DECODER_2ND_DERIV);
+  BIT_CLEAR(decoderState, BIT_DECODER_IS_SEQUENTIAL);
+  BIT_CLEAR(decoderState, BIT_DECODER_HAS_SECONDARY);
+  //MAX_STALL_TIME = (3333UL * 60); //Minimum 50rpm. (3333uS is the time per degree at 50rpm)
+  MAX_STALL_TIME = ((MICROS_PER_DEG_1_RPM/50U) * 60U); //Minimum 50rpm. (3333uS is the time per degree at 50rpm)
+  if(currentStatus.initialisationComplete == false) { toothLastToothTime = micros(); } //Set a startup value here to avoid filter errors when starting. This MUST have the initi check to prevent the fuel pump just staying on all the time
+  triggerFilterTime = 1500;
+  BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); // We must start with a valid trigger or we cannot start measuring the lobe width. We only have a false trigger on the lobe up event when it doesn't pass the filter. Then, the lobe width will also not be beasured.
+  toothAngles[1] = 0;      //tooth #1, these are the absolute tooth positions
+  toothAngles[2] = 90;     //tooth #2
+  toothAngles[3] = 180;    //tooth #3
+  toothAngles[4] = 270;    //tooth #4
+}
+
+//curGap = microseconds between primary triggers
+//curGap2 = microseconds between secondary triggers
+//toothCurrentCount = the current number for the end of a lobe
+//secondaryToothCount = the current number of the beginning of a lobe
+//We measure the width of a lobe so on the end of a lobe, but want to trigger on the beginning. Variable toothCurrentCount tracks the downward events, and secondaryToothCount updates on the upward events. Ideally, it should be the other way round but the engine stall routine resets secondaryToothCount, so it would not sync again after an engine stall.
+
+void triggerPri_XTZ(void)
+{
+  curTime = micros();
+  if(READ_PRI_TRIGGER() == primaryTriggerEdge){// Forwarded from the config page to setup the primary trigger edge (rising or falling). Inverting VR-conditioners require FALLING, non-inverting VR-conditioners require RISING in the Trigger edge setup.
+    curGap2 = curTime;
+    curGap = curTime - toothLastToothTime;
+    if ( (curGap >= triggerFilterTime) ){
+      BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
+      if (toothCurrentCount > 0) // We have sync based on the tooth width.
+      {
+          BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
+          if (toothCurrentCount==1)
+          {
+            toothOneMinusOneTime = toothOneTime;
+            toothOneTime = curTime;
+            currentStatus.hasSync = true;
+            currentStatus.startRevolutions++; //Counter
+          }
+
+          setFilter(curGap);
+          secondaryToothCount = toothCurrentCount;
+          triggerToothAngle = 90;// Has to be equal to Angle Routine, and describe the delta between two teeth.
+          toothLastMinusOneToothTime = toothLastToothTime;
+          toothLastToothTime = curTime;
+          if (triggerFilterTime > 50000){//The first pulse seen 
+            triggerFilterTime = 0;
+          }
+      }
+      else{
+        triggerFilterTime = 0;
+        return;//Zero, no sync yet.
+      }
+    }
+    else{
+      BIT_CLEAR(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being an invalid trigger
+    }
+  }
+  else if( BIT_CHECK(decoderState, BIT_DECODER_VALID_TRIGGER) ) // Inverted due to vr conditioner. So this is the falling lobe. We only process if there was a valid trigger.
+  {
+    unsigned long curGapLocal = curTime - curGap2;
+    if (curGapLocal > (lastGap * 3)){// Small lobe is 5 degrees, big lobe is 45 degrees. So this should be the wide lobe.
+        if (toothCurrentCount == 0 || toothCurrentCount == 4){//Wide should be seen with toothCurrentCount = 0, when there is no sync yet, or toothCurrentCount = 6 when we have done a full revolution. 
+          currentStatus.hasSync = true;
+        }
+        else{//Wide lobe seen where it shouldn't, adding a sync error.
+          currentStatus.syncLossCounter++;
+        }
+        toothCurrentCount = 1;
+    }
+    else if(toothCurrentCount == 4){//The 6th lobe should be wide, adding a sync error.
+        toothCurrentCount = 1;
+        currentStatus.syncLossCounter++;
+    }
+    else{// Small lobe, just add 1 to the toothCurrentCount.
+      toothCurrentCount++;
+    }
+    lastGap = curGapLocal;
+    return;
+  }
+  else if( BIT_CHECK(decoderState, BIT_DECODER_VALID_TRIGGER) == false)
+  {
+    BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //We reset this every time to ensure we only filter when needed.
+  }
+}
+
+
+void triggerSec_XTZ(void)
+// Needs to be enabled in main()
+{
+  return;// No need for now. The only thing it could help to sync more quikly or confirm position.
+} // End Sec Trigger
+
+
+uint16_t getRPM_XTZ(void)
+{
+  uint16_t tempRPM = 0;
+  if (currentStatus.hasSync == true)
+  {
+    if ( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { tempRPM = 0; }
+    else
+    {
+      /*
+      noInterrupts();
+        revolutionTime = (toothLastToothTime - toothLastMinusOneToothTime)<<2; 
+      interrupts();
+      tempRPM = ((unsigned long) 6000000UL) / revolutionTime;
+      if(tempRPM >= MAX_RPM) tempRPM = currentStatus.RPM; //Sanity check
+      */
+      tempRPM = stdGetRPM(CRANK_SPEED);
+    }
+  }
+  return tempRPM;
+}
+
+
+int getCrankAngle_XTZ(void)
+{
+  //This is the current angle ATDC the engine is at. This is the last known position based on what tooth was last 'seen'. It is only accurate to the resolution of the trigger wheel (Eg 36-1 is 10 degrees)
+  unsigned long tempToothLastToothTime;
+  int tempsecondaryToothCount;
+  //Grab some variables that are used in the trigger code and assign them to temp variables.
+  noInterrupts();
+  tempsecondaryToothCount = secondaryToothCount;
+  tempToothLastToothTime = toothLastToothTime;
+  lastCrankAngleCalc = micros(); //micros() is no longer interrupt safe
+  interrupts();
+  //Check if the last tooth seen was the reference tooth (Number 3). All others can be calculated, but tooth 3 has a unique angle
+  int crankAngle;
+  crankAngle=toothAngles[tempsecondaryToothCount] + configPage4.triggerAngle;
+  
+  //Estimate the number of degrees travelled since the last tooth}
+  elapsedTime = (lastCrankAngleCalc - tempToothLastToothTime);
+  //crankAngle += timeToAngle(elapsedTime, CRANKMATH_METHOD_INTERVAL_REV);
+  crankAngle += timeToAngleDegPerMicroSec(elapsedTime);
+
+  if (crankAngle >= 720) { crankAngle -= 720; }
+  if (crankAngle > CRANK_ANGLE_MAX) { crankAngle -= CRANK_ANGLE_MAX; }
+  if (crankAngle < 0) { crankAngle += 360; }
+
+  return crankAngle;
+}
+
+void triggerSetEndTeeth_XTZ(void)
+{
+}
+
 /** @} */
 

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -6011,7 +6011,6 @@ void triggerSetup_XTZ(void)
   BIT_CLEAR(decoderState, BIT_DECODER_2ND_DERIV);
   BIT_CLEAR(decoderState, BIT_DECODER_IS_SEQUENTIAL);
   BIT_CLEAR(decoderState, BIT_DECODER_HAS_SECONDARY);
-  //MAX_STALL_TIME = (3333UL * 60); //Minimum 50rpm. (3333uS is the time per degree at 50rpm)
   MAX_STALL_TIME = ((MICROS_PER_DEG_1_RPM/50U) * 60U); //Minimum 50rpm. (3333uS is the time per degree at 50rpm)
   if(currentStatus.initialisationComplete == false) { toothLastToothTime = micros(); } //Set a startup value here to avoid filter errors when starting. This MUST have the initi check to prevent the fuel pump just staying on all the time
   triggerFilterTime = 1500;
@@ -6109,13 +6108,6 @@ uint16_t getRPM_XTZ(void)
     if ( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { tempRPM = 0; }
     else
     {
-      /*
-      noInterrupts();
-        revolutionTime = (toothLastToothTime - toothLastMinusOneToothTime)<<2; 
-      interrupts();
-      tempRPM = ((unsigned long) 6000000UL) / revolutionTime;
-      if(tempRPM >= MAX_RPM) tempRPM = currentStatus.RPM; //Sanity check
-      */
       tempRPM = stdGetRPM(CRANK_SPEED);
     }
   }
@@ -6140,7 +6132,6 @@ int getCrankAngle_XTZ(void)
   
   //Estimate the number of degrees travelled since the last tooth}
   elapsedTime = (lastCrankAngleCalc - tempToothLastToothTime);
-  //crankAngle += timeToAngle(elapsedTime, CRANKMATH_METHOD_INTERVAL_REV);
   crankAngle += timeToAngleDegPerMicroSec(elapsedTime);
 
   if (crankAngle >= 720) { crankAngle -= 720; }

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -41,6 +41,7 @@
 #define DECODER_ROVERMEMS		      25
 #define DECODER_SUZUKI_K6A        26
 #define DECODER_HONDA_J32         27
+#define DECODER_XTZ               28
 
 #define BIT_DECODER_2ND_DERIV           0 //The use of the 2nd derivative calculation is limited to certain decoders. This is set to either true or false in each decoders setup routine
 #define BIT_DECODER_IS_SEQUENTIAL       1 //Whether or not the decoder supports sequential operation
@@ -249,6 +250,13 @@ void triggerSec_Vmax(void);
 uint16_t getRPM_Vmax(void);
 int getCrankAngle_Vmax(void);
 void triggerSetEndTeeth_Vmax(void);
+
+void triggerSetup_XTZ(void);
+void triggerPri_XTZ(void);
+void triggerSec_XTZ(void);
+uint16_t getRPM_XTZ(void);
+int getCrankAngle_XTZ(void);
+void triggerSetEndTeeth_XTZ(void);
 
 void triggerSetup_SuzukiK6A(void);
 void triggerPri_SuzukiK6A(void);

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -3710,6 +3710,19 @@ void initialiseTriggers(void)
       attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 
+    case DECODER_XTZ:
+      triggerSetup_XTZ();
+      triggerHandler = triggerPri_XTZ;
+      getRPM = getRPM_XTZ;
+      getCrankAngle = getCrankAngle_XTZ;
+      triggerSetEndTeeth = triggerSetEndTeeth_XTZ;
+
+      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = true; } // set as boolean so we can directly use it in decoder.
+      else { primaryTriggerEdge = false; }
+      
+      attachInterrupt(triggerInterrupt, triggerHandler, CHANGE); //Hardcoded change, the primaryTriggerEdge will be used in the decoder to select if it`s an inverted or non-inverted signal.
+      break;
+
 
     default:
       triggerHandler = triggerPri_missingTooth;


### PR DESCRIPTION
This is a trigger I`ve been riding around with for about a year based on the Vmax one from @RempageR1 . The XTZ flywheel has 4 unevenly sized lobes, where one is the wide lobe used for triggering. This trigger therefore has a routine to note the times when an upward and downward tooth edge is seen and can therefore calculate the tooth width. The actual trigger needs to happen on the upward tooth edge so this is included in the routine.

IMPORTANT: The VR conditioner must have the zero-crossing disabled in order to have reliable triggering

This is my first commit to the Speeduino project, please let me know if there is anything I need to change or of you need any additional information. Thank you!