### PR TITLE
fix: CORE_AVR is the only architecture that supports ATOMIC_BLOCK.

### DIFF
--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -24,34 +24,7 @@ void wmiControl(void);
 #define SIMPLE_BOOST_I  1
 #define SIMPLE_BOOST_D  1
 
-#if(defined(CORE_TEENSY) || defined(CORE_STM32))
-#define BOOST_PIN_LOW()         (digitalWrite(pinBoost, LOW))
-#define BOOST_PIN_HIGH()        (digitalWrite(pinBoost, HIGH))
-#define VVT1_PIN_LOW()          (digitalWrite(pinVVT_1, LOW))
-#define VVT1_PIN_HIGH()         (digitalWrite(pinVVT_1, HIGH))
-#define VVT2_PIN_LOW()          (digitalWrite(pinVVT_2, LOW))
-#define VVT2_PIN_HIGH()         (digitalWrite(pinVVT_2, HIGH))
-#define FAN_PIN_LOW()           (digitalWrite(pinFan, LOW))
-#define FAN_PIN_HIGH()          (digitalWrite(pinFan, HIGH))
-#define N2O_STAGE1_PIN_LOW()    (digitalWrite(configPage10.n2o_stage1_pin, LOW))
-#define N2O_STAGE1_PIN_HIGH()   (digitalWrite(configPage10.n2o_stage1_pin, HIGH))
-#define N2O_STAGE2_PIN_LOW()    (digitalWrite(configPage10.n2o_stage2_pin, LOW))
-#define N2O_STAGE2_PIN_HIGH()   (digitalWrite(configPage10.n2o_stage2_pin, HIGH))
-#define AIRCON_PIN_LOW()        (digitalWrite(pinAirConComp, LOW))
-#define AIRCON_PIN_HIGH()       (digitalWrite(pinAirConComp, HIGH))
-#define AIRCON_FAN_PIN_LOW()    (digitalWrite(pinAirConFan, LOW))
-#define AIRCON_FAN_PIN_HIGH()   (digitalWrite(pinAirConFan, HIGH))
-#define FUEL_PUMP_ON()          (digitalWrite(pinFuelPump, HIGH))
-#define FUEL_PUMP_OFF()         (digitalWrite(pinFuelPump, LOW))
-
-#define AIRCON_ON()             { (((configPage15.airConCompPol==1)) ? AIRCON_PIN_LOW() : AIRCON_PIN_HIGH()); BIT_SET(currentStatus.airConStatus, BIT_AIRCON_COMPRESSOR); }
-#define AIRCON_OFF()            { (((configPage15.airConCompPol==1)) ? AIRCON_PIN_HIGH() : AIRCON_PIN_LOW()); BIT_CLEAR(currentStatus.airConStatus, BIT_AIRCON_COMPRESSOR); }
-#define AIRCON_FAN_ON()         { (((configPage15.airConFanPol==1)) ? AIRCON_FAN_PIN_LOW() : AIRCON_FAN_PIN_HIGH()); BIT_SET(currentStatus.airConStatus, BIT_AIRCON_FAN); }
-#define AIRCON_FAN_OFF()        { (((configPage15.airConFanPol==1)) ? AIRCON_FAN_PIN_HIGH() : AIRCON_FAN_PIN_LOW()); BIT_CLEAR(currentStatus.airConStatus, BIT_AIRCON_FAN); }
-
-#define FAN_ON()                { ((configPage6.fanInv) ? FAN_PIN_LOW() : FAN_PIN_HIGH()); }
-#define FAN_OFF()               { ((configPage6.fanInv) ? FAN_PIN_HIGH() : FAN_PIN_LOW()); }
-#else
+#ifdef CORE_AVR
 #define BOOST_PIN_LOW()         ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { *boost_pin_port &= ~(boost_pin_mask); }
 #define BOOST_PIN_HIGH()        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { *boost_pin_port |= (boost_pin_mask);  }
 #define VVT1_PIN_LOW()          ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { *vvt1_pin_port &= ~(vvt1_pin_mask);   }
