### PR TITLE
Hardened pin reassignment

### DIFF
--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -127,10 +127,14 @@ void jumpToBootloader();
     #define A15  PA5
   #endif
 #else
+  /* PA11/PA12 is USB
+  *  PD0/PD1 is CAN
+  *  PB0/PB3/PB4/PB5 is SPI used for external flash on black F407
+  */
   #ifdef USE_SPI_EEPROM
-    #define pinIsReserved(pin)  ( ((pin) == PA11) || ((pin) == PA12) || ((pin) == PB3) || ((pin) == PB4) || ((pin) == PB5) || ((pin) == USE_SPI_EEPROM) ) //Forbidden pins like USB
+    #define pinIsReserved(pin)  ( ((pin) == PA11) || ((pin) == PA12) || ((pin) == PD0) || ((pin) == PD1) || ((pin) == PB3) || ((pin) == PB4) || ((pin) == PB5) || ((pin) == USE_SPI_EEPROM) ) //Forbidden pins like USB
   #else
-    #define pinIsReserved(pin)  ( ((pin) == PA11) || ((pin) == PA12) || ((pin) == PB3) || ((pin) == PB4) || ((pin) == PB5) || ((pin) == PB0) ) //Forbidden pins like USB
+    #define pinIsReserved(pin)  ( ((pin) == PA11) || ((pin) == PA12) || ((pin) == PD0) || ((pin) == PD1) || ((pin) == PB3) || ((pin) == PB4) || ((pin) == PB5) || ((pin) == PB0) ) //Forbidden pins like USB
   #endif
 #endif
 

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -239,18 +239,18 @@ void initialiseAll(void)
     initialiseProgrammableIO();
 
     //Check whether the flex sensor is enabled and if so, attach an interrupt for it
-    if(configPage2.flexEnabled > 0)
+    if( (configPage2.flexEnabled > 0) && !pinIsOutput(pinFlex) )
     {
       attachInterrupt(digitalPinToInterrupt(pinFlex), flexPulse, CHANGE);
       currentStatus.ethanolPct = 0;
     }
     //Same as above, but for the VSS input
-    if(configPage2.vssMode > 1) // VSS modes 2 and 3 are interrupt drive (Mode 1 is CAN)
+    if( (configPage2.vssMode > 1) && !pinIsOutput(pinVSS) ) // VSS modes 2 and 3 are interrupt drive (Mode 1 is CAN)
     {
       attachInterrupt(digitalPinToInterrupt(pinVSS), vssPulse, RISING);
     }
     //As above but for knock pulses
-    if(configPage10.knock_mode == KNOCK_MODE_DIGITAL)
+    if( (configPage10.knock_mode == KNOCK_MODE_DIGITAL) && !pinIsOutput(configPage10.knock_pin) )
     {
       if(configPage10.knock_pullup) { pinMode(configPage10.knock_pin, INPUT_PULLUP); }
       else { pinMode(configPage10.knock_pin, INPUT); }
@@ -2748,51 +2748,47 @@ void setPinMapping(byte boardID)
       break;
   }
 
-  //Setup any devices that are using selectable pins
-
-  if ( (configPage6.launchPin != 0) && (configPage6.launchPin < BOARD_MAX_IO_PINS) ) { pinLaunch = pinTranslate(configPage6.launchPin); }
-  if ( (configPage4.ignBypassPin != 0) && (configPage4.ignBypassPin < BOARD_MAX_IO_PINS) ) { pinIgnBypass = pinTranslate(configPage4.ignBypassPin); }
-  if ( (configPage2.tachoPin != 0) && (configPage2.tachoPin < BOARD_MAX_IO_PINS) ) { pinTachOut = pinTranslate(configPage2.tachoPin); }
-  if ( (configPage4.fuelPumpPin != 0) && (configPage4.fuelPumpPin < BOARD_MAX_IO_PINS) ) { pinFuelPump = pinTranslate(configPage4.fuelPumpPin); }
-  if ( (configPage6.fanPin != 0) && (configPage6.fanPin < BOARD_MAX_IO_PINS) ) { pinFan = pinTranslate(configPage6.fanPin); }
-  if ( (configPage6.boostPin != 0) && (configPage6.boostPin < BOARD_MAX_IO_PINS) ) { pinBoost = pinTranslate(configPage6.boostPin); }
-  if ( (configPage6.vvt1Pin != 0) && (configPage6.vvt1Pin < BOARD_MAX_IO_PINS) ) { pinVVT_1 = pinTranslate(configPage6.vvt1Pin); }
+  //Setup any devices that are using selectable pins, pins will be reassigned only if isn't already in use or is protected
   if ( (configPage6.useExtBaro != 0) && (configPage6.baroPin < BOARD_MAX_IO_PINS) ) { pinBaro = pinTranslateAnalog(configPage6.baroPin); }
