### PR TITLE
Bugfix for serial I/O hanging when the payload size is only partially sent

### DIFF
--- a/misra/misra_2012_text.txt
+++ b/misra/misra_2012_text.txt
@@ -273,6 +273,8 @@ Rule 21.11
 No text specified
 Rule 21.12
 No text specified
+Rule 21.15
+The pointer arguments to the Standard Library functions memcpy, memmove and memcmp shall be pointers to qualified or unqualified versions of compatible types
 Rule 22.1
 No text specified
 Rule 22.2

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -494,7 +494,7 @@ void serialReceive(void)
       serialReceiveStartTime = millis();
       serialPayloadLength = readSerialIntegralTimeout<uint16_t>();
       if (!isRxTimeout()) {
-        serialBytesRxTx = sizeof(serialPayloadLength);
+        serialBytesRxTx = 0U;
         serialStatusFlag = SERIAL_RECEIVE_INPROGRESS; //Flag the serial receive as being in progress
       }
     }
@@ -503,10 +503,10 @@ void serialReceive(void)
   //If there is a serial receive in progress, read as much from the buffer as possible or until we receive all bytes
   while( (Serial.available() > 0) && (serialStatusFlag == SERIAL_RECEIVE_INPROGRESS) )
   {
-    if (serialBytesRxTx < (serialPayloadLength + sizeof(serialPayloadLength)) )
+    if (serialBytesRxTx < serialPayloadLength )
     {
-      serialPayload[serialBytesRxTx - sizeof(serialPayloadLength)] = (byte)Serial.read();
-      serialBytesRxTx++;
+      serialPayload[serialBytesRxTx] = (byte)Serial.read();
+      ++serialBytesRxTx;
     }
     else
     {

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -1251,7 +1251,7 @@ void sendToothLog_legacy(byte startOffset) /* Blocking */
   if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_TOOTHLOG1READY)) //Sanity check. Flagging system means this should always be true
   {
       serialStatusFlag = SERIAL_TRANSMIT_TOOTH_INPROGRESS_LEGACY; 
-      for (int x = startOffset; x < TOOTH_LOG_SIZE; x++)
+      for (uint8_t x = startOffset; x < TOOTH_LOG_SIZE; ++x)
       {
         Serial.write(toothHistory[x] >> 24);
         Serial.write(toothHistory[x] >> 16);
@@ -1265,7 +1265,7 @@ void sendToothLog_legacy(byte startOffset) /* Blocking */
   else 
   { 
     //TunerStudio has timed out, send a LOG of all 0s
-    for(int x = 0; x < (4*TOOTH_LOG_SIZE); x++)
+    for(uint16_t x = 0U; x < (4U*TOOTH_LOG_SIZE); ++x)
     {
       Serial.write(static_cast<byte>(0x00)); //GCC9 fix
     }
@@ -1279,7 +1279,7 @@ void sendCompositeLog_legacy(byte startOffset) /* Non-blocking */
   {
       serialStatusFlag = SERIAL_TRANSMIT_COMPOSITE_INPROGRESS_LEGACY;
 
-      for (int x = startOffset; x < TOOTH_LOG_SIZE; x++)
+      for (uint8_t x = startOffset; x < TOOTH_LOG_SIZE; ++x)
       {
         //Check whether the tx buffer still has space
         if(Serial.availableForWrite() < 4) 
@@ -1305,7 +1305,7 @@ void sendCompositeLog_legacy(byte startOffset) /* Non-blocking */
   else 
   { 
     //TunerStudio has timed out, send a LOG of all 0s
-    for(int x = 0; x < (5*TOOTH_LOG_SIZE); x++)
+    for(uint16_t x = 0U; x < (5U*TOOTH_LOG_SIZE); ++x)
     {
       Serial.write(static_cast<byte>(0x00)); //GCC9 fix
     }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -208,10 +208,12 @@
 #define VALID_MAP_MIN 2 //The smallest ADC value that is valid for the MAP sensor
 
 #ifndef UNIT_TEST 
-#define TOOTH_LOG_SIZE      127
+#define TOOTH_LOG_SIZE      127U
 #else
-#define TOOTH_LOG_SIZE      1
+#define TOOTH_LOG_SIZE      1U
 #endif
+// Some code relies on TOOTH_LOG_SIZE being uint8_t.
+static_assert(TOOTH_LOG_SIZE<UINT8_MAX, "Check all uses of TOOTH_LOG_SIZE");
 
 #define O2_CALIBRATION_PAGE   2U
 #define IAT_CALIBRATION_PAGE  1U
@@ -328,10 +330,10 @@
 #define SPARK2_CONDITION_TPS 2
 #define SPARK2_CONDITION_ETH 3
 
-#define RESET_CONTROL_DISABLED             0
-#define RESET_CONTROL_PREVENT_WHEN_RUNNING 1
-#define RESET_CONTROL_PREVENT_ALWAYS       2
-#define RESET_CONTROL_SERIAL_COMMAND       3
+#define RESET_CONTROL_DISABLED             0U
+#define RESET_CONTROL_PREVENT_WHEN_RUNNING 1U
+#define RESET_CONTROL_PREVENT_ALWAYS       2U
+#define RESET_CONTROL_SERIAL_COMMAND       3U
 
 #define OPEN_LOOP_BOOST     0
 #define CLOSED_LOOP_BOOST   1


### PR DESCRIPTION
Serial I/O will hang the system if a 2nd payload byte is never sent. This PR adds a timeout to that operation.

Plus MISRA fixes & DOxygen clean up/corrections for comms.cpp