### PR TITLE
feat: adds AEM 30-0300 X-Series UEGO wideband over CAN support 

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -477,7 +477,7 @@ page = 1
 
       unused0_126               = bits,   U08,  126, [0:2]
       ;These are reserved for future use, in case of more CAN broadcasting features are added
-      canWBO                    = bits,   U08,  126, [2:3], "Off", "rusEFI WBO", "INVALID", "INVALID"
+      canWBO                    = bits,   U08,  126, [2:3], "Off", "rusEFI WBO", "AEM", "INVALID"
       vssAuxCh                  = bits,   U08,  126, [4:7], "Aux0", "Aux1", "Aux2", "Aux3", "Aux4", "Aux5", "Aux6", "Aux7", "Aux8", "Aux9", "Aux10", "Aux11", "Aux12", "Aux13", "Aux14", "Aux15"
       decelAmount               = scalar, U08,  127,        "%",  1.0,       0.0,   0.0,     150.0,    0
 

--- a/speeduino/comms_CAN.cpp
+++ b/speeduino/comms_CAN.cpp
@@ -172,7 +172,9 @@ void receiveCANwbo()
         if ((inLambda * configPage2.stoich / 10000) > 250) { //Check if we dont overflow the 8bit O2 variable
           currentStatus.O2 = 250;
         }
-        currentStatus.O2 = (unsigned int)(inLambda * configPage2.stoich / 10000); //Multiplying lambda by stoich ratio to get AFR and dividing it by 10000 to get correct value
+        else {
+          currentStatus.O2 = (unsigned int)(inLambda * configPage2.stoich / 10000); //Multiplying lambda by stoich ratio to get AFR and dividing it by 10000 to get correct value
+        }
       }
     }
   }

--- a/speeduino/comms_CAN.cpp
+++ b/speeduino/comms_CAN.cpp
@@ -169,12 +169,9 @@ void receiveCANwbo()
       inLambda = (word(inMsg.buf[0], inMsg.buf[1])); //Combining 2 bytes of data into single variable factor is 0.0001 so lambda 1 comes in as 10K
       if(BIT_CHECK(inMsg.buf[6], 7)) //Checking if lambda is valid
       {
-        if ((inLambda * configPage2.stoich / 10000) > 250) { //Check if we dont overflow the 8bit O2 variable
-          currentStatus.O2 = 250;
-        }
-        else {
-          currentStatus.O2 = (unsigned int)(inLambda * configPage2.stoich / 10000); //Multiplying lambda by stoich ratio to get AFR and dividing it by 10000 to get correct value
-        }
+        inLambda = (inLambda * configPage2.stoich) / 10000; //Multiplying lambda by stoich ratio to get AFR and dividing it by 10000 to get correct value
+        if (inLambda > 250) { currentStatus.O2 = 250; } //Check if we don't overflow the 8bit O2 variable
+        else { currentStatus.O2 = inLambda & 0xFF; }
       }
     }
   }

--- a/speeduino/comms_CAN.cpp
+++ b/speeduino/comms_CAN.cpp
@@ -127,8 +127,7 @@ void sendCANBroadcast(uint8_t frequency)
 
 void receiveCANwbo() 
 {
-  // Currently only RusEFI CAN Wideband supported: https://github.com/mck1117/wideband
-  if(configPage2.canWBO == CAN_WBO_RUSEFI)
+  if(configPage2.canWBO == CAN_WBO_RUSEFI) //RusEFI CAN Wideband supported: https://github.com/mck1117/wideband
   {
     outMsg.id = 0xEF50000;
     outMsg.flags.extended = 1;
@@ -159,6 +158,21 @@ void receiveCANwbo()
           default:
           break;
         }
+      }
+    }
+  }
+  else if(configPage2.canWBO == CAN_WBO_AEM) //AEM 30-0300 X-Series UEGO Gauge
+  {
+    if(inMsg.id == 0x180)  //AEM wideband default ID1 message id
+    {
+      uint32_t inLambda;
+      inLambda = (word(inMsg.buf[0], inMsg.buf[1])); //Combining 2 bytes of data into single variable factor is 0.0001 so lambda 1 comes in as 10K
+      if(BIT_CHECK(inMsg.buf[6], 7)) //Checking if lambda is valid
+      {
+        if ((inLambda * configPage2.stoich / 10000) > 250) { //Check if we dont overflow the 8bit O2 variable
+          currentStatus.O2 = 250;
+        }
+        currentStatus.O2 = (unsigned int)(inLambda * configPage2.stoich / 10000); //Multiplying lambda by stoich ratio to get AFR and dividing it by 10000 to get correct value
       }
     }
   }

--- a/speeduino/comms_CAN.h
+++ b/speeduino/comms_CAN.h
@@ -30,6 +30,7 @@
 
 
 #define CAN_WBO_RUSEFI 1
+#define CAN_WBO_AEM 2
 
 #define TS_CAN_OFFSET 0x100
 


### PR DESCRIPTION
Currently the code is untested and based on the comment of @NickZ1969  

https://discord.com/channels/879495735912071269/937475043976441917/1229441506230796399

I am currently moving so all my car stuff is in a box somewhere and I can't test this for half a year or so. So please, if someone has a AEM wideband, feel free to test!

CAN data from the manual:
![image](https://github.com/user-attachments/assets/9dad1c75-2937-4260-8874-4d7a6a8c6f7b)
[source](https://static.summitracing.com/global/images/instructions/avm-30-0300.pdf)

Currently using the default 0x180 message ID, this can be changed on the gauge itself to 16 different addresses.
We can maybe say that ID1 is the primary O2 and ID2 is the secondary O2?
For now I just kept it simple with the default CAN ID :)