-  if ( (configPage6.useEMAP != 0) && (configPage10.EMAPPin < BOARD_MAX_IO_PINS) ) { pinEMAP = pinTranslateAnalog(configPage10.EMAPPin); }
-  if ( (configPage10.fuel2InputPin != 0) && (configPage10.fuel2InputPin < BOARD_MAX_IO_PINS) ) { pinFuel2Input = pinTranslate(configPage10.fuel2InputPin); }
-  if ( (configPage10.spark2InputPin != 0) && (configPage10.spark2InputPin < BOARD_MAX_IO_PINS) ) { pinSpark2Input = pinTranslate(configPage10.spark2InputPin); }
-  if ( (configPage2.vssPin != 0) && (configPage2.vssPin < BOARD_MAX_IO_PINS) ) { pinVSS = pinTranslate(configPage2.vssPin); }
   if ( (configPage10.fuelPressureEnable) && (configPage10.fuelPressurePin < BOARD_MAX_IO_PINS) ) { pinFuelPressure = pinTranslateAnalog(configPage10.fuelPressurePin); }
   if ( (configPage10.oilPressureEnable) && (configPage10.oilPressurePin < BOARD_MAX_IO_PINS) ) { pinOilPressure = pinTranslateAnalog(configPage10.oilPressurePin); }
+  if ( (configPage6.useEMAP != 0) && (configPage10.EMAPPin < BOARD_MAX_IO_PINS) ) { pinEMAP = pinTranslateAnalog(configPage10.EMAPPin); }
+  pinReassign(&pinLaunch, configPage6.launchPin);
+  pinReassign(&pinIgnBypass, configPage4.ignBypassPin);
+  pinReassign(&pinTachOut, configPage2.tachoPin);
+  pinReassign(&pinFuelPump, configPage4.fuelPumpPin);
+  pinReassign(&pinFan, configPage6.fanPin);
+  pinReassign(&pinBoost, configPage6.boostPin);
+  pinReassign(&pinVVT_1, configPage6.vvt1Pin);
+  pinReassign(&pinFuel2Input, configPage10.fuel2InputPin);
+  pinReassign(&pinSpark2Input, configPage10.spark2InputPin);
+  pinReassign(&pinVSS, configPage2.vssPin);  
+  pinReassign(&pinWMIEmpty, configPage10.wmiEmptyPin);
+  pinReassign(&pinWMIIndicator, configPage10.wmiIndicatorPin);
+  pinReassign(&pinWMIEnabled, configPage10.wmiEnabledPin);
+  pinReassign(&pinVVT_2, configPage10.vvt2Pin);
+  if ( (configPage13.onboard_log_trigger_Epin != 0 ) && (configPage13.onboard_log_trigger_Epin != 0) ) { pinReassign(&pinSDEnable, configPage13.onboard_log_tr5_Epin_pin); }
   
-  if ( (configPage10.wmiEmptyPin != 0) && (configPage10.wmiEmptyPin < BOARD_MAX_IO_PINS) ) { pinWMIEmpty = pinTranslate(configPage10.wmiEmptyPin); }
-  if ( (configPage10.wmiIndicatorPin != 0) && (configPage10.wmiIndicatorPin < BOARD_MAX_IO_PINS) ) { pinWMIIndicator = pinTranslate(configPage10.wmiIndicatorPin); }
-  if ( (configPage10.wmiEnabledPin != 0) && (configPage10.wmiEnabledPin < BOARD_MAX_IO_PINS) ) { pinWMIEnabled = pinTranslate(configPage10.wmiEnabledPin); }
-  if ( (configPage10.vvt2Pin != 0) && (configPage10.vvt2Pin < BOARD_MAX_IO_PINS) ) { pinVVT_2 = pinTranslate(configPage10.vvt2Pin); }
-  if ( (configPage13.onboard_log_trigger_Epin != 0 ) && (configPage13.onboard_log_trigger_Epin != 0) && (configPage13.onboard_log_tr5_Epin_pin < BOARD_MAX_IO_PINS) ) { pinSDEnable = pinTranslate(configPage13.onboard_log_tr5_Epin_pin); }
-  
-
   //Currently there's no default pin for Idle Up
-  
-  pinIdleUp = pinTranslate(configPage2.idleUpPin);
+  if(!pinReassign(&pinIdleUp, configPage2.idleUpPin)) { pinIdleUp = BOARD_MAX_IO_PINS; } //Invalid pin, protect current function
 
   //Currently there's no default pin for Idle Up Output
-  pinIdleUpOutput = pinTranslate(configPage2.idleUpOutputPin);
+  if(!pinReassign(&pinIdleUpOutput, configPage2.idleUpOutputPin)) { pinIdleUpOutput = BOARD_MAX_IO_PINS; } //Invalid pin, protect current function
 
   //Currently there's no default pin for closed throttle position sensor
-  pinCTPS = pinTranslate(configPage2.CTPSPin);
+  if(!pinReassign(&pinCTPS, configPage2.CTPSPin)) { pinCTPS = BOARD_MAX_IO_PINS; } //Invalid pin, protect current function
   
   // Air conditioning control initialisation
-  if ((configPage15.airConCompPin != 0) && (configPage15.airConCompPin < BOARD_MAX_IO_PINS) ) { pinAirConComp = pinTranslate(configPage15.airConCompPin); }
-  if ((configPage15.airConFanPin != 0) && (configPage15.airConFanPin < BOARD_MAX_IO_PINS) ) { pinAirConFan = pinTranslate(configPage15.airConFanPin); }
-  if ((configPage15.airConReqPin != 0) && (configPage15.airConReqPin < BOARD_MAX_IO_PINS) ) { pinAirConRequest = pinTranslate(configPage15.airConReqPin); }
+  pinReassign(&pinAirConComp, configPage15.airConCompPin);
+  pinReassign(&pinAirConFan, configPage15.airConFanPin);
+  pinReassign(&pinAirConRequest, configPage15.airConReqPin);
     
   /* Reset control is a special case. If reset control is enabled, it needs its initial state set BEFORE its pinMode.
      If that doesn't happen and reset control is in "Serial Command" mode, the Arduino will end up in a reset loop
      because the control pin will go low as soon as the pinMode is set to OUTPUT. */
-  if ( (configPage4.resetControlConfig != 0) && (configPage4.resetControlPin < BOARD_MAX_IO_PINS) )
+  if ( (configPage4.resetControlConfig != 0) && (configPage4.resetControlPin < BOARD_MAX_IO_PINS) && !pinIsOutput(configPage4.resetControlPin) )
   {
-    if (configPage4.resetControlPin!=0U) {
+    if (configPage4.resetControlPin != 0U) {
       pinResetControl = pinTranslate(configPage4.resetControlPin);
     }
     resetControl = configPage4.resetControlConfig;
@@ -2989,10 +2985,10 @@ void setPinMapping(byte boardID)
   {
     pinMode(pinSDEnable, INPUT);
   }
-  if(configPage10.wmiEnabled > 0)
+  if( (configPage10.wmiEnabled > 0) && (!pinIsOutput(pinWMIEnabled)) )
   {
     pinMode(pinWMIEnabled, OUTPUT);
-    if(configPage10.wmiIndicatorEnabled > 0)
+    if( (configPage10.wmiIndicatorEnabled > 0) && (!pinIsOutput(pinWMIIndicator)) )
     {
       pinMode(pinWMIIndicator, OUTPUT);
       if (configPage10.wmiIndicatorPolarity > 0) { digitalWrite(pinWMIIndicator, HIGH); }
@@ -3004,7 +3000,7 @@ void setPinMapping(byte boardID)
     }
   } 
 
-  if((pinAirConComp>0) && ((configPage15.airConEnable) == 1))
+  if( (pinAirConComp>0) && ((configPage15.airConEnable) == 1) && (!pinIsOutput(pinAirConComp)) )
   {
     pinMode(pinAirConComp, OUTPUT);
   }
@@ -3025,7 +3021,7 @@ void setPinMapping(byte boardID)
     }
   }
 
-  if((pinAirConFan > 0) && ((configPage15.airConEnable) == 1) && ((configPage15.airConFanEnabled) == 1))
+  if( (pinAirConFan > 0) && ((configPage15.airConEnable) == 1) && ((configPage15.airConFanEnabled) == 1) && (!pinIsOutput(pinAirConFan)) )
   {
     pinMode(pinAirConFan, OUTPUT);
   }  

--- a/speeduino/utilities.cpp
+++ b/speeduino/utilities.cpp
@@ -90,6 +90,29 @@ byte pinTranslateAnalog(byte rawPin)
   return outputPin;
 }
 
+/** Check if new pin assignment is valid before changing it.
+* It also check if the pin is protected, when protected change the pin to boad max
+* @param rawPin - Pin function to be reassigned
+* @param pin - Intended pin number
+*/
+bool pinReassign(byte *rawPin, byte pin)
+{
+  bool reassigned = false;
+  if( (pin != 0) && (pin < BOARD_MAX_IO_PINS) && !pinIsOutput(pin) )
+  {
+    *rawPin = pinTranslate(pin);
+    reassigned = true;
+  }
+
+  //On STM32 wrong board layout can lock up the board, check and reassign every forbidden pin use
+  if( pinIsReserved(*rawPin) )
+  {
+    *rawPin = BOARD_MAX_IO_PINS; //Invalid pin, protect against board lock up
+    reassigned = false; //Already the default value but it can be changed on the previous check
+  }
+
+  return reassigned;
+}
 
 void setResetControlPinState(void)
 {

--- a/speeduino/utilities.h
+++ b/speeduino/utilities.h
@@ -33,6 +33,7 @@ extern uint8_t currentRuleStatus;
 void setResetControlPinState(void);
 byte pinTranslate(byte rawPin);
 byte pinTranslateAnalog(byte rawPin);
+bool pinReassign(byte *rawPin, byte pin);
 void initialiseProgrammableIO(void);
 void checkProgrammableIO(void);
 int16_t ProgrammableIOGetData(uint16_t index);


### PR DESCRIPTION
Added check as some functions access the pin via registers and had no check.

Added protection for "board default" pin value as it can lock up STM32 board due to wrong board layout.

Added STM32 CAN pins to the `pinIsReserved` check.

I did many board layout selection tests and pin reassignment tests to STM32 USB pins and everything works.