### PR TITLE
Run unit tests on SimAVR

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,12 +38,14 @@ jobs:
         platformio upgrade
         platformio pkg update
         
+    - name: Install SimAVR
+      run: |
+        sudo apt update
+        sudo apt-get install -y simavr
+        
     - name: Run Unit Tests
-      env:
-        PLATFORMIO_AUTH_TOKEN: ${{ secrets.PLATFORMIO_AUTH_TOKEN }}
       run: | 
-        platformio run -e megaatmega2560
-        platformio remote test --force-remote --environment megaatmega2560
+        platformio test -v -e megaatmega2560_sim_unittest_ubuntu
 
     - name: Discord Notification (Unit Tests Failed)
       uses: rjstone/discord-webhook-notify@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,14 +38,12 @@ jobs:
         platformio upgrade
         platformio pkg update
         
-    - name: Install SimAVR
-      run: |
-        sudo apt update
-        sudo apt-get install -y simavr
-        
     - name: Run Unit Tests
+      env:
+        PLATFORMIO_AUTH_TOKEN: ${{ secrets.PLATFORMIO_AUTH_TOKEN }}
       run: | 
-        platformio test -v -e megaatmega2560_sim_unittest_ubuntu
+        platformio run -e megaatmega2560
+        platformio remote test --force-remote --environment megaatmega2560
 
     - name: Discord Notification (Unit Tests Failed)
       uses: rjstone/discord-webhook-notify@v1

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,41 @@ build_flags = ${env:megaatmega2560.build_flags} -DINJ_CHANNELS=6 -DIGN_CHANNELS=
 extends = env:megaatmega2560
 build_flags = ${env:megaatmega2560.build_flags} -DINJ_CHANNELS=8 -DIGN_CHANNELS=1
 
+[env:megaatmega2560_sim_unittest]
+extends = env:megaatmega2560
+build_src_flags =  ${env:megaatmega2560.build_src_flags} -DSIMULATOR
+
+[env:megaatmega2560_sim_unittest_windows]
+extends = env:megaatmega2560_sim_unittest
+build_type = test
+platform_packages =
+    platformio/tool-simavr
+test_speed = 9600
+upload_protocol = custom
+upload_command =
+test_testing_command =
+    ${platformio.packages_dir}/tool-simavr/bin/simavr
+    -m
+    atmega2560
+    -f
+    16000000L
+    ${platformio.build_dir}/${this.__env__}/firmware.elf
+
+[env:megaatmega2560_sim_unittest_ubuntu]
+; PlatformIO SimAvr package doesn't run in Ubuntu:
+;   error while loading shared libraries: libsimavr.so.1: cannot open shared object file: No such file or directory
+;
+; So instead we manually install SimAVR ('sudo apt-get install -y simavr')
+; and run the unit tests using that instead.
+extends = env:megaatmega2560_sim_unittest_windows
+test_testing_command =
+    simavr
+    -m
+    atmega2560
+    -f
+    16000000L
+    ${platformio.build_dir}/${this.__env__}/firmware.elf
+
 [env:megaatmega2561]
 extends = env:megaatmega2560
 board=ATmega2561

--- a/test/test_decoders/test_decoders.cpp
+++ b/test/test_decoders/test_decoders.cpp
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include <globals.h>
 #include <unity.h>
+#include <avr/sleep.h>
 
 #include "missing_tooth/missing_tooth.h"
 #include "dual_wheel/dual_wheel.h"
@@ -19,7 +20,9 @@ void setup()
 
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
+#if !defined(SIMULATOR)
     delay(2000);
+#endif
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
@@ -34,6 +37,12 @@ void setup()
     testDecoder_General();
 
     UNITY_END(); // stop unit testing
+
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif    
 }
 
 void loop()

--- a/test/test_fuel/test_fuel.cpp
+++ b/test/test_fuel/test_fuel.cpp
@@ -2,6 +2,7 @@
 #include <init.h>
 #include <Arduino.h>
 #include <unity.h>
+#include <avr/sleep.h>
 
 #include "test_corrections.h"
 #include "test_PW.h"
@@ -15,7 +16,9 @@ void setup()
 
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
+#if !defined(SIMULATOR)
     delay(2000);
+#endif
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
@@ -24,6 +27,12 @@ void setup()
     testStaging();
 
     UNITY_END(); // stop unit testing
+
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif 
 }
 
 void loop()

--- a/test/test_ign/main.cpp
+++ b/test/test_ign/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <unity.h>
+#include <avr/sleep.h>
 
 void testIgnCorrections(void);
 