@@ -80,6 +53,33 @@ void wmiControl(void);
 
 #define FAN_ON()                ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { ((configPage6.fanInv) ? FAN_PIN_LOW() : FAN_PIN_HIGH()); }
 #define FAN_OFF()               ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { ((configPage6.fanInv) ? FAN_PIN_HIGH() : FAN_PIN_LOW()); }
+#else
+#define BOOST_PIN_LOW()         (digitalWrite(pinBoost, LOW))
+#define BOOST_PIN_HIGH()        (digitalWrite(pinBoost, HIGH))
+#define VVT1_PIN_LOW()          (digitalWrite(pinVVT_1, LOW))
+#define VVT1_PIN_HIGH()         (digitalWrite(pinVVT_1, HIGH))
+#define VVT2_PIN_LOW()          (digitalWrite(pinVVT_2, LOW))
+#define VVT2_PIN_HIGH()         (digitalWrite(pinVVT_2, HIGH))
+#define FAN_PIN_LOW()           (digitalWrite(pinFan, LOW))
+#define FAN_PIN_HIGH()          (digitalWrite(pinFan, HIGH))
+#define N2O_STAGE1_PIN_LOW()    (digitalWrite(configPage10.n2o_stage1_pin, LOW))
+#define N2O_STAGE1_PIN_HIGH()   (digitalWrite(configPage10.n2o_stage1_pin, HIGH))
+#define N2O_STAGE2_PIN_LOW()    (digitalWrite(configPage10.n2o_stage2_pin, LOW))
+#define N2O_STAGE2_PIN_HIGH()   (digitalWrite(configPage10.n2o_stage2_pin, HIGH))
+#define AIRCON_PIN_LOW()        (digitalWrite(pinAirConComp, LOW))
+#define AIRCON_PIN_HIGH()       (digitalWrite(pinAirConComp, HIGH))
+#define AIRCON_FAN_PIN_LOW()    (digitalWrite(pinAirConFan, LOW))
+#define AIRCON_FAN_PIN_HIGH()   (digitalWrite(pinAirConFan, HIGH))
+#define FUEL_PUMP_ON()          (digitalWrite(pinFuelPump, HIGH))
+#define FUEL_PUMP_OFF()         (digitalWrite(pinFuelPump, LOW))
+
+#define AIRCON_ON()             { (((configPage15.airConCompPol==1)) ? AIRCON_PIN_LOW() : AIRCON_PIN_HIGH()); BIT_SET(currentStatus.airConStatus, BIT_AIRCON_COMPRESSOR); }
+#define AIRCON_OFF()            { (((configPage15.airConCompPol==1)) ? AIRCON_PIN_HIGH() : AIRCON_PIN_LOW()); BIT_CLEAR(currentStatus.airConStatus, BIT_AIRCON_COMPRESSOR); }
+#define AIRCON_FAN_ON()         { (((configPage15.airConFanPol==1)) ? AIRCON_FAN_PIN_LOW() : AIRCON_FAN_PIN_HIGH()); BIT_SET(currentStatus.airConStatus, BIT_AIRCON_FAN); }
+#define AIRCON_FAN_OFF()        { (((configPage15.airConFanPol==1)) ? AIRCON_FAN_PIN_HIGH() : AIRCON_FAN_PIN_LOW()); BIT_CLEAR(currentStatus.airConStatus, BIT_AIRCON_FAN); }
+
+#define FAN_ON()                { ((configPage6.fanInv) ? FAN_PIN_LOW() : FAN_PIN_HIGH()); }
+#define FAN_OFF()               { ((configPage6.fanInv) ? FAN_PIN_HIGH() : FAN_PIN_LOW()); }
 #endif
 
 #define READ_N2O_ARM_PIN()    ((*n2o_arming_pin_port & n2o_arming_pin_mask) ? true : false)


### PR DESCRIPTION
Since CORE_AVR is the only archiecture that supports ATOMIC_BLOCK, change the preprocessor definitions to be exclusive to that architecture. rather than having to define all other architecture as exclusive from a default ATOMIC_BLOCK