@@ -11,13 +12,21 @@ void setup()
 
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
+#if !defined(SIMULATOR)
     delay(2000);
+#endif
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
     testIgnCorrections();
 
     UNITY_END(); // stop unit testing
+
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif     
 }
 
 void loop()

--- a/test/test_init/main.cpp
+++ b/test/test_init/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <unity.h>
+#include <avr/sleep.h>
 #include "storage.h"
 #include "globals.h"
 
@@ -35,7 +36,9 @@ void setup()
 
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
+#if !defined(SIMULATOR)
     delay(2000);
+#endif
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
@@ -44,6 +47,12 @@ void setup()
     testInitialisation();
 
     UNITY_END(); // stop unit testing
+
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif     
 }
 
 void loop()

--- a/test/test_math/main.cpp
+++ b/test/test_math/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <unity.h>
+#include <avr/sleep.h>
 #include "tests_crankmaths.h"
 
 extern void testPercent(void);
@@ -15,7 +16,9 @@ void setup()
 
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
+#if !defined(SIMULATOR)
     delay(2000);
+#endif
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
@@ -26,6 +29,12 @@ void setup()
     test_LOW_PASS_FILTER();
 
     UNITY_END(); // stop unit testing
+
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif     
 }
 
 void loop()

--- a/test/test_schedule_calcs/test_schedule_calcs.cpp
+++ b/test/test_schedule_calcs/test_schedule_calcs.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include <unity.h>
 #include <init.h>
+#include <avr/sleep.h>
 
 extern void test_calc_ign_timeout();
 extern void test_calc_inj_timeout();
@@ -9,7 +10,9 @@ extern void test_adjust_crank_angle();
 void setup()
 {
   pinMode(LED_BUILTIN, OUTPUT);
-  delay(2000);
+#if !defined(SIMULATOR)
+    delay(2000);
+#endif
 
   UNITY_BEGIN(); // start unit testing
 
@@ -19,6 +22,11 @@ void setup()
   
   UNITY_END(); // stop unit testing
 
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif     
 }
 
 void loop()

--- a/test/test_schedules/test_schedules.cpp
+++ b/test/test_schedules/test_schedules.cpp
@@ -1,13 +1,16 @@
 #include <Arduino.h>
 #include <unity.h>
 #include <init.h>
+#include <avr/sleep.h>
 
 #include "test_schedules.h"
 
 void setup()
 {
   pinMode(LED_BUILTIN, OUTPUT);
-  delay(2000);
+#if !defined(SIMULATOR)
+    delay(2000);
+#endif
 
   UNITY_BEGIN(); // start unit testing
 
@@ -22,6 +25,11 @@ void setup()
   
   UNITY_END(); // stop unit testing
 
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif   
 }
 
 void loop()

--- a/test/test_sensors/main.cpp
+++ b/test/test_sensors/main.cpp
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #include <unity.h>
-
+#include <avr/sleep.h>
 
 #define UNITY_EXCLUDE_DETAILS
 
@@ -13,7 +13,9 @@ void setup()
 
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
+#if !defined(SIMULATOR)
     delay(2000);
+#endif
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
@@ -21,6 +23,12 @@ void setup()
     test_map_sampling();
     
     UNITY_END(); // stop unit testing
+
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif   
 }
 
 void loop()

--- a/test/test_tables/main.cpp
+++ b/test/test_tables/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <unity.h>
+#include <avr/sleep.h>
 
 #include "tests_tables.h"
 #include "test_table2d.h"
@@ -12,7 +13,9 @@ void setup()
 
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
+#if !defined(SIMULATOR)
     delay(2000);
+#endif
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
@@ -20,6 +23,12 @@ void setup()
     testTable2d();
 
     UNITY_END(); // stop unit testing
+
+#if defined(SIMULATOR)       // Tell SimAVR we are done
+    cli();
+    sleep_enable();
+    sleep_cpu();
+#endif  
 }
 
 void loop()


### PR DESCRIPTION
This PR allows the unit tests to be run under SimAVR.

1. Anyone can run the unit test suite - no need for hardware :grin:
2. No need for remote board access in the CI build (PR includes modified GitHub action)

Some minor caveats:

- Because of [this bug](https://github.com/platformio/platformio-core/issues/4985) we need a separate environment for Ubuntu
    - `pio test -v -e megaatmega2560_sim_unittest_windows`
    - `pio test -v -e megaatmega2560_sim_unittest_ubuntu` 
        - And developer needs to install SimAVR manually: `sudo apt-get install -y simavr`
- Because of [this bug](https://github.com/buserror/simavr/issues/489), output is slow to appear on Windows (but is acceptable IMO).