### PR TITLE
Reduce table2d memory size (130 bytes)

### DIFF
--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -9,6 +9,7 @@ A full copy of the license may be found in the projects root directory
 #include "src/PID_v1/PID_v1.h"
 #include "decoders.h"
 #include "timers.h"
+#include "utilities.h"
 
 static long vvt1_pwm_value;
 static long vvt2_pwm_value;
@@ -53,6 +54,7 @@ uint16_t fan_pwm_max_count; //Used for variable PWM frequency
 volatile unsigned int fan_pwm_cur_value;
 long fan_pwm_value;
 #endif
+static constexpr table2D fanPWMTable(_countof(configPage9.PWMFanDuty), configPage9.PWMFanDuty, configPage6.fanPWMBins);
 
 bool acIsEnabled;
 bool acStandAloneFanIsEnabled;
@@ -71,6 +73,7 @@ bool vvtIsHot;
 bool vvtTimeHold;
 uint16_t vvt_pwm_max_count; //Used for variable PWM frequency
 uint16_t boost_pwm_max_count; //Used for variable PWM frequency
+static constexpr table2D flexBoostTable(_countof(configPage10.flexBoostAdj), configPage10.flexBoostAdj, configPage10.flexBoostBins);
 
 //Old PID method. Retained in case the new one has issues
 //integerPID boostPID(&MAPx100, &boost_pwm_target_value, &boostTargetx100, configPage6.boostKP, configPage6.boostKI, configPage6.boostKD, DIRECT);

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -1200,7 +1200,6 @@ void receiveCalibration(byte tableID)
       break;
     case 2:
       //O2 table
-      //pnt_TargetTable = (byte *)&o2CalibrationTable;
       pnt_TargetTable_values = (uint8_t *)&o2Calibration_values;
       pnt_TargetTable_bins = (uint16_t *)&o2Calibration_bins;
       OFFSET = 0;

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -29,6 +29,8 @@ There are 2 top level functions that call more detailed corrections for Fuel and
 #include "timers.h"
 #include "maths.h"
 #include "sensors.h"
+#include "unit_testing.h"
+#include "utilities.h"
 #include "src/PID_v1/PID_v1.h"
 
 long PID_O2, PID_output, PID_AFRTarget;
@@ -52,6 +54,25 @@ uint8_t dfcoDelay;
 uint8_t idleAdvTaper;
 uint8_t crankingEnrichTaper;
 uint8_t dfcoTaper;
+
+TESTABLE_CONSTEXPR table2D taeTable(_countof(configPage4.taeValues), configPage4.taeValues, configPage4.taeBins);
+TESTABLE_CONSTEXPR table2D maeTable(_countof(configPage4.maeRates), configPage4.maeRates, configPage4.maeBins);
+TESTABLE_CONSTEXPR table2D WUETable(_countof(configPage2.wueValues), configPage2.wueValues, configPage4.wueBins);
+TESTABLE_CONSTEXPR table2D ASETable(_countof(configPage2.asePct), configPage2.asePct, configPage2.aseBins);
+TESTABLE_CONSTEXPR table2D ASECountTable(_countof(configPage2.aseCount), configPage2.aseCount, configPage2.aseBins);
+TESTABLE_CONSTEXPR table2D crankingEnrichTable(_countof(configPage10.crankingEnrichValues), configPage10.crankingEnrichValues, configPage10.crankingEnrichBins);
+TESTABLE_CONSTEXPR table2D dwellVCorrectionTable(_countof(configPage4.dwellCorrectionValues), configPage4.dwellCorrectionValues, configPage6.voltageCorrectionBins);
+TESTABLE_CONSTEXPR table2D injectorVCorrectionTable(_countof(configPage6.injVoltageCorrectionValues), configPage6.injVoltageCorrectionValues, configPage6.voltageCorrectionBins);
+TESTABLE_CONSTEXPR table2D IATDensityCorrectionTable(_countof(configPage6.airDenRates), configPage6.airDenRates, configPage6.airDenBins);
+TESTABLE_CONSTEXPR table2D baroFuelTable(_countof(configPage4.baroFuelValues), configPage4.baroFuelValues, configPage4.baroFuelBins);
+TESTABLE_CONSTEXPR table2D IATRetardTable(_countof(configPage4.iatRetValues), configPage4.iatRetValues, configPage4.iatRetBins);
+TESTABLE_CONSTEXPR table2D idleAdvanceTable(_countof(configPage4.idleAdvValues), configPage4.idleAdvValues, configPage4.idleAdvBins);
+TESTABLE_CONSTEXPR table2D CLTAdvanceTable(_countof(configPage4.cltAdvValues), configPage4.cltAdvValues, configPage4.cltAdvBins);
+TESTABLE_CONSTEXPR table2D flexFuelTable(_countof(configPage10.flexFuelAdj), configPage10.flexFuelAdj, configPage10.flexFuelBins);
+TESTABLE_CONSTEXPR table2D flexAdvTable(_countof(configPage10.flexAdvAdj), configPage10.flexAdvAdj, configPage10.flexAdvBins);
+TESTABLE_CONSTEXPR table2D flexBoostTable(_countof(configPage10.flexBoostAdj), configPage10.flexBoostAdj, configPage10.flexBoostBins);
+TESTABLE_CONSTEXPR table2D fuelTempTable(_countof(configPage10.fuelTempValues), configPage10.fuelTempValues, configPage10.fuelTempBins);
+TESTABLE_CONSTEXPR table2D wmiAdvTable(_countof(configPage10.wmiAdvAdj), configPage10.wmiAdvAdj, configPage10.wmiAdvBins);
 
 /** Initialise instances and vars related to corrections (at ECU boot-up).
  */

--- a/speeduino/engineProtection.cpp
+++ b/speeduino/engineProtection.cpp
@@ -2,8 +2,11 @@
 #include "globals.h"
 #include "engineProtection.h"
 #include "maths.h"
+#include "utilities.h"
 
 byte oilProtStartTime = 0;
+static constexpr table2D oilPressureProtectTable(_countof(configPage10.oilPressureProtMins), configPage10.oilPressureProtMins, configPage10.oilPressureProtRPM);
+static constexpr table2D coolantProtectTable(_countof(configPage9.coolantProtRPM), configPage9.coolantProtRPM, configPage9.coolantProtTemp);
 
 byte checkEngineProtect(void)
 {

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -2,6 +2,7 @@
  * Instantiation of various (table2D, table3D) tables, volatile (interrupt modified) variables, Injector (1...8) enablement flags, etc.
  */
 #include "globals.h"
+#include "utilities.h"
 
 struct table3d16RpmLoad fuelTable; ///< 16x16 fuel map
 struct table3d16RpmLoad fuelTable2; ///< 16x16 fuel map
@@ -23,34 +24,34 @@ trimTable3d trim6Table; ///< 6x6 Fuel trim 6 map
 trimTable3d trim7Table; ///< 6x6 Fuel trim 7 map
 trimTable3d trim8Table; ///< 6x6 Fuel trim 8 map
 struct table3d4RpmLoad dwellTable; ///< 4x4 Dwell map
-struct table2D taeTable; ///< 4 bin TPS Acceleration Enrichment map (2D)
-struct table2D maeTable;
-struct table2D WUETable; ///< 10 bin Warm Up Enrichment map (2D)
-struct table2D ASETable; ///< 4 bin After Start Enrichment map (2D)
-struct table2D ASECountTable; ///< 4 bin After Start duration map (2D)
-struct table2D PrimingPulseTable; ///< 4 bin Priming pulsewidth map (2D)
-struct table2D crankingEnrichTable; ///< 4 bin cranking Enrichment map (2D)
-struct table2D dwellVCorrectionTable; ///< 6 bin dwell voltage correction (2D)
-struct table2D injectorVCorrectionTable; ///< 6 bin injector voltage correction (2D)
-struct table2D injectorAngleTable; ///< 4 bin injector angle curve (2D)
-struct table2D IATDensityCorrectionTable; ///< 9 bin inlet air temperature density correction (2D)
-struct table2D baroFuelTable; ///< 8 bin baro correction curve (2D)
-struct table2D IATRetardTable; ///< 6 bin ignition adjustment based on inlet air temperature  (2D)
-struct table2D idleTargetTable; ///< 10 bin idle target table for idle timing (2D)
-struct table2D idleAdvanceTable; ///< 6 bin idle advance adjustment table based on RPM difference  (2D)
-struct table2D CLTAdvanceTable; ///< 6 bin ignition adjustment based on coolant temperature  (2D)
-struct table2D rotarySplitTable; ///< 8 bin ignition split curve for rotary leading/trailing  (2D)
-struct table2D flexFuelTable;  ///< 6 bin flex fuel correction table for fuel adjustments (2D)
-struct table2D flexAdvTable;   ///< 6 bin flex fuel correction table for timing advance (2D)
-struct table2D flexBoostTable; ///< 6 bin flex fuel correction table for boost adjustments (2D)
-struct table2D fuelTempTable;  ///< 6 bin flex fuel correction table for fuel adjustments (2D)
-struct table2D knockWindowStartTable;
-struct table2D knockWindowDurationTable;
-struct table2D oilPressureProtectTable;
-struct table2D wmiAdvTable; //6 bin wmi correction table for timing advance (2D)
-struct table2D coolantProtectTable;
-struct table2D fanPWMTable;
-struct table2D rollingCutTable;
+struct table2D taeTable(_countof(configPage4.taeValues), configPage4.taeValues, configPage4.taeBins);
+struct table2D maeTable(_countof(configPage4.maeRates), configPage4.maeRates, configPage4.maeBins);
+struct table2D WUETable(_countof(configPage2.wueValues), configPage2.wueValues, configPage4.wueBins);
+struct table2D ASETable(_countof(configPage2.asePct), configPage2.asePct, configPage2.aseBins);
+struct table2D ASECountTable(_countof(configPage2.aseCount), configPage2.aseCount, configPage2.aseBins);
+struct table2D PrimingPulseTable(_countof(configPage2.primePulse), configPage2.primePulse, configPage2.primeBins);
+struct table2D crankingEnrichTable(_countof(configPage10.crankingEnrichValues), configPage10.crankingEnrichValues, configPage10.crankingEnrichBins);
+struct table2D dwellVCorrectionTable(_countof(configPage4.dwellCorrectionValues), configPage4.dwellCorrectionValues, configPage6.voltageCorrectionBins);
+struct table2D injectorVCorrectionTable(_countof(configPage6.injVoltageCorrectionValues), configPage6.injVoltageCorrectionValues, configPage6.voltageCorrectionBins);
+struct table2D injectorAngleTable(_countof(configPage2.injAng), configPage2.injAng, configPage2.injAngRPM);
+struct table2D IATDensityCorrectionTable(_countof(configPage6.airDenRates), configPage6.airDenRates, configPage6.airDenBins);
+struct table2D baroFuelTable(_countof(configPage4.baroFuelValues), configPage4.baroFuelValues, configPage4.baroFuelBins);
+struct table2D IATRetardTable(_countof(configPage4.iatRetValues), configPage4.iatRetValues, configPage4.iatRetBins);
+struct table2D idleTargetTable(_countof(configPage6.iacCLValues), configPage6.iacCLValues, configPage6.iacBins);
+struct table2D idleAdvanceTable(_countof(configPage4.idleAdvValues), configPage4.idleAdvValues, configPage4.idleAdvBins);
+struct table2D CLTAdvanceTable(_countof(configPage4.cltAdvValues), configPage4.cltAdvValues, configPage4.cltAdvBins);
+struct table2D rotarySplitTable(_countof(configPage10.rotarySplitValues), configPage10.rotarySplitValues, configPage10.rotarySplitBins);
+struct table2D flexFuelTable(_countof(configPage10.flexFuelAdj), configPage10.flexFuelAdj, configPage10.flexFuelBins);
+struct table2D flexAdvTable(_countof(configPage10.flexAdvAdj), configPage10.flexAdvAdj, configPage10.flexAdvBins);
+struct table2D flexBoostTable(_countof(configPage10.flexBoostAdj), configPage10.flexBoostAdj, configPage10.flexBoostBins);
+struct table2D fuelTempTable(_countof(configPage10.fuelTempValues), configPage10.fuelTempValues, configPage10.fuelTempBins);
+struct table2D knockWindowStartTable(_countof(configPage10.knock_window_angle), configPage10.knock_window_angle, configPage10.knock_window_rpms);
+struct table2D knockWindowDurationTable(_countof(configPage10.knock_window_dur), configPage10.knock_window_dur, configPage10.knock_window_rpms);
+struct table2D oilPressureProtectTable(_countof(configPage10.oilPressureProtMins), configPage10.oilPressureProtMins, configPage10.oilPressureProtRPM);
+struct table2D wmiAdvTable(_countof(configPage10.wmiAdvAdj), configPage10.wmiAdvAdj, configPage10.wmiAdvBins);
+struct table2D coolantProtectTable(_countof(configPage9.coolantProtRPM), configPage9.coolantProtRPM, configPage9.coolantProtTemp);
+struct table2D fanPWMTable(_countof(configPage9.PWMFanDuty), configPage9.PWMFanDuty, configPage6.fanPWMBins);
+struct table2D rollingCutTable(_countof(configPage15.rollingProtCutPercent), configPage15.rollingProtCutPercent, configPage15.rollingProtRPMDelta);
 
 /// volatile inj*_pin_port and  inj*_pin_mask vars are for the direct port manipulation of the injectors, coils and aux outputs.
 volatile PORT_TYPE *inj1_pin_port;
@@ -238,19 +239,15 @@ struct config10 configPage10;
 struct config13 configPage13;
 struct config15 configPage15;
 
-//byte cltCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the coolant sensor calibration values */
-//byte iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
-//byte o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
-
 uint16_t cltCalibration_bins[32];
 uint16_t cltCalibration_values[32];
-struct table2D cltCalibrationTable;
+struct table2D cltCalibrationTable(_countof(cltCalibration_values), cltCalibration_values, cltCalibration_bins);
 uint16_t iatCalibration_bins[32];
 uint16_t iatCalibration_values[32];
-struct table2D iatCalibrationTable;
+struct table2D iatCalibrationTable(_countof(iatCalibration_values), iatCalibration_values, iatCalibration_bins);
 uint16_t o2Calibration_bins[32];
 uint8_t o2Calibration_values[32];
-struct table2D o2CalibrationTable; 
+struct table2D o2CalibrationTable(_countof(o2Calibration_values), o2Calibration_values, o2Calibration_bins); 
 
 //These function do checks on a pin to determine if it is already in use by another (higher importance) active function
 bool pinIsOutput(byte pin)

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -45,8 +45,6 @@ struct table2D flexFuelTable(_countof(configPage10.flexFuelAdj), configPage10.fl
 struct table2D flexAdvTable(_countof(configPage10.flexAdvAdj), configPage10.flexAdvAdj, configPage10.flexAdvBins);
 struct table2D flexBoostTable(_countof(configPage10.flexBoostAdj), configPage10.flexBoostAdj, configPage10.flexBoostBins);
 struct table2D fuelTempTable(_countof(configPage10.fuelTempValues), configPage10.fuelTempValues, configPage10.fuelTempBins);
-struct table2D knockWindowStartTable(_countof(configPage10.knock_window_angle), configPage10.knock_window_angle, configPage10.knock_window_rpms);
-struct table2D knockWindowDurationTable(_countof(configPage10.knock_window_dur), configPage10.knock_window_dur, configPage10.knock_window_rpms);
 struct table2D oilPressureProtectTable(_countof(configPage10.oilPressureProtMins), configPage10.oilPressureProtMins, configPage10.oilPressureProtRPM);
 struct table2D wmiAdvTable(_countof(configPage10.wmiAdvAdj), configPage10.wmiAdvAdj, configPage10.wmiAdvBins);
 struct table2D coolantProtectTable(_countof(configPage9.coolantProtRPM), configPage9.coolantProtRPM, configPage9.coolantProtTemp);

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -24,32 +24,7 @@ trimTable3d trim6Table; ///< 6x6 Fuel trim 6 map
 trimTable3d trim7Table; ///< 6x6 Fuel trim 7 map
 trimTable3d trim8Table; ///< 6x6 Fuel trim 8 map
 struct table3d4RpmLoad dwellTable; ///< 4x4 Dwell map
-struct table2D taeTable(_countof(configPage4.taeValues), configPage4.taeValues, configPage4.taeBins);
-struct table2D maeTable(_countof(configPage4.maeRates), configPage4.maeRates, configPage4.maeBins);
-struct table2D WUETable(_countof(configPage2.wueValues), configPage2.wueValues, configPage4.wueBins);
-struct table2D ASETable(_countof(configPage2.asePct), configPage2.asePct, configPage2.aseBins);
-struct table2D ASECountTable(_countof(configPage2.aseCount), configPage2.aseCount, configPage2.aseBins);
-struct table2D PrimingPulseTable(_countof(configPage2.primePulse), configPage2.primePulse, configPage2.primeBins);
-struct table2D crankingEnrichTable(_countof(configPage10.crankingEnrichValues), configPage10.crankingEnrichValues, configPage10.crankingEnrichBins);
-struct table2D dwellVCorrectionTable(_countof(configPage4.dwellCorrectionValues), configPage4.dwellCorrectionValues, configPage6.voltageCorrectionBins);
-struct table2D injectorVCorrectionTable(_countof(configPage6.injVoltageCorrectionValues), configPage6.injVoltageCorrectionValues, configPage6.voltageCorrectionBins);
-struct table2D injectorAngleTable(_countof(configPage2.injAng), configPage2.injAng, configPage2.injAngRPM);
-struct table2D IATDensityCorrectionTable(_countof(configPage6.airDenRates), configPage6.airDenRates, configPage6.airDenBins);
-struct table2D baroFuelTable(_countof(configPage4.baroFuelValues), configPage4.baroFuelValues, configPage4.baroFuelBins);
-struct table2D IATRetardTable(_countof(configPage4.iatRetValues), configPage4.iatRetValues, configPage4.iatRetBins);
-struct table2D idleTargetTable(_countof(configPage6.iacCLValues), configPage6.iacCLValues, configPage6.iacBins);
-struct table2D idleAdvanceTable(_countof(configPage4.idleAdvValues), configPage4.idleAdvValues, configPage4.idleAdvBins);
-struct table2D CLTAdvanceTable(_countof(configPage4.cltAdvValues), configPage4.cltAdvValues, configPage4.cltAdvBins);
-struct table2D rotarySplitTable(_countof(configPage10.rotarySplitValues), configPage10.rotarySplitValues, configPage10.rotarySplitBins);
-struct table2D flexFuelTable(_countof(configPage10.flexFuelAdj), configPage10.flexFuelAdj, configPage10.flexFuelBins);
-struct table2D flexAdvTable(_countof(configPage10.flexAdvAdj), configPage10.flexAdvAdj, configPage10.flexAdvBins);
-struct table2D flexBoostTable(_countof(configPage10.flexBoostAdj), configPage10.flexBoostAdj, configPage10.flexBoostBins);
-struct table2D fuelTempTable(_countof(configPage10.fuelTempValues), configPage10.fuelTempValues, configPage10.fuelTempBins);
-struct table2D oilPressureProtectTable(_countof(configPage10.oilPressureProtMins), configPage10.oilPressureProtMins, configPage10.oilPressureProtRPM);
-struct table2D wmiAdvTable(_countof(configPage10.wmiAdvAdj), configPage10.wmiAdvAdj, configPage10.wmiAdvBins);
-struct table2D coolantProtectTable(_countof(configPage9.coolantProtRPM), configPage9.coolantProtRPM, configPage9.coolantProtTemp);
-struct table2D fanPWMTable(_countof(configPage9.PWMFanDuty), configPage9.PWMFanDuty, configPage6.fanPWMBins);
-struct table2D rollingCutTable(_countof(configPage15.rollingProtCutPercent), configPage15.rollingProtCutPercent, configPage15.rollingProtRPMDelta);
+
 
 /// volatile inj*_pin_port and  inj*_pin_mask vars are for the direct port manipulation of the injectors, coils and aux outputs.
 volatile PORT_TYPE *inj1_pin_port;
@@ -239,13 +214,10 @@ struct config15 configPage15;
 
 uint16_t cltCalibration_bins[32];
 uint16_t cltCalibration_values[32];
-struct table2D cltCalibrationTable(_countof(cltCalibration_values), cltCalibration_values, cltCalibration_bins);
 uint16_t iatCalibration_bins[32];
 uint16_t iatCalibration_values[32];
-struct table2D iatCalibrationTable(_countof(iatCalibration_values), iatCalibration_values, iatCalibration_bins);
 uint16_t o2Calibration_bins[32];
 uint8_t o2Calibration_values[32];
-struct table2D o2CalibrationTable(_countof(o2Calibration_values), o2Calibration_values, o2Calibration_bins); 
 
 //These function do checks on a pin to determine if it is already in use by another (higher importance) active function
 bool pinIsOutput(byte pin)

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -240,8 +240,6 @@ extern struct table2D flexFuelTable;  //6 bin flex fuel correction table for fue
 extern struct table2D flexAdvTable;   //6 bin flex fuel correction table for timing advance (2D)
 extern struct table2D flexBoostTable; //6 bin flex fuel correction table for boost adjustments (2D)
 extern struct table2D fuelTempTable;  //6 bin fuel temperature correction table for fuel adjustments (2D)
-extern struct table2D knockWindowStartTable;
-extern struct table2D knockWindowDurationTable;
 extern struct table2D oilPressureProtectTable;
 extern struct table2D wmiAdvTable; //6 bin wmi correction table for timing advance (2D)
 extern struct table2D coolantProtectTable; //6 bin coolant temperature protection table for engine protection (2D)

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -219,32 +219,6 @@ extern trimTable3d trim7Table; //6x6 Fuel trim 7 map
 extern trimTable3d trim8Table; //6x6 Fuel trim 8 map
 
 extern struct table3d4RpmLoad dwellTable; //4x4 Dwell map
-extern struct table2D taeTable; //4 bin TPS Acceleration Enrichment map (2D)
-extern struct table2D maeTable;
-extern struct table2D WUETable; //10 bin Warm Up Enrichment map (2D)
-extern struct table2D ASETable; //4 bin After Start Enrichment map (2D)
-extern struct table2D ASECountTable; //4 bin After Start duration map (2D)
-extern struct table2D PrimingPulseTable; //4 bin Priming pulsewidth map (2D)
-extern struct table2D crankingEnrichTable; //4 bin cranking Enrichment map (2D)
-extern struct table2D dwellVCorrectionTable; //6 bin dwell voltage correction (2D)
-extern struct table2D injectorVCorrectionTable; //6 bin injector voltage correction (2D)
-extern struct table2D injectorAngleTable; //4 bin injector timing curve (2D)
-extern struct table2D IATDensityCorrectionTable; //9 bin inlet air temperature density correction (2D)
-extern struct table2D baroFuelTable; //8 bin baro correction curve (2D)
-extern struct table2D IATRetardTable; //6 bin ignition adjustment based on inlet air temperature  (2D)
-extern struct table2D idleTargetTable; //10 bin idle target table for idle timing (2D)
-extern struct table2D idleAdvanceTable; //6 bin idle advance adjustment table based on RPM difference  (2D)
-extern struct table2D CLTAdvanceTable; //6 bin ignition adjustment based on coolant temperature  (2D)
-extern struct table2D rotarySplitTable; //8 bin ignition split curve for rotary leading/trailing  (2D)
-extern struct table2D flexFuelTable;  //6 bin flex fuel correction table for fuel adjustments (2D)
-extern struct table2D flexAdvTable;   //6 bin flex fuel correction table for timing advance (2D)
-extern struct table2D flexBoostTable; //6 bin flex fuel correction table for boost adjustments (2D)
-extern struct table2D fuelTempTable;  //6 bin fuel temperature correction table for fuel adjustments (2D)
-extern struct table2D oilPressureProtectTable;
-extern struct table2D wmiAdvTable; //6 bin wmi correction table for timing advance (2D)
-extern struct table2D coolantProtectTable; //6 bin coolant temperature protection table for engine protection (2D)
-extern struct table2D fanPWMTable;
-extern struct table2D rollingCutTable;
 
 //These are for the direct port manipulation of the injectors, coils and aux outputs
 extern volatile PORT_TYPE *inj1_pin_port;
@@ -433,9 +407,6 @@ extern struct config9 configPage9;
 extern struct config10 configPage10;
 extern struct config13 configPage13;
 extern struct config15 configPage15;
-//extern byte cltCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the coolant sensor calibration values */
-//extern byte iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
-//extern byte o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
 
 extern uint16_t cltCalibration_bins[32];
 extern uint16_t cltCalibration_values[32];
@@ -443,9 +414,6 @@ extern uint16_t iatCalibration_bins[32];
 extern uint16_t iatCalibration_values[32];
 extern uint16_t o2Calibration_bins[32];
 extern uint8_t  o2Calibration_values[32]; // Note 8-bit values
-extern struct table2D cltCalibrationTable; /**< A 32 bin array containing the coolant temperature sensor calibration values */
-extern struct table2D iatCalibrationTable; /**< A 32 bin array containing the inlet air temperature sensor calibration values */
-extern struct table2D o2CalibrationTable; /**< A 32 bin array containing the O2 sensor calibration values */
 
 bool pinIsOutput(byte pin);
 bool pinIsUsed(byte pin);

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -40,11 +40,11 @@ volatile PINMASK_TYPE idle2_pin_mask;
 volatile PORT_TYPE *idleUpOutput_pin_port;
 volatile PINMASK_TYPE idleUpOutput_pin_mask;
 
-static struct table2D iacPWMTable(_countof(configPage6.iacOLPWMVal), configPage6.iacOLPWMVal, configPage6.iacBins);
-static struct table2D iacStepTable(_countof(configPage6.iacOLStepVal), configPage6.iacOLStepVal, configPage6.iacBins);
+static constexpr table2D iacPWMTable(_countof(configPage6.iacOLPWMVal), configPage6.iacOLPWMVal, configPage6.iacBins);
+static constexpr table2D iacStepTable(_countof(configPage6.iacOLStepVal), configPage6.iacOLStepVal, configPage6.iacBins);
 //Open loop tables specifically for cranking
-static struct table2D iacCrankStepsTable(_countof(configPage6.iacCrankSteps), configPage6.iacCrankSteps, configPage6.iacCrankBins);
-static struct table2D iacCrankDutyTable(_countof(configPage6.iacCrankDuty), configPage6.iacCrankDuty, configPage6.iacCrankBins);
+static constexpr table2D iacCrankStepsTable(_countof(configPage6.iacCrankSteps), configPage6.iacCrankSteps, configPage6.iacCrankBins);
+static constexpr table2D iacCrankDutyTable(_countof(configPage6.iacCrankDuty), configPage6.iacCrankDuty, configPage6.iacCrankBins);
 
 /*
 These functions cover the PWM and stepper idle control

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -98,18 +98,8 @@ void initialiseIdle(bool forcehoming)
 
     case IAC_ALGORITHM_PWM_OL:
       //Case 2 is PWM open loop
-      iacPWMTable.xSize = 10;
-      iacPWMTable.valueSize = SIZE_BYTE;
-      iacPWMTable.axisSize = SIZE_BYTE;
-      iacPWMTable.values = configPage6.iacOLPWMVal;
-      iacPWMTable.axisX = configPage6.iacBins;
-
-
-      iacCrankDutyTable.xSize = 4;
-      iacCrankDutyTable.valueSize = SIZE_BYTE;
-      iacCrankDutyTable.axisSize = SIZE_BYTE;
-      iacCrankDutyTable.values = configPage6.iacCrankDuty;
-      iacCrankDutyTable.axisX = configPage6.iacCrankBins;
+      construct2dTable(iacPWMTable, configPage6.iacOLPWMVal, configPage6.iacBins);
+      construct2dTable(iacCrankDutyTable, configPage6.iacCrankDuty, configPage6.iacCrankBins);
 
       #if defined(CORE_AVR)
         idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
@@ -123,17 +113,8 @@ void initialiseIdle(bool forcehoming)
 
     case IAC_ALGORITHM_PWM_OLCL:
       //Case 6 is PWM closed loop with open loop table used as feed forward
-      iacPWMTable.xSize = 10;
-      iacPWMTable.valueSize = SIZE_BYTE;
-      iacPWMTable.axisSize = SIZE_BYTE;
-      iacPWMTable.values = configPage6.iacOLPWMVal;
-      iacPWMTable.axisX = configPage6.iacBins;
-
-      iacCrankDutyTable.xSize = 4;
-      iacCrankDutyTable.valueSize = SIZE_BYTE;
-      iacCrankDutyTable.axisSize = SIZE_BYTE;
-      iacCrankDutyTable.values = configPage6.iacCrankDuty;
-      iacCrankDutyTable.axisX = configPage6.iacCrankBins;
+      construct2dTable(iacPWMTable, configPage6.iacOLPWMVal, configPage6.iacBins);
+      construct2dTable(iacCrankDutyTable, configPage6.iacCrankDuty, configPage6.iacCrankBins);
 
       #if defined(CORE_AVR)
         idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
@@ -153,11 +134,7 @@ void initialiseIdle(bool forcehoming)
 
     case IAC_ALGORITHM_PWM_CL:
       //Case 3 is PWM closed loop
-      iacCrankDutyTable.xSize = 4;
-      iacCrankDutyTable.valueSize = SIZE_BYTE;
-      iacCrankDutyTable.axisSize = SIZE_BYTE;
-      iacCrankDutyTable.values = configPage6.iacCrankDuty;
-      iacCrankDutyTable.axisX = configPage6.iacCrankBins;
+      construct2dTable(iacCrankDutyTable, configPage6.iacCrankDuty, configPage6.iacCrankBins);
 
       #if defined(CORE_AVR)
         idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
@@ -177,17 +154,9 @@ void initialiseIdle(bool forcehoming)
 
     case IAC_ALGORITHM_STEP_OL:
       //Case 2 is Stepper open loop
-      iacStepTable.xSize = 10;
-      iacStepTable.valueSize = SIZE_BYTE;
-      iacStepTable.axisSize = SIZE_BYTE;
-      iacStepTable.values = configPage6.iacOLStepVal;
-      iacStepTable.axisX = configPage6.iacBins;
+      construct2dTable(iacStepTable, configPage6.iacOLStepVal, configPage6.iacBins);
+      construct2dTable(iacCrankStepsTable, configPage6.iacCrankSteps, configPage6.iacCrankBins);
 
-      iacCrankStepsTable.xSize = 4;
-      iacCrankStepsTable.valueSize = SIZE_BYTE;
-      iacCrankStepsTable.axisSize = SIZE_BYTE;
-      iacCrankStepsTable.values = configPage6.iacCrankSteps;
-      iacCrankStepsTable.axisX = configPage6.iacCrankBins;
       iacStepTime_uS = configPage6.iacStepTime * 1000;
       iacCoolTime_uS = configPage9.iacCoolTime * 1000;
 
@@ -204,11 +173,8 @@ void initialiseIdle(bool forcehoming)
 
     case IAC_ALGORITHM_STEP_CL:
       //Case 5 is Stepper closed loop
-      iacCrankStepsTable.xSize = 4;
-      iacCrankStepsTable.valueSize = SIZE_BYTE;
-      iacCrankStepsTable.axisSize = SIZE_BYTE;
-      iacCrankStepsTable.values = configPage6.iacCrankSteps;
-      iacCrankStepsTable.axisX = configPage6.iacCrankBins;
+		  construct2dTable(iacCrankStepsTable, configPage6.iacCrankSteps, configPage6.iacCrankBins);
+
       iacStepTime_uS = configPage6.iacStepTime * 1000;
       iacCoolTime_uS = configPage9.iacCoolTime * 1000;
 
@@ -231,17 +197,9 @@ void initialiseIdle(bool forcehoming)
 
     case IAC_ALGORITHM_STEP_OLCL:
       //Case 7 is Stepper closed loop with open loop table used as feed forward
-      iacStepTable.xSize = 10;
-      iacStepTable.valueSize = SIZE_BYTE;
-      iacStepTable.axisSize = SIZE_BYTE;
-      iacStepTable.values = configPage6.iacOLStepVal;
-      iacStepTable.axisX = configPage6.iacBins;
+  		construct2dTable(iacStepTable, configPage6.iacOLStepVal, configPage6.iacBins);
+	  	construct2dTable(iacCrankStepsTable, configPage6.iacCrankSteps, configPage6.iacCrankBins);
 
-      iacCrankStepsTable.xSize = 4;
-      iacCrankStepsTable.valueSize = SIZE_BYTE;
-      iacCrankStepsTable.axisSize = SIZE_BYTE;
-      iacCrankStepsTable.values = configPage6.iacCrankSteps;
-      iacCrankStepsTable.axisX = configPage6.iacCrankBins;
       iacStepTime_uS = configPage6.iacStepTime * 1000;
       iacCoolTime_uS = configPage9.iacCoolTime * 1000;
 

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -2,7 +2,6 @@
 #define IDLE_H
 
 #include "globals.h"
-#include "table2d.h"
 #include BOARD_H //Note that this is not a real file, it is defined in globals.h. 
 
 #define IAC_ALGORITHM_NONE    0U

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -36,44 +36,6 @@
 #pragma GCC optimize ("Os") 
 #endif
 
-#if !defined(UNIT_TEST)
-static inline 
-#endif
-void construct2dTables(void) {
-  //Repoint the 2D table structs to the config pages that were just loaded
-  construct2dTable(taeTable,                  configPage4.taeValues,                  configPage4.taeBins);
-  construct2dTable(maeTable,                  configPage4.maeRates,                   configPage4.maeBins);
-  construct2dTable(WUETable,                  configPage2.wueValues,                  configPage4.wueBins);
-  construct2dTable(ASETable,                  configPage2.asePct,                     configPage2.aseBins);
-  construct2dTable(ASECountTable,             configPage2.aseCount,                   configPage2.aseBins);
-  construct2dTable(PrimingPulseTable,         configPage2.primePulse,                 configPage2.primeBins);
-  construct2dTable(crankingEnrichTable,       configPage10.crankingEnrichValues,      configPage10.crankingEnrichBins);
-  construct2dTable(dwellVCorrectionTable,     configPage4.dwellCorrectionValues,      configPage6.voltageCorrectionBins);
-  construct2dTable(injectorVCorrectionTable,  configPage6.injVoltageCorrectionValues, configPage6.voltageCorrectionBins);
-  construct2dTable(IATDensityCorrectionTable, configPage6.airDenRates,                configPage6.airDenBins);
-  construct2dTable(baroFuelTable,             configPage4.baroFuelValues,             configPage4.baroFuelBins);
-  construct2dTable(IATRetardTable,            configPage4.iatRetValues,               configPage4.iatRetBins);
-  construct2dTable(CLTAdvanceTable,           configPage4.cltAdvValues,               configPage4.cltAdvBins);
-  construct2dTable(idleTargetTable,           configPage6.iacCLValues,                configPage6.iacBins);
-  construct2dTable(idleAdvanceTable,          configPage4.idleAdvValues,              configPage4.idleAdvBins);
-  construct2dTable(rotarySplitTable,          configPage10.rotarySplitValues,         configPage10.rotarySplitBins);
-  construct2dTable(flexFuelTable,             configPage10.flexFuelAdj,               configPage10.flexFuelBins);
-  construct2dTable(flexAdvTable,              configPage10.flexAdvAdj,                configPage10.flexAdvBins);
-  construct2dTable(fuelTempTable,             configPage10.fuelTempValues,            configPage10.fuelTempBins);
-  construct2dTable(oilPressureProtectTable,   configPage10.oilPressureProtMins,       configPage10.oilPressureProtRPM);
-  construct2dTable(coolantProtectTable,       configPage9.coolantProtRPM,             configPage9.coolantProtTemp);
-  construct2dTable(fanPWMTable,               configPage9.PWMFanDuty,                 configPage6.fanPWMBins);
-  construct2dTable(wmiAdvTable,               configPage10.wmiAdvAdj,                 configPage10.wmiAdvBins);
-  construct2dTable(rollingCutTable,           configPage15.rollingProtCutPercent,     configPage15.rollingProtRPMDelta);
-  construct2dTable(injectorAngleTable,        configPage2.injAng,                     configPage2.injAngRPM);
-  construct2dTable(flexBoostTable,            configPage10.flexBoostAdj,              configPage10.flexBoostBins);
-  construct2dTable(knockWindowStartTable,     configPage10.knock_window_angle,        configPage10.knock_window_rpms);
-  construct2dTable(knockWindowDurationTable,  configPage10.knock_window_dur,          configPage10.knock_window_rpms);
-  construct2dTable(cltCalibrationTable,       cltCalibration_values,                  cltCalibration_bins);
-  construct2dTable(iatCalibrationTable,       iatCalibration_values,                  iatCalibration_bins);
-  construct2dTable(o2CalibrationTable,        o2Calibration_values,                   o2Calibration_bins);
-}
-
 /** Initialise Speeduino for the main loop.
  * Top level init entry point for all initialisations:
  * - Initialise and set sizes of 3D tables
@@ -170,10 +132,7 @@ void initialiseAll(void)
 #endif
     pPrimarySerial = &Serial; //Default to standard Serial interface
     BIT_SET(currentStatus.status4, BIT_STATUS4_ALLOW_LEGACY_COMMS); //Flag legacy comms as being allowed on startup
-
-    //Repoint the 2D table structs to the config pages that were just loaded
-    construct2dTables();
-    
+   
     //Setup the calibration tables
     loadCalibration();   
 

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -41,37 +41,37 @@ static inline
 #endif
 void construct2dTables(void) {
   //Repoint the 2D table structs to the config pages that were just loaded
-  construct2dTable(taeTable,                  _countof(configPage4.taeValues),                  configPage4.taeValues,                  configPage4.taeBins);
-  construct2dTable(maeTable,                  _countof(configPage4.maeRates),                   configPage4.maeRates,                   configPage4.maeBins);
-  construct2dTable(WUETable,                  _countof(configPage2.wueValues),                  configPage2.wueValues,                  configPage4.wueBins);
-  construct2dTable(ASETable,                  _countof(configPage2.asePct),                     configPage2.asePct,                     configPage2.aseBins);
-  construct2dTable(ASECountTable,             _countof(configPage2.aseCount),                   configPage2.aseCount,                   configPage2.aseBins);
-  construct2dTable(PrimingPulseTable,         _countof(configPage2.primePulse),                 configPage2.primePulse,                 configPage2.primeBins);
-  construct2dTable(crankingEnrichTable,       _countof(configPage10.crankingEnrichValues),      configPage10.crankingEnrichValues,      configPage10.crankingEnrichBins);
-  construct2dTable(dwellVCorrectionTable,     _countof(configPage4.dwellCorrectionValues),      configPage4.dwellCorrectionValues,      configPage6.voltageCorrectionBins);
-  construct2dTable(injectorVCorrectionTable,  _countof(configPage6.injVoltageCorrectionValues), configPage6.injVoltageCorrectionValues, configPage6.voltageCorrectionBins);
-  construct2dTable(IATDensityCorrectionTable, _countof(configPage6.airDenRates),                configPage6.airDenRates,                configPage6.airDenBins);
-  construct2dTable(baroFuelTable,             _countof(configPage4.baroFuelValues),             configPage4.baroFuelValues,             configPage4.baroFuelBins);
-  construct2dTable(IATRetardTable,            _countof(configPage4.iatRetValues),               configPage4.iatRetValues,               configPage4.iatRetBins);
-  construct2dTable(CLTAdvanceTable,           _countof(configPage4.cltAdvValues),               configPage4.cltAdvValues,               configPage4.cltAdvBins);
-  construct2dTable(idleTargetTable,           _countof(configPage6.iacCLValues),                configPage6.iacCLValues,                configPage6.iacBins);
-  construct2dTable(idleAdvanceTable,          _countof(configPage4.idleAdvValues),              configPage4.idleAdvValues,              configPage4.idleAdvBins);
-  construct2dTable(rotarySplitTable,          _countof(configPage10.rotarySplitValues),         configPage10.rotarySplitValues,         configPage10.rotarySplitBins);
-  construct2dTable(flexFuelTable,             _countof(configPage10.flexFuelAdj),               configPage10.flexFuelAdj,               configPage10.flexFuelBins);
-  construct2dTable(flexAdvTable,              _countof(configPage10.flexAdvAdj),                configPage10.flexAdvAdj,                configPage10.flexAdvBins);
-  construct2dTable(fuelTempTable,             _countof(configPage10.fuelTempValues),            configPage10.fuelTempValues,            configPage10.fuelTempBins);
-  construct2dTable(oilPressureProtectTable,   _countof(configPage10.oilPressureProtMins),       configPage10.oilPressureProtMins,       configPage10.oilPressureProtRPM);
-  construct2dTable(coolantProtectTable,       _countof(configPage9.coolantProtRPM),             configPage9.coolantProtRPM,             configPage9.coolantProtTemp);
-  construct2dTable(fanPWMTable,               _countof(configPage9.PWMFanDuty),                 configPage9.PWMFanDuty,                 configPage6.fanPWMBins);
-  construct2dTable(wmiAdvTable,               _countof(configPage10.wmiAdvAdj),                 configPage10.wmiAdvAdj,                 configPage10.wmiAdvBins);
-  construct2dTable(rollingCutTable,           _countof(configPage15.rollingProtCutPercent),     configPage15.rollingProtCutPercent,     configPage15.rollingProtRPMDelta);
-  construct2dTable(injectorAngleTable,        _countof(configPage2.injAng),                     configPage2.injAng,                     configPage2.injAngRPM);
-  construct2dTable(flexBoostTable,            _countof(configPage10.flexBoostAdj),              configPage10.flexBoostAdj,              configPage10.flexBoostBins);
-  construct2dTable(knockWindowStartTable,      _countof(configPage10.knock_window_angle),        configPage10.knock_window_angle, configPage10.knock_window_rpms);
-  construct2dTable(knockWindowDurationTable,   _countof(configPage10.knock_window_dur),          configPage10.knock_window_dur,   configPage10.knock_window_rpms);
-  construct2dTable(cltCalibrationTable,       _countof(cltCalibration_values), cltCalibration_values, cltCalibration_bins);
-  construct2dTable(iatCalibrationTable,       _countof(iatCalibration_values), iatCalibration_values, iatCalibration_bins);
-  construct2dTable(o2CalibrationTable,        _countof(o2Calibration_values),  o2Calibration_values,  o2Calibration_bins);
+  construct2dTable(taeTable,                  configPage4.taeValues,                  configPage4.taeBins);
+  construct2dTable(maeTable,                  configPage4.maeRates,                   configPage4.maeBins);
+  construct2dTable(WUETable,                  configPage2.wueValues,                  configPage4.wueBins);
+  construct2dTable(ASETable,                  configPage2.asePct,                     configPage2.aseBins);
+  construct2dTable(ASECountTable,             configPage2.aseCount,                   configPage2.aseBins);
+  construct2dTable(PrimingPulseTable,         configPage2.primePulse,                 configPage2.primeBins);
+  construct2dTable(crankingEnrichTable,       configPage10.crankingEnrichValues,      configPage10.crankingEnrichBins);
+  construct2dTable(dwellVCorrectionTable,     configPage4.dwellCorrectionValues,      configPage6.voltageCorrectionBins);
+  construct2dTable(injectorVCorrectionTable,  configPage6.injVoltageCorrectionValues, configPage6.voltageCorrectionBins);
+  construct2dTable(IATDensityCorrectionTable, configPage6.airDenRates,                configPage6.airDenBins);
+  construct2dTable(baroFuelTable,             configPage4.baroFuelValues,             configPage4.baroFuelBins);
+  construct2dTable(IATRetardTable,            configPage4.iatRetValues,               configPage4.iatRetBins);
+  construct2dTable(CLTAdvanceTable,           configPage4.cltAdvValues,               configPage4.cltAdvBins);
+  construct2dTable(idleTargetTable,           configPage6.iacCLValues,                configPage6.iacBins);
+  construct2dTable(idleAdvanceTable,          configPage4.idleAdvValues,              configPage4.idleAdvBins);
+  construct2dTable(rotarySplitTable,          configPage10.rotarySplitValues,         configPage10.rotarySplitBins);
+  construct2dTable(flexFuelTable,             configPage10.flexFuelAdj,               configPage10.flexFuelBins);
+  construct2dTable(flexAdvTable,              configPage10.flexAdvAdj,                configPage10.flexAdvBins);
+  construct2dTable(fuelTempTable,             configPage10.fuelTempValues,            configPage10.fuelTempBins);
+  construct2dTable(oilPressureProtectTable,   configPage10.oilPressureProtMins,       configPage10.oilPressureProtRPM);
+  construct2dTable(coolantProtectTable,       configPage9.coolantProtRPM,             configPage9.coolantProtTemp);
+  construct2dTable(fanPWMTable,               configPage9.PWMFanDuty,                 configPage6.fanPWMBins);
+  construct2dTable(wmiAdvTable,               configPage10.wmiAdvAdj,                 configPage10.wmiAdvBins);
+  construct2dTable(rollingCutTable,           configPage15.rollingProtCutPercent,     configPage15.rollingProtRPMDelta);
+  construct2dTable(injectorAngleTable,        configPage2.injAng,                     configPage2.injAngRPM);
+  construct2dTable(flexBoostTable,            configPage10.flexBoostAdj,              configPage10.flexBoostBins);
+  construct2dTable(knockWindowStartTable,     configPage10.knock_window_angle,        configPage10.knock_window_rpms);
+  construct2dTable(knockWindowDurationTable,  configPage10.knock_window_dur,          configPage10.knock_window_rpms);
+  construct2dTable(cltCalibrationTable,       cltCalibration_values,                  cltCalibration_bins);
+  construct2dTable(iatCalibrationTable,       iatCalibration_values,                  iatCalibration_bins);
+  construct2dTable(o2CalibrationTable,        o2Calibration_values,                   o2Calibration_bins);
 }
 
 /** Initialise Speeduino for the main loop.

--- a/speeduino/scheduler.cpp
+++ b/speeduino/scheduler.cpp
@@ -29,6 +29,7 @@ A full copy of the license may be found in the projects root directory
 #include "scheduledIO.h"
 #include "timers.h"
 #include "schedule_calcs.h"
+#include "utilities.h"
 
 FuelSchedule fuelSchedule1(FUEL1_COUNTER, FUEL1_COMPARE, FUEL1_TIMER_DISABLE, FUEL1_TIMER_ENABLE);
 FuelSchedule fuelSchedule2(FUEL2_COUNTER, FUEL2_COMPARE, FUEL2_TIMER_DISABLE, FUEL2_TIMER_ENABLE);
@@ -281,6 +282,8 @@ void refreshIgnitionSchedule1(unsigned long timeToEnd)
     interrupts();
   }
 }
+
+static constexpr table2D PrimingPulseTable(_countof(configPage2.primePulse), configPage2.primePulse, configPage2.primeBins);
 
 /** Perform the injector priming pulses.
  * Set these to run at an arbitrary time in the future (100us).

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -33,6 +33,10 @@ volatile uint32_t flexPulseWidth = 0U;
 
 static map_algorithm_t mapAlgorithmState;
 
+static constexpr table2D cltCalibrationTable(_countof(cltCalibration_values), cltCalibration_values, cltCalibration_bins);
+static constexpr table2D iatCalibrationTable(_countof(iatCalibration_values), iatCalibration_values, iatCalibration_bins);
+static constexpr table2D o2CalibrationTable(_countof(o2Calibration_values), o2Calibration_values, o2Calibration_bins); 
+
 /**
  * @brief A specialist function to map a value in the range [0, 1023] (I.e. 10-bit) to a different range.
  * 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -60,7 +60,14 @@ uint32_t rollingCutLastRev = 0; /**< Tracks whether we're on the same or a diffe
 
 uint16_t staged_req_fuel_mult_pri = 0;
 uint16_t staged_req_fuel_mult_sec = 0;   
+
+static constexpr table2D injectorAngleTable(_countof(configPage2.injAng), configPage2.injAng, configPage2.injAngRPM);
+static constexpr table2D rotarySplitTable(_countof(configPage10.rotarySplitValues), configPage10.rotarySplitValues, configPage10.rotarySplitBins);
+static constexpr table2D rollingCutTable(_countof(configPage15.rollingProtCutPercent), configPage15.rollingProtCutPercent, configPage15.rollingProtRPMDelta);
+static constexpr table2D idleTargetTable(_countof(configPage6.iacCLValues), configPage6.iacCLValues, configPage6.iacBins);
+
 #ifndef UNIT_TEST // Scope guard for unit testing
+
 void setup(void)
 {
   currentStatus.initialisationComplete = false; //Tracks whether the initialiseAll() function has run completely

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -13,7 +13,7 @@ Note that this may clear some of the existing values of the table
 #include "globals.h"
 #endif
 
-static void construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSize, uint8_t length, void *values, void *bins) {
+static void _construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSize, uint8_t length, const void *values, const void *bins) {
   table.valueSize = valueSize;
   table.axisSize = axisSize;
   table.xSize = length;
@@ -24,23 +24,23 @@ static void construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSize
   table.lastXMin = UINT8_MAX;
 }
 
-void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint8_t *bins) {
-  construct2dTable(table, SIZE_BYTE, SIZE_BYTE, length, values, bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint8_t *bins) {
+  _construct2dTable(table, SIZE_BYTE, SIZE_BYTE, length, values, bins);
 }
-void construct2dTable(table2D &table, uint8_t length, uint8_t *values, int8_t *bins) {
-  construct2dTable(table, SIZE_BYTE, SIZE_SIGNED_BYTE, length, values, bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const int8_t *bins) {
+  _construct2dTable(table, SIZE_BYTE, SIZE_SIGNED_BYTE, length, values, bins);
 }
-void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint16_t *bins) {
-  construct2dTable(table, SIZE_INT, SIZE_INT, length, values, bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint16_t *bins) {
+  _construct2dTable(table, SIZE_INT, SIZE_INT, length, values, bins);
 }
-void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint16_t *bins) {
-  construct2dTable(table, SIZE_BYTE, SIZE_INT, length, values, bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint16_t *bins) {
+  _construct2dTable(table, SIZE_BYTE, SIZE_INT, length, values, bins);
 }
-void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint8_t *bins) {
-  construct2dTable(table, SIZE_INT, SIZE_BYTE, length, values, bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint8_t *bins) {
+  _construct2dTable(table, SIZE_INT, SIZE_BYTE, length, values, bins);
 }
-void construct2dTable(table2D &table, uint8_t length, int16_t *values, uint8_t *bins) {
-  construct2dTable(table, SIZE_INT, SIZE_BYTE, length, values, bins);
+void _construct2dTable(table2D &table, uint8_t length, const int16_t *values, const uint8_t *bins) {
+  _construct2dTable(table, SIZE_INT, SIZE_BYTE, length, values, bins);
 }
 
 static inline uint8_t getCacheTime(void) {

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -20,7 +20,7 @@ static void _construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSiz
   table.values = values;
   table.axisX = bins;
   table.lastInput = INT16_MAX;
-  table.lastBinUpperIndex = UINT8_MAX;
+  table.lastBinUpperIndex = 1U;
 }
 
 void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint8_t *bins) {

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -14,32 +14,7 @@ Note that this may clear some of the existing values of the table
 #include "globals.h"
 #endif
 
-static void construct2dTable(table2D &table, OpaqueArray::TypeIndicator valueType, OpaqueArray::TypeIndicator axisType, uint8_t length, const void *values, const void *bins) {
-  table.values = { valueType, values };
-  table.axis = { axisType, bins };
-  table.length = length;
-  table.cache.lastInput = INT16_MAX;
-  table.cache.lastBinUpperIndex = 1U;
-}
 
-void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint8_t *bins) {
-  construct2dTable(table, OpaqueArray::TYPE_UINT8, OpaqueArray::TYPE_UINT8, length, values, bins);
-}
-void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const int8_t *bins) {
-  construct2dTable(table, OpaqueArray::TYPE_UINT8, OpaqueArray::TYPE_INT8, length, values, bins);
-}
-void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint16_t *bins) {
-  construct2dTable(table, OpaqueArray::TYPE_UINT16, OpaqueArray::TYPE_UINT16, length, values, bins);
-}
-void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint16_t *bins) {
-  construct2dTable(table, OpaqueArray::TYPE_UINT8, OpaqueArray::TYPE_UINT16, length, values, bins);
-}
-void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint8_t *bins) {
-  construct2dTable(table, OpaqueArray::TYPE_UINT16, OpaqueArray::TYPE_UINT8, length, values, bins);
-}
-void _construct2dTable(table2D &table, uint8_t length, const int16_t *values, const uint8_t *bins) {
-  construct2dTable(table, OpaqueArray::TYPE_INT16, OpaqueArray::TYPE_UINT8, length, values, bins);
-}
 
 static inline uint8_t getCacheTime(void) {
 #if !defined(UNIT_TEST)

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -66,8 +66,8 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
 
   int16_t X = X_in;
   int16_t xMinValue, xMaxValue;
-  int xMin = 0;
-  int xMax = fromTable->xSize-1;
+  uint8_t xMin = 0;
+  uint8_t xMax = fromTable->xSize-1;
 
   //Check whether the X input is the same as last time this ran
   if( (X_in == fromTable->lastInput) && (fromTable->cacheTime == getCacheTime()) )
@@ -103,9 +103,9 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     {
       //If we're not in the same bin, loop through to find where we are
       xMaxValue = table2D_getAxisValue(fromTable, fromTable->xSize-1); // init xMaxValue in preparation for loop.
-      for (int x = fromTable->xSize-1; x > 0; x--)
+      for (uint8_t x = fromTable->xSize-1U; x > 0; x--)
       {
-        xMinValue = table2D_getAxisValue(fromTable, x-1); // fetch next Min
+        xMinValue = table2D_getAxisValue(fromTable, x-1U); // fetch next Min
 
         //Checks the case where the X value is exactly what was requested
         if (X == xMaxValue)
@@ -119,7 +119,7 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
           // Value is in the current bin
           xMax = x;
           fromTable->lastXMax = xMax;
-          xMin = x-1;
+          xMin = x-1U;
           fromTable->lastXMin = xMin;
           break;
         }

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -21,7 +21,6 @@ static void _construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSiz
   table.axisX = bins;
   table.lastInput = INT16_MAX;
   table.lastXMax = UINT8_MAX;
-  table.lastXMin = UINT8_MAX;
 }
 
 void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint8_t *bins) {
@@ -66,7 +65,6 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
 
   int16_t X = X_in;
   int16_t xMinValue, xMaxValue;
-  uint8_t xMin = 0;
   uint8_t xMax = fromTable->xSize-1;
 
   //Check whether the X input is the same as last time this ran
@@ -81,9 +79,9 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     returnValue = table2D_getRawValue(fromTable, xMax);
     valueFound = true;
   }
-  else if(X <= table2D_getAxisValue(fromTable, xMin))
+  else if(X <= table2D_getAxisValue(fromTable, 0U))
   {
-    returnValue = table2D_getRawValue(fromTable, xMin);
+    returnValue = table2D_getRawValue(fromTable, 0U);
     valueFound = true;
   }
   //Finally if none of that is found
@@ -93,11 +91,10 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
 
     //1st check is whether we're still in the same X bin as last time
     xMaxValue = table2D_getAxisValue(fromTable, fromTable->lastXMax);
-    xMinValue = table2D_getAxisValue(fromTable, fromTable->lastXMin);
+    xMinValue = table2D_getAxisValue(fromTable, fromTable->lastXMax-1U);
     if ( (X <= xMaxValue) && (X > xMinValue) )
     {
       xMax = fromTable->lastXMax;
-      xMin = fromTable->lastXMin;
     }
     else
     {
@@ -119,8 +116,6 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
           // Value is in the current bin
           xMax = x;
           fromTable->lastXMax = xMax;
-          xMin = x-1U;
-          fromTable->lastXMin = xMin;
           break;
         }
         // Otherwise, continue to next bin
@@ -135,7 +130,7 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     int16_t n = xMaxValue - xMinValue;
 
     int16_t yMax = table2D_getRawValue(fromTable, xMax);
-    int16_t yMin = table2D_getRawValue(fromTable, xMin);
+    int16_t yMin = table2D_getRawValue(fromTable, xMax-1U);
 
     /* Float version (if m, yMax, yMin and n were float's)
        int yVal = (m * (yMax - yMin)) / n;

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -20,7 +20,7 @@ static void _construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSiz
   table.values = values;
   table.axisX = bins;
   table.lastInput = INT16_MAX;
-  table.lastXMax = UINT8_MAX;
+  table.lastBinUpperIndex = UINT8_MAX;
 }
 
 void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint8_t *bins) {
@@ -90,11 +90,11 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     fromTable->cacheTime = getCacheTime(); //As we're not using the cache value, set the current secl value to track when this new value was calculated
 
     //1st check is whether we're still in the same X bin as last time
-    xMaxValue = table2D_getAxisValue(fromTable, fromTable->lastXMax);
-    xMinValue = table2D_getAxisValue(fromTable, fromTable->lastXMax-1U);
+    xMaxValue = table2D_getAxisValue(fromTable, fromTable->lastBinUpperIndex);
+    xMinValue = table2D_getAxisValue(fromTable, fromTable->lastBinUpperIndex-1U);
     if ( (X <= xMaxValue) && (X > xMinValue) )
     {
-      xMax = fromTable->lastXMax;
+      xMax = fromTable->lastBinUpperIndex;
     }
     else
     {
@@ -115,7 +115,7 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
         {
           // Value is in the current bin
           xMax = x;
-          fromTable->lastXMax = xMax;
+          fromTable->lastBinUpperIndex = xMax;
           break;
         }
         // Otherwise, continue to next bin

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -69,7 +69,7 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
 
   int16_t X = X_in;
   int16_t xMinValue, xMaxValue;
-  uint8_t xMax = fromTable->length-1;
+  uint8_t xMax = fromTable->length-1U;
 
   //Check whether the X input is the same as last time this ran
   if( (X_in == fromTable->lastInput) && (fromTable->cacheTime == getCacheTime()) )
@@ -103,8 +103,8 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     else
     {
       //If we're not in the same bin, loop through to find where we are
-      xMaxValue = table2D_getAxisValue(fromTable, fromTable->length-1); // init xMaxValue in preparation for loop.
-      for (uint8_t x = fromTable->length-1U; x > 0; x--)
+      xMaxValue = table2D_getAxisValue(fromTable, fromTable->length-1U); // init xMaxValue in preparation for loop.
+      for (uint8_t x = fromTable->length-1U; x > 0U; x--)
       {
         xMinValue = table2D_getAxisValue(fromTable, x-1U); // fetch next Min
 
@@ -121,27 +121,29 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
           xMax = x;
           fromTable->lastBinUpperIndex = xMax;
           break;
+        } else {
+          // Otherwise, continue to next bin
+          xMaxValue = xMinValue; // for the next bin, our Min is their Max
         }
-        // Otherwise, continue to next bin
-        xMaxValue = xMinValue; // for the next bin, our Min is their Max
       }
     }
   } //X_in same as last time
 
   if (valueFound == false)
   {
-    int16_t m = X - xMinValue;
-    int16_t n = xMaxValue - xMinValue;
+    int32_t m = (int32_t)X - (int32_t)xMinValue;
+    int32_t n = (int32_t)xMaxValue - (int32_t)xMinValue;
 
     int16_t yMax = table2D_getRawValue(fromTable, xMax);
     int16_t yMin = table2D_getRawValue(fromTable, xMax-1U);
+    int32_t yRange = (int32_t) yMax - (int32_t) yMin;
 
     /* Float version (if m, yMax, yMin and n were float's)
        int yVal = (m * (yMax - yMin)) / n;
     */
     
     //Non-Float version
-    int16_t yVal = ( ((int32_t) m) * (yMax-yMin) ) / n;
+    int16_t yVal = (int16_t)(( m * yRange ) / n);
     returnValue = yMin + yVal;
   }
 
@@ -165,7 +167,7 @@ int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in)
   if(fromTable->axisType == TYPE_UINT16) { returnValue = ((int16_t*)fromTable->axisX)[X_in]; }
   else if(fromTable->axisType == TYPE_UINT8) { returnValue = ((uint8_t*)fromTable->axisX)[X_in]; }
   else if(fromTable->axisType == TYPE_INT8) { returnValue = ((int8_t*)fromTable->axisX)[X_in]; }
-  
+  else { /* Keep MISRA checker happy*/ }  
 
   return returnValue;
 }
@@ -184,6 +186,7 @@ int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index)
   if(fromTable->valueType == TYPE_UINT16) { returnValue = ((int16_t*)fromTable->values)[X_index]; }
   else if(fromTable->valueType == TYPE_UINT8) { returnValue = ((uint8_t*)fromTable->values)[X_index]; }
   else if(fromTable->valueType == TYPE_INT8) { returnValue = ((int8_t*)fromTable->values)[X_index]; }
+  else { /* Keep MISRA checker happy*/ }  
 
   return returnValue;
 }

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -13,10 +13,14 @@ Note that this may clear some of the existing values of the table
 #include "globals.h"
 #endif
 
-static void _construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSize, uint8_t length, const void *values, const void *bins) {
-  table.valueSize = valueSize;
-  table.axisSize = axisSize;
-  table.xSize = length;
+#define TYPE_INT8    1U
+#define TYPE_UINT8   2U
+#define TYPE_UINT16  3U
+
+static void _construct2dTable(table2D &table, uint8_t valueType, uint8_t axisType, uint8_t length, const void *values, const void *bins) {
+  table.valueType = valueType;
+  table.axisType = axisType;
+  table.length = length;
   table.values = values;
   table.axisX = bins;
   table.lastInput = INT16_MAX;
@@ -24,22 +28,22 @@ static void _construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSiz
 }
 
 void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint8_t *bins) {
-  _construct2dTable(table, SIZE_BYTE, SIZE_BYTE, length, values, bins);
+  _construct2dTable(table, TYPE_UINT8, TYPE_UINT8, length, values, bins);
 }
 void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const int8_t *bins) {
-  _construct2dTable(table, SIZE_BYTE, SIZE_SIGNED_BYTE, length, values, bins);
+  _construct2dTable(table, TYPE_UINT8, TYPE_INT8, length, values, bins);
 }
 void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint16_t *bins) {
-  _construct2dTable(table, SIZE_INT, SIZE_INT, length, values, bins);
+  _construct2dTable(table, TYPE_UINT16, TYPE_UINT16, length, values, bins);
 }
 void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint16_t *bins) {
-  _construct2dTable(table, SIZE_BYTE, SIZE_INT, length, values, bins);
+  _construct2dTable(table, TYPE_UINT8, TYPE_UINT16, length, values, bins);
 }
 void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint8_t *bins) {
-  _construct2dTable(table, SIZE_INT, SIZE_BYTE, length, values, bins);
+  _construct2dTable(table, TYPE_UINT16, TYPE_UINT8, length, values, bins);
 }
 void _construct2dTable(table2D &table, uint8_t length, const int16_t *values, const uint8_t *bins) {
-  _construct2dTable(table, SIZE_INT, SIZE_BYTE, length, values, bins);
+  _construct2dTable(table, TYPE_UINT16, TYPE_UINT8, length, values, bins);
 }
 
 static inline uint8_t getCacheTime(void) {
@@ -65,7 +69,7 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
 
   int16_t X = X_in;
   int16_t xMinValue, xMaxValue;
-  uint8_t xMax = fromTable->xSize-1;
+  uint8_t xMax = fromTable->length-1;
 
   //Check whether the X input is the same as last time this ran
   if( (X_in == fromTable->lastInput) && (fromTable->cacheTime == getCacheTime()) )
@@ -99,8 +103,8 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     else
     {
       //If we're not in the same bin, loop through to find where we are
-      xMaxValue = table2D_getAxisValue(fromTable, fromTable->xSize-1); // init xMaxValue in preparation for loop.
-      for (uint8_t x = fromTable->xSize-1U; x > 0; x--)
+      xMaxValue = table2D_getAxisValue(fromTable, fromTable->length-1); // init xMaxValue in preparation for loop.
+      for (uint8_t x = fromTable->length-1U; x > 0; x--)
       {
         xMinValue = table2D_getAxisValue(fromTable, x-1U); // fetch next Min
 
@@ -158,9 +162,9 @@ int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in)
 {
   int returnValue = 0;
 
-  if(fromTable->axisSize == SIZE_INT) { returnValue = ((int16_t*)fromTable->axisX)[X_in]; }
-  else if(fromTable->axisSize == SIZE_BYTE) { returnValue = ((uint8_t*)fromTable->axisX)[X_in]; }
-  else if(fromTable->axisSize == SIZE_SIGNED_BYTE) { returnValue = ((int8_t*)fromTable->axisX)[X_in]; }
+  if(fromTable->axisType == TYPE_UINT16) { returnValue = ((int16_t*)fromTable->axisX)[X_in]; }
+  else if(fromTable->axisType == TYPE_UINT8) { returnValue = ((uint8_t*)fromTable->axisX)[X_in]; }
+  else if(fromTable->axisType == TYPE_INT8) { returnValue = ((int8_t*)fromTable->axisX)[X_in]; }
   
 
   return returnValue;
@@ -177,9 +181,9 @@ int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index)
 {
   int returnValue = 0;
 
-  if(fromTable->valueSize == SIZE_INT) { returnValue = ((int16_t*)fromTable->values)[X_index]; }
-  else if(fromTable->valueSize == SIZE_BYTE) { returnValue = ((uint8_t*)fromTable->values)[X_index]; }
-  else if(fromTable->valueSize == SIZE_SIGNED_BYTE) { returnValue = ((int8_t*)fromTable->values)[X_index]; }
+  if(fromTable->valueType == TYPE_UINT16) { returnValue = ((int16_t*)fromTable->values)[X_index]; }
+  else if(fromTable->valueType == TYPE_UINT8) { returnValue = ((uint8_t*)fromTable->values)[X_index]; }
+  else if(fromTable->valueType == TYPE_INT8) { returnValue = ((int8_t*)fromTable->values)[X_index]; }
 
   return returnValue;
 }

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -38,7 +38,7 @@ void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, c
   construct2dTable(table, OpaqueArray::TYPE_UINT16, OpaqueArray::TYPE_UINT8, length, values, bins);
 }
 void _construct2dTable(table2D &table, uint8_t length, const int16_t *values, const uint8_t *bins) {
-  construct2dTable(table, OpaqueArray::TYPE_UINT16, OpaqueArray::TYPE_UINT8, length, values, bins);
+  construct2dTable(table, OpaqueArray::TYPE_INT16, OpaqueArray::TYPE_UINT8, length, values, bins);
 }
 
 static inline uint8_t getCacheTime(void) {
@@ -58,11 +58,12 @@ static inline bool cacheExpired(const Table2DCache &cache) {
 #define OPAQUE_ARRAY_DISPATCH(opaqueArray, action, ...) \
   if((opaqueArray).type == OpaqueArray::TYPE_UINT8) { return (action)((const uint8_t*)((opaqueArray).data), __VA_ARGS__); } \
   if((opaqueArray).type == OpaqueArray::TYPE_UINT16) { return (action)((const uint16_t*)((opaqueArray).data), __VA_ARGS__); } \
-  if((opaqueArray).type == OpaqueArray::TYPE_INT8) { return (action)((const int8_t*)((opaqueArray).data), __VA_ARGS__); }
+  if((opaqueArray).type == OpaqueArray::TYPE_INT8) { return (action)((const int8_t*)((opaqueArray).data), __VA_ARGS__); } \
+  if((opaqueArray).type == OpaqueArray::TYPE_INT16) { return (action)((const int16_t*)((opaqueArray).data), __VA_ARGS__); }
 
 template <typename TArray>
-static inline TArray getValue(const TArray *axis, uint8_t index) {
-  return axis[index];
+static inline TArray getValue(const TArray *array, uint8_t index) {
+  return array[index];
 }
  
 static inline int16_t getValue(const OpaqueArray &array, uint8_t index) {
@@ -140,7 +141,7 @@ int16_t table2D_getValue(const struct table2D *fromTable, const int16_t X_in)
     xBin = findAxisBin(fromTable, X_in);
   }
 
-  // We are exactly at the bin upper bound, so need to interpolate
+  // We are exactly at the bin upper bound, so no need to interpolate
   if (X_in==xBin.upperValue) {
     fromTable->cache.lastOutput = getValue(fromTable->values, xBin.upperIndex);
     fromTable->cache.lastBinUpperIndex = xBin.upperIndex;

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -20,8 +20,8 @@ static void construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSize
   table.values = values;
   table.axisX = bins;
   table.lastInput = INT16_MAX;
-  table.lastXMax = INT16_MAX;
-  table.lastXMin = INT16_MAX;
+  table.lastXMax = UINT8_MAX;
+  table.lastXMin = UINT8_MAX;
 }
 
 void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint8_t *bins) {
@@ -58,14 +58,14 @@ ie: Given a value on the X axis, it returns a Y value that corresponds to the po
 This function must take into account whether a table contains 8-bit or 16-bit values.
 Unfortunately this means many of the lines are duplicated depending on this
 */
-int table2D_getValue(struct table2D *fromTable, int X_in)
+int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
 {
   //Orig memory usage = 5414
-  int returnValue = 0;
+  int16_t returnValue = 0;
   bool valueFound = false;
 
-  int X = X_in;
-  int xMinValue, xMaxValue;
+  int16_t X = X_in;
+  int16_t xMinValue, xMaxValue;
   int xMin = 0;
   int xMax = fromTable->xSize-1;
 
@@ -159,7 +159,7 @@ int table2D_getValue(struct table2D *fromTable, int X_in)
  * @param X_in 
  * @return int16_t 
  */
-int16_t table2D_getAxisValue(struct table2D *fromTable, byte X_in)
+int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in)
 {
   int returnValue = 0;
 
@@ -178,7 +178,7 @@ int16_t table2D_getAxisValue(struct table2D *fromTable, byte X_in)
  * @param X_index 
  * @return int16_t 
  */
-int16_t table2D_getRawValue(struct table2D *fromTable, byte X_index)
+int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index)
 {
   int returnValue = 0;
 

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -61,13 +61,11 @@ ie: Given a value on the X axis, it returns a Y value that corresponds to the po
 This function must take into account whether a table contains 8-bit or 16-bit values.
 Unfortunately this means many of the lines are duplicated depending on this
 */
-int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
+int16_t table2D_getValue(struct table2D *fromTable, const int16_t X_in)
 {
-  //Orig memory usage = 5414
   int16_t returnValue = 0;
   bool valueFound = false;
 
-  int16_t X = X_in;
   int16_t xMinValue, xMaxValue;
   uint8_t xMax = fromTable->length-1U;
 
@@ -78,12 +76,12 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     valueFound = true;
   }
   //If the requested X value is greater/small than the maximum/minimum bin, simply return that value
-  else if(X >= table2D_getAxisValue(fromTable, xMax))
+  else if(X_in >= table2D_getAxisValue(fromTable, fromTable->xSize-1U))
   {
-    returnValue = table2D_getRawValue(fromTable, xMax);
+    returnValue = table2D_getRawValue(fromTable, fromTable->xSize-1U);
     valueFound = true;
   }
-  else if(X <= table2D_getAxisValue(fromTable, 0U))
+  else if(X_in <= table2D_getAxisValue(fromTable, 0U))
   {
     returnValue = table2D_getRawValue(fromTable, 0U);
     valueFound = true;
@@ -96,7 +94,7 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     //1st check is whether we're still in the same X bin as last time
     xMaxValue = table2D_getAxisValue(fromTable, fromTable->lastBinUpperIndex);
     xMinValue = table2D_getAxisValue(fromTable, fromTable->lastBinUpperIndex-1U);
-    if ( (X <= xMaxValue) && (X > xMinValue) )
+    if ( (X_in <= xMaxValue) && (X_in > xMinValue) )
     {
       xMax = fromTable->lastBinUpperIndex;
     }
@@ -109,17 +107,17 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
         xMinValue = table2D_getAxisValue(fromTable, x-1U); // fetch next Min
 
         //Checks the case where the X value is exactly what was requested
-        if (X == xMaxValue)
+        if (X_in == xMaxValue)
         {
           returnValue = table2D_getRawValue(fromTable, x); //Simply return the corresponding value
           valueFound = true;
           break;
         }
-        else if (X > xMinValue)
+        else if (X_in > xMinValue)
         {
           // Value is in the current bin
           xMax = x;
-          fromTable->lastBinUpperIndex = xMax;
+          fromTable->lastBinUpperIndex = x;
           break;
         } else {
           // Otherwise, continue to next bin
@@ -131,7 +129,7 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
 
   if (valueFound == false)
   {
-    int32_t m = (int32_t)X - (int32_t)xMinValue;
+    int32_t m = (int32_t)X_in - (int32_t)xMinValue;
     int32_t n = (int32_t)xMaxValue - (int32_t)xMinValue;
 
     int16_t yMax = table2D_getRawValue(fromTable, xMax);

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -4,11 +4,7 @@ This file is used for everything related to maps/tables including their definiti
 #ifndef TABLE_H
 #define TABLE_H
 
-#include "globals.h"
-
-#define SIZE_SIGNED_BYTE    4
-#define SIZE_BYTE           8
-#define SIZE_INT            16
+#include <stdint.h>
 
 /**
  * @brief A polymorphic 2D table.
@@ -23,9 +19,9 @@ This file is used for everything related to maps/tables including their definiti
  */
 struct table2D {
   //Used 5414 RAM with original version
-  uint8_t valueSize;
-  uint8_t axisSize;
-  uint8_t xSize;
+  uint8_t valueType;
+  uint8_t axisType;
+  uint8_t length;
 
   const void *values;
   const void *axisX;

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -34,8 +34,8 @@ struct table2D {
   //int16_t *axisX16;
 
   //Store the last X and Y coordinates in the table. This is used to make the next check faster
-  int16_t lastXMax;
-  int16_t lastXMin;
+  uint8_t lastXMax;
+  uint8_t lastXMin;
 
   //Store the last input and output for caching
   int16_t lastInput;

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -16,9 +16,9 @@ The valueSize variable should be set to either 8 or 16 to indicate this BEFORE t
 */
 struct table2D {
   //Used 5414 RAM with original version
-  byte valueSize;
-  byte axisSize;
-  byte xSize;
+  uint8_t valueSize;
+  uint8_t axisSize;
+  uint8_t xSize;
 
   void *values;
   void *axisX;
@@ -33,7 +33,7 @@ struct table2D {
   //Store the last input and output for caching
   int16_t lastInput;
   int16_t lastOutput;
-  byte cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
+  uint8_t cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
 };
 
 void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint8_t *bins);
@@ -43,9 +43,9 @@ void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint16_t 
 void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint8_t *bins);
 void construct2dTable(table2D &table, uint8_t length, int16_t *values, uint8_t *bins);
 
-int16_t table2D_getAxisValue(struct table2D *fromTable, byte X_in);
-int16_t table2D_getRawValue(struct table2D *fromTable, byte X_index);
+int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in);
+int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index);
 
-int table2D_getValue(struct table2D *fromTable, int X_in);
+int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in);
 
 #endif // TABLE_H

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -6,6 +6,20 @@ This file is used for everything related to maps/tables including their definiti
 
 #include <stdint.h>
 
+/// @cond
+// private to table2D implementation
+struct Table2DCache {
+  // Store the upper index of the bin we last found. This is used to make the next check faster
+  // Since this is the *upper* index, it can never be 0.
+  uint8_t lastBinUpperIndex;
+
+  //Store the last input and output for caching
+  int16_t lastInput;
+  int16_t lastOutput;
+  uint8_t cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
+};
+/// @endcond
+
 /**
  * @brief A polymorphic 2D table.
  * 
@@ -26,17 +40,7 @@ struct table2D {
   const void *values;
   const void *axisX;
 
-  //int16_t *values16;
-  //int16_t *axisX16;
-
-  // Store the upper index of the bin we last found. This is used to make the next check faster
-  // Since this is the *upper* index, it can never be 0.
-  uint8_t lastBinUpperIndex;
-
-  //Store the last input and output for caching
-  int16_t lastInput;
-  int16_t lastOutput;
-  uint8_t cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
+  mutable Table2DCache cache;
 };
 
 /// @cond
@@ -66,9 +70,9 @@ void construct2dTable(table2D &table, const value_t (&values)[TSize], const axis
   _construct2dTable(table, TSize, values, bins);
 }
 
-int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in);
-int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index);
+int16_t table2D_getAxisValue(const struct table2D *fromTable, uint8_t index);
+int16_t table2D_getRawValue(const struct table2D *fromTable, uint8_t index);
 
-int16_t table2D_getValue(struct table2D *fromTable, const int16_t X_in);
+int16_t table2D_getValue(const struct table2D *fromTable, const int16_t X_in);
 
 #endif // TABLE_H

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -13,12 +13,14 @@ This file is used for everything related to maps/tables including their definiti
 struct Table2DCache {
   // Store the upper index of the bin we last found. This is used to make the next check faster
   // Since this is the *upper* index, it can never be 0.
-  uint8_t lastBinUpperIndex;
+  uint8_t lastBinUpperIndex = 1U; // The algorithms rely on this being less than the length of the table AND non-zero
 
   //Store the last input and output for caching
-  int16_t lastInput;
-  int16_t lastOutput;
-  uint8_t cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
+  int16_t lastInput = INT16_MAX;
+  int16_t lastOutput = 0;
+  uint8_t cacheTime = 0U; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
+
+  constexpr Table2DCache(void) = default;
 };
 
 // Captures the concept of an opaque array
@@ -30,8 +32,30 @@ struct OpaqueArray {
     TYPE_UINT16,
     TYPE_INT16,
   };
-  TypeIndicator type;
-  const void *data;
+  TypeIndicator type = TYPE_UINT8;
+  const void *data = nullptr;
+
+  explicit constexpr OpaqueArray(const uint8_t *data)
+    : type(TYPE_UINT8)
+    , data((const void *)data)
+  {
+  };
+  explicit constexpr OpaqueArray(const int8_t *data)
+    : type(TYPE_INT8)
+    , data((const void *)data)
+  {
+  };
+  explicit constexpr OpaqueArray(const uint16_t *data)
+    : type(TYPE_UINT16)
+    , data((const void *)data)
+  {
+  };
+  explicit constexpr OpaqueArray(const int16_t *data)
+    : type(TYPE_INT16)
+    , data((const void *)data)
+  {
+  };
+  
 };
 
 /// @endcond
@@ -40,11 +64,11 @@ struct OpaqueArray {
  * @brief A polymorphic 2D table.
  * 
  * The table is designed to be used with the table2D_getValue function to interpolate values from a 2D table.
- *  * Construct by calling construct2dTable
+ *  * Construct by calling one of the constructors below
  *    * The table is defined by providing the axis and value arrays 
  *    * The axis and value arrays must be the same length
- *  * The axis array **must** be sorted
- *  * The axis and values can be any integral type up to 16-bits wide.
+ *    * The axis array **must** be sorted
+ *    * The axis and values can be any integral type up to 16-bits wide.
  *    * Signed or unsigned.
  */
 struct table2D { // cppcheck-suppress ctuOneDefinitionRuleViolation; false positive
@@ -54,34 +78,29 @@ struct table2D { // cppcheck-suppress ctuOneDefinitionRuleViolation; false posit
   OpaqueArray axis;
 
   mutable Table2DCache cache;
+
+  constexpr table2D(uint8_t length, const OpaqueArray &values, const OpaqueArray &bins) 
+    : length(length), values(values), axis(bins) {  
+  }
+  constexpr table2D(uint8_t length, const uint8_t *values, const uint8_t *bins) 
+    : table2D(length, OpaqueArray(values), OpaqueArray(bins)) {
+  }
+  constexpr table2D(uint8_t length, const uint8_t *values, const int8_t *bins)
+    : table2D(length, OpaqueArray(values), OpaqueArray(bins)) {
+  }
+  constexpr table2D(uint8_t length, const uint16_t *values, const uint16_t *bins)
+    : table2D(length, OpaqueArray(values), OpaqueArray(bins)) {
+  }
+  constexpr table2D(uint8_t length, const uint8_t *values, const uint16_t *bins)
+    : table2D(length, OpaqueArray(values), OpaqueArray(bins)) {
+  }
+  constexpr table2D(uint8_t length, const uint16_t *values, const uint8_t *bins)
+    : table2D(length, OpaqueArray(values), OpaqueArray(bins)) {
+  }
+  constexpr table2D(uint8_t length, const int16_t *values, const uint8_t *bins)
+    : table2D(length, OpaqueArray(values), OpaqueArray(bins)) {
+  } 
 };
-
-/// @cond
-// private to construct2dTable
-void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint8_t *bins);
-void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const int8_t *bins);
-void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint16_t *bins);
-void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint16_t *bins);
-void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint8_t *bins);
-void _construct2dTable(table2D &table, uint8_t length, const int16_t *values, const uint8_t *bins);
-/// @endcond
-
-/**
- * @brief Wire up the 2D table struct to the axis (aka bins) and value arrays 
- * 
- * The 2 arrays must be the same length
- *
- * @tparam axis_t Integral type of the axis. E.g. uint8_t
- * @tparam value_t Integral type of the values. E.g. uint8_t
- * @tparam TSize Size of the arrays
- * @param table The table to wire up
- * @param values Array of values
- * @param bins Array of axis values
- */
-template <typename axis_t, typename value_t, uint8_t TSize>
-void construct2dTable(table2D &table, const value_t (&values)[TSize], const axis_t (&bins)[TSize]) {
-  _construct2dTable(table, TSize, values, bins);
-}
 
 int16_t table2D_getAxisValue(const struct table2D *fromTable, uint8_t index);
 int16_t table2D_getRawValue(const struct table2D *fromTable, uint8_t index);

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -8,6 +8,8 @@ This file is used for everything related to maps/tables including their definiti
 
 /// @cond
 // private to table2D implementation
+
+// The 2D table cache
 struct Table2DCache {
   // Store the upper index of the bin we last found. This is used to make the next check faster
   // Since this is the *upper* index, it can never be 0.
@@ -18,6 +20,20 @@ struct Table2DCache {
   int16_t lastOutput;
   uint8_t cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
 };
+
+// Captures the concept of an opaque array
+// (at some point this needs to be replaced with C++ templates)
+struct OpaqueArray {
+  enum TypeIndicator {
+    TYPE_UINT8,
+    TYPE_INT8,
+    TYPE_UINT16,
+    TYPE_INT16,
+  };
+  TypeIndicator type;
+  const void *data;
+};
+
 /// @endcond
 
 /**
@@ -32,13 +48,10 @@ struct Table2DCache {
  *    * Signed or unsigned.
  */
 struct table2D {
-  //Used 5414 RAM with original version
-  uint8_t valueType;
-  uint8_t axisType;
   uint8_t length;
 
-  const void *values;
-  const void *axisX;
+  OpaqueArray values;
+  OpaqueArray axis;
 
   mutable Table2DCache cache;
 };

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -47,7 +47,7 @@ struct OpaqueArray {
  *  * The axis and values can be any integral type up to 16-bits wide.
  *    * Signed or unsigned.
  */
-struct table2D {
+struct table2D { // cppcheck-suppress ctuOneDefinitionRuleViolation; false positive
   uint8_t length;
 
   OpaqueArray values;

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -69,6 +69,6 @@ void construct2dTable(table2D &table, const value_t (&values)[TSize], const axis
 int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in);
 int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index);
 
-int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in);
+int16_t table2D_getValue(struct table2D *fromTable, const int16_t X_in);
 
 #endif // TABLE_H

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -10,18 +10,25 @@ This file is used for everything related to maps/tables including their definiti
 #define SIZE_BYTE           8
 #define SIZE_INT            16
 
-/*
-The 2D table can contain either 8-bit (byte) or 16-bit (int) values
-The valueSize variable should be set to either 8 or 16 to indicate this BEFORE the table is used
-*/
+/**
+ * @brief A polymorphic 2D table.
+ * 
+ * The table is designed to be used with the table2D_getValue function to interpolate values from a 2D table.
+ *  * Construct by calling construct2dTable
+ *    * The table is defined by providing the axis and value arrays 
+ *    * The axis and value arrays must be the same length
+ *  * The axis array **must** be sorted
+ *  * The axis and values can be any integral type up to 16-bits wide.
+ *    * Signed or unsigned.
+ */
 struct table2D {
   //Used 5414 RAM with original version
   uint8_t valueSize;
   uint8_t axisSize;
   uint8_t xSize;
 
-  void *values;
-  void *axisX;
+  const void *values;
+  const void *axisX;
 
   //int16_t *values16;
   //int16_t *axisX16;
@@ -36,12 +43,32 @@ struct table2D {
   uint8_t cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
 };
 
-void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint8_t *bins);
-void construct2dTable(table2D &table, uint8_t length, uint8_t *values, int8_t *bins);
-void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint16_t *bins);
-void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint16_t *bins);
-void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint8_t *bins);
-void construct2dTable(table2D &table, uint8_t length, int16_t *values, uint8_t *bins);
+/// @cond
+// private to construct2dTable
+void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint8_t *bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const int8_t *bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint16_t *bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint8_t *values, const uint16_t *bins);
+void _construct2dTable(table2D &table, uint8_t length, const uint16_t *values, const uint8_t *bins);
+void _construct2dTable(table2D &table, uint8_t length, const int16_t *values, const uint8_t *bins);
+/// @endcond
+
+/**
+ * @brief Wire up the 2D table struct to the axis (aka bins) and value arrays 
+ * 
+ * The 2 arrays must be the same length
+ *
+ * @tparam axis_t Integral type of the axis. E.g. uint8_t
+ * @tparam value_t Integral type of the values. E.g. uint8_t
+ * @tparam TSize Size of the arrays
+ * @param table The table to wire up
+ * @param values Array of values
+ * @param bins Array of axis values
+ */
+template <typename axis_t, typename value_t, uint8_t TSize>
+void construct2dTable(table2D &table, const value_t (&values)[TSize], const axis_t (&bins)[TSize]) {
+  _construct2dTable(table, TSize, values, bins);
+}
 
 int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in);
 int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index);

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -35,7 +35,7 @@ struct table2D {
 
   // Store the upper index of the bin we last found. This is used to make the next check faster
   // Since this is the *upper* index, it can never be 0.
-  uint8_t lastXMax;
+  uint8_t lastBinUpperIndex;
 
   //Store the last input and output for caching
   int16_t lastInput;

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -33,9 +33,9 @@ struct table2D {
   //int16_t *values16;
   //int16_t *axisX16;
 
-  //Store the last X and Y coordinates in the table. This is used to make the next check faster
+  // Store the upper index of the bin we last found. This is used to make the next check faster
+  // Since this is the *upper* index, it can never be 0.
   uint8_t lastXMax;
-  uint8_t lastXMin;
 
   //Store the last input and output for caching
   int16_t lastInput;

--- a/speeduino/unit_testing.h
+++ b/speeduino/unit_testing.h
@@ -31,3 +31,16 @@
 #else
 #define TESTABLE_INLINE_STATIC
 #endif
+
+#if !defined(UNIT_TEST) 
+/** 
+ * @brief Mark an entity with constexpr (giving it internal linkage), unless a unit
+ * test is in progress - then the entity is given external linkage so the test can access it.
+ * 
+ * Most useful for translation unit scoped variables. I.e. constexpr within a CPP file 
+ * 
+ */
+#define TESTABLE_CONSTEXPR constexpr 
+#else
+#define TESTABLE_CONSTEXPR
+#endif

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -69,7 +69,7 @@ static void test_corrections_WUE_active_value(void)
   setup_wue_table();
 
   //Force invalidate the cache
-  WUETable.cacheTime = currentStatus.secl - 1;
+  WUETable.cache.cacheTime = currentStatus.secl - 1;
   
   //Value should be midway between 120 and 130 = 125
   TEST_ASSERT_EQUAL(125, correctionWUE() );
@@ -1547,7 +1547,7 @@ static void test_corrections_correctionsFuel_ae_modes(void) {
   configPage4.dfcoRPM = 100;
   configPage4.wueBins[9] = 100;
   configPage2.wueValues[9] = 100; //Use a value other than 100 here to ensure we are using the non-default value
-  WUETable.cacheTime = currentStatus.secl - 1;
+  WUETable.cache.cacheTime = currentStatus.secl - 1;
 
   configPage4.floodClear = 100;
 

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -8,12 +8,9 @@
 #include "speeduino.h"
 #include "sensors_map_structs.h"
 
-extern void construct2dTables(void);
-
 extern byte correctionWUE(void);
 
 static void setup_wue_table(void) {
-  construct2dTables();
   initialiseCorrections();
 
   //Set some fake values in the table axis. Target value will fall between points 6 and 7
@@ -86,7 +83,6 @@ static void test_corrections_WUE(void)
 extern uint16_t correctionCranking(void);
 
 static void setup_correctionCranking_table(void) {
-  construct2dTables();
   initialiseCorrections();
 
   uint8_t values[] = { 120U / 5U, 130U / 5U, 140U / 5U, 150U / 5U };
@@ -100,7 +96,6 @@ static void setup_correctionCranking_table(void) {
 }
 
 static void test_corrections_cranking_inactive(void) {
-  construct2dTables();
   initialiseCorrections();
   BIT_CLEAR(currentStatus.engine, BIT_ENGINE_CRANK);
   BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ASE);
@@ -200,7 +195,6 @@ extern uint8_t correctionASE(void);
 
 static void test_corrections_ASE_inactive_cranking(void)
 {
-  construct2dTables();
   initialiseCorrections();
   BIT_SET(currentStatus.engine, BIT_ENGINE_CRANK);
 
@@ -210,7 +204,6 @@ static void test_corrections_ASE_inactive_cranking(void)
 }
 
 static inline void setup_correctionASE(void) {
-  construct2dTables();
   initialiseCorrections();
 
   BIT_CLEAR(currentStatus.engine, BIT_ENGINE_CRANK);
@@ -327,7 +320,6 @@ static void setup_valid_ego_cycle(void) {
 }
 
 static void setup_ego_simple(void) {
-  construct2dTables();
   initialiseCorrections();
 
   configPage6.egoType = EGO_TYPE_NARROW;
@@ -613,7 +605,6 @@ static void test_corrections_closedloop(void)
 uint8_t correctionFlex(void);
 
 static void setupFlexFuelTable(void) {
-  construct2dTables();
   initialiseCorrections();
 
   TEST_DATA_P uint8_t bins[] = { 0, 10, 30, 50, 60, 70 };
@@ -638,7 +629,6 @@ static void test_corrections_flex_flex_on(void) {
 uint8_t correctionFuelTemp(void);
 
 static void setupFuelTempTable(void) {
-  construct2dTables();
   initialiseCorrections();
 
   TEST_DATA_P uint8_t bins[] = { 0, 10, 30, 50, 60, 70 };
@@ -671,7 +661,6 @@ static void test_corrections_flex(void)
 uint8_t correctionBatVoltage(void);
 
 static void setup_battery_correction(void) {
-  construct2dTables();
   initialiseCorrections();
 
   TEST_DATA_P uint8_t bins[] = { 60, 70, 80, 90, 100, 110 };
@@ -742,7 +731,6 @@ extern bool correctionDFCO(void);
 
 static void setup_DFCO_on_taper_off_no_delay()
 {
-  construct2dTables();
   initialiseCorrections();
 
   //Sets all the required conditions to have the DFCO be active
@@ -948,7 +936,6 @@ static void reset_AE(void) {
 }
 
 static void setup_AE(void) {
-  construct2dTables();
   initialiseCorrections();
 
   //Divided by 100
@@ -1599,7 +1586,6 @@ static void test_corrections_correctionsFuel_ae_modes(void) {
 }
 
 static void test_corrections_correctionsFuel_clip_limit(void) {
-  construct2dTables();
   initialiseCorrections();
 
   populate_2dtable(&injectorVCorrectionTable, 255, 100);

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -9,6 +9,7 @@
 #include "sensors_map_structs.h"
 
 extern byte correctionWUE(void);
+extern table2D WUETable; ///< 10 bin Warm Up Enrichment map (2D)
 
 static void setup_wue_table(void) {
   initialiseCorrections();
@@ -81,6 +82,7 @@ static void test_corrections_WUE(void)
 }
 
 extern uint16_t correctionCranking(void);
+extern table2D crankingEnrichTable; ///< 4 bin cranking Enrichment map (2D)
 
 static void setup_correctionCranking_table(void) {
   initialiseCorrections();
@@ -202,6 +204,9 @@ static void test_corrections_ASE_inactive_cranking(void)
   TEST_ASSERT_EQUAL(100U, correctionASE());
   TEST_ASSERT_BIT_LOW(BIT_ENGINE_ASE, currentStatus.engine);
 }
+
+extern table2D ASETable; ///< 4 bin After Start Enrichment map (2D)
+extern table2D ASECountTable; ///< 4 bin After Start duration map (2D)
 
 static inline void setup_correctionASE(void) {
   initialiseCorrections();
@@ -603,6 +608,7 @@ static void test_corrections_closedloop(void)
 }
 
 uint8_t correctionFlex(void);
+extern table2D flexFuelTable;  ///< 6 bin flex fuel correction table for fuel adjustments (2D)
 
 static void setupFlexFuelTable(void) {
   initialiseCorrections();
@@ -627,6 +633,7 @@ static void test_corrections_flex_flex_on(void) {
 }
 
 uint8_t correctionFuelTemp(void);
+extern table2D fuelTempTable;  ///< 6 bin flex fuel correction table for fuel adjustments (2D)
 
 static void setupFuelTempTable(void) {
   initialiseCorrections();
@@ -659,6 +666,7 @@ static void test_corrections_flex(void)
 }
 
 uint8_t correctionBatVoltage(void);
+extern table2D injectorVCorrectionTable; ///< 6 bin injector voltage correction (2D)
 
 static void setup_battery_correction(void) {
   initialiseCorrections();
@@ -953,6 +961,8 @@ static void setup_AE(void) {
   reset_AE();
 }
 
+extern table2D taeTable; ///< 4 bin TPS Acceleration Enrichment map (2D)
+
 static void setup_TAE()
 {
   setup_AE();
@@ -1166,6 +1176,9 @@ extern map_last_read_t& getMapLast(void);
 
 //**********************************************************************************************************************
 //Setup a basic MAE enrichment curve, threshold etc that are common to all tests. Specifica values maybe updated in each individual test
+
+extern table2D maeTable;
+
 static void setup_MAE(void)
 {
   setup_AE();
@@ -1502,6 +1515,9 @@ extern byte correctionIATDensity(void);
 #endif
  
 extern byte correctionBaro(void);
+
+extern table2D IATDensityCorrectionTable; ///< 9 bin inlet air temperature density correction (2D)
+extern table2D baroFuelTable; ///< 8 bin baro correction curve (2D)
 
 static void test_corrections_correctionsFuel_ae_modes(void) {
   setup_TAE();

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -6,8 +6,6 @@
 #include "../test_utils.h"
 #include "sensors.h"
 
-extern void construct2dTables(void);
-
 extern int8_t correctionFixedTiming(int8_t advance);
 
 static void test_correctionFixedTiming_inactive(void) {
@@ -34,7 +32,6 @@ static void test_correctionFixedTiming(void) {
 extern int8_t correctionCLTadvance(int8_t advance);
 
 static void setup_clt_advance_table(void) {
-  construct2dTables();
   initialiseCorrections();
   TEST_DATA_P uint8_t bins[] = { 60, 70, 80, 90, 100, 110 };
   TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
@@ -99,7 +96,6 @@ static void test_correctionCrankingFixedTiming(void) {
 extern int8_t correctionFlexTiming(int8_t advance);
 
 static void setup_flexAdv(void) {
-  construct2dTables();
   initialiseCorrections();
   TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
   TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
@@ -136,7 +132,6 @@ static void test_correctionFlexTiming(void) {
 extern int8_t correctionWMITiming(int8_t advance);
 
 static void setup_WMIAdv(void) {
-    construct2dTables();
     initialiseCorrections();
 
     configPage10.wmiEnabled= 1;
@@ -238,7 +233,6 @@ static void test_correctionWMITiming(void) {
 extern int8_t correctionIATretard(int8_t advance);
 
 static void setup_IATRetard(void) {
-  construct2dTables();
   initialiseCorrections();
 
   TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
@@ -275,7 +269,6 @@ static void setup_idleadv_ctps(void) {
 }
 
 static void setup_correctionIdleAdvance(void) {
-    construct2dTables();
     initialiseCorrections();
 
     TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
@@ -412,7 +405,6 @@ static void test_correctionIdleAdvance(void) {
 extern int8_t correctionSoftRevLimit(int8_t advance);
 
 static void setup_correctionSoftRevLimit(void) {
-    construct2dTables();
     initialiseCorrections();
 
     configPage6.engineProtectType = PROTECT_CUT_IGN;
@@ -765,7 +757,6 @@ static void test_correctionKnock(void) {
 }
 
 static void setup_correctionsDwell(void) {
-    construct2dTables();
     initialiseCorrections();
     
     configPage4.sparkDur = 10;

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -30,6 +30,7 @@ static void test_correctionFixedTiming(void) {
 }
 
 extern int8_t correctionCLTadvance(int8_t advance);
+extern table2D CLTAdvanceTable; ///< 6 bin ignition adjustment based on coolant temperature  (2D)
 
 static void setup_clt_advance_table(void) {
   initialiseCorrections();
@@ -94,6 +95,7 @@ static void test_correctionCrankingFixedTiming(void) {
 }
 
 extern int8_t correctionFlexTiming(int8_t advance);
+extern table2D flexAdvTable;   ///< 6 bin flex fuel correction table for timing advance (2D)
 
 static void setup_flexAdv(void) {
   initialiseCorrections();
@@ -130,6 +132,7 @@ static void test_correctionFlexTiming(void) {
 }
 
 extern int8_t correctionWMITiming(int8_t advance);
+extern table2D wmiAdvTable; //6 bin wmi correction table for timing advance (2D)
 
 static void setup_WMIAdv(void) {
     initialiseCorrections();
@@ -231,6 +234,7 @@ static void test_correctionWMITiming(void) {
 }
 
 extern int8_t correctionIATretard(int8_t advance);
+extern table2D IATRetardTable; ///< 6 bin ignition adjustment based on inlet air temperature  (2D)
 
 static void setup_IATRetard(void) {
   initialiseCorrections();
@@ -267,6 +271,8 @@ static void setup_idleadv_ctps(void) {
     configPage2.idleAdvAlgorithm = IDLEADVANCE_ALGO_CTPS;
     currentStatus.CTPSActive = 1;
 }
+
+extern table2D idleAdvanceTable; ///< 6 bin idle advance adjustment table based on RPM difference  (2D)
 
 static void setup_correctionIdleAdvance(void) {
     initialiseCorrections();
@@ -755,6 +761,8 @@ static void test_correctionKnock_disabled_knockactive(void) {
 
 static void test_correctionKnock(void) {
 }
+
+extern table2D dwellVCorrectionTable; ///< 6 bin dwell voltage correction (2D)
 
 static void setup_correctionsDwell(void) {
     initialiseCorrections();

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -52,7 +52,7 @@ static void test_table2dLookup(table2D &table, TValue *data, TAxis *axis, uint8_
         char szMsg[128];
         sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.valueSize, table.axisSize, lookupValue, data[i], data[i+1], binFrac);
         TEST_ASSERT_INT_WITHIN_MESSAGE(1U, expected, result, szMsg);
-        TEST_ASSERT_EQUAL(i+1, table.lastXMax);
+        TEST_ASSERT_EQUAL(i+1, table.lastBinUpperIndex);
     }
 }
 

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -43,7 +43,7 @@ static void setup_test_subjects(void)
 }
 
 template <typename TValue, typename TAxis>
-static void test_table2dLookup(table2D &table, TValue *data, TAxis *axis, uint8_t binFrac)
+static void test_table2dLookup(const table2D &table, const TValue *data, const TAxis *axis, uint8_t binFrac)
 {
     for (uint8_t i=0; i<TEST_TABLE2D_SIZE-1U; ++i) {
         TAxis lookupValue = intermediate(axis[i], axis[i+1], binFrac);
@@ -93,15 +93,14 @@ static void test_table2dLookup_bin_66(void)
 }
 
 template <typename TValue, typename TAxis>
-static void test_table2dLookup_bin_edges(table2D &table, TValue *data, TAxis *axis) {
+static void test_table2dLookup_bin_edges(const table2D &table, const TValue *data, const TAxis *axis) {
     for (uint8_t i=0; i<TEST_TABLE2D_SIZE; ++i) {
         TValue result = (TValue)table2D_getValue(&table, axis[i]);
         char szMsg[64];
         sprintf(szMsg, "%d, %d lookup %d: %d", table.values.typeIndicator, table.axis.typeIndicator, i, axis[i]);
         TEST_ASSERT_EQUAL_MESSAGE(data[i], result, szMsg);
-        // sprintf(szMsg, "Index %d, lastBinUpperIndex: %d", i, table.lastBinUpperIndex);
-        // TEST_MESSAGE(szMsg);
-        // TEST_ASSERT_EQUAL_MESSAGE((i==0 || i==1) ? 1 : i+1, table.lastBinUpperIndex, szMsg);
+        sprintf(szMsg, "%d, %d lookup %d", table.values.typeIndicator, table.axis.typeIndicator, i);
+        TEST_ASSERT_EQUAL_MESSAGE(i==0  ? 1 : i, table.cache.lastBinUpperIndex, szMsg);
     }
 }
 
@@ -118,7 +117,7 @@ static void test_table2dLookup_bin_edges(void)
 }
 
 template <typename TValue, typename TAxis>
-static void test_table2dLookup_overMax(table2D &table, TValue *data, TAxis *axis) {
+static void test_table2dLookup_overMax(const table2D &table, const TValue *data, const TAxis *axis) {
     TValue result = (TValue)table2D_getValue(&table, axis[TEST_TABLE2D_SIZE-1]+1);
     TEST_ASSERT_EQUAL(data[TEST_TABLE2D_SIZE-1], result);
 }
@@ -136,9 +135,10 @@ static void test_table2dLookup_overMax(void)
 }
 
 template <typename TValue, typename TAxis>
-static void test_table2dLookup_underMin(table2D &table, TValue *data, TAxis *axis) {
+static void test_table2dLookup_underMin(const table2D &table, const TValue *data, const TAxis *axis) {
     TValue result = (TValue)table2D_getValue(&table, axis[0]-1);
     TEST_ASSERT_EQUAL(data[0], result);
+    TEST_ASSERT_EQUAL(1, table.cache.lastBinUpperIndex);
 }
 
 static void test_table2dLookup_underMin(void)

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -50,7 +50,7 @@ static void test_table2dLookup(table2D &table, TValue *data, TAxis *axis, uint8_
         TValue expected = map(lookupValue, axis[i], axis[i+1], data[i], data[i+1]);
         TValue result = (TValue)table2D_getValue(&table, lookupValue);
         char szMsg[128];
-        sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.valueSize, table.axisSize, lookupValue, data[i], data[i+1], binFrac);
+        sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.valueType, table.axisType, lookupValue, data[i], data[i+1], binFrac);
         TEST_ASSERT_INT_WITHIN_MESSAGE(1U, expected, result, szMsg);
         TEST_ASSERT_EQUAL(i+1, table.lastBinUpperIndex);
     }
@@ -97,7 +97,7 @@ static void test_table2dLookup_bin_edges(table2D &table, TValue *data, TAxis *ax
     for (uint8_t i=0; i<TEST_TABLE2D_SIZE; ++i) {
         TValue result = (TValue)table2D_getValue(&table, axis[i]);
         char szMsg[64];
-        sprintf(szMsg, "%d, %d lookup %d: %d", table.valueSize, table.axisSize, i, axis[i]);
+        sprintf(szMsg, "%d, %d lookup %d: %d", table.valueType, table.axisType, i, axis[i]);
         TEST_ASSERT_EQUAL_MESSAGE(data[i], result, szMsg);
         // sprintf(szMsg, "Index %d, lastBinUpperIndex: %d", i, table.lastBinUpperIndex);
         // TEST_MESSAGE(szMsg);

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -1,8 +1,5 @@
-#include <string.h> // memcpy
 #include <unity.h>
 #include <stdio.h>
-typedef uint8_t byte;
-#include "test_table2d.h"
 #include "table2d.h"
 #include "../test_utils.h"
 
@@ -11,128 +8,153 @@ static constexpr uint8_t TEST_TABLE2D_SIZE = 9;
 static uint8_t table2d_data_u8[TEST_TABLE2D_SIZE] = {
     251, 211, 199, 167, 127, 101, 59, 23, 5
 };
-static int16_t table2d_data_s16[TEST_TABLE2D_SIZE] = {
+static uint16_t table2d_data_u16[TEST_TABLE2D_SIZE] = {
     32029, 26357, 21323, 16363, 11329, 7537, 5531, 2539, 1237
+};
+static int16_t table2d_data_i16[TEST_TABLE2D_SIZE] = {
+    32029, 21323, 11329, 5531, 1237, -5531, -11329, -21323, -32029
 };
 
 static uint8_t table2d_axis_u8[TEST_TABLE2D_SIZE] {
     5, 23, 59, 101, 127, 167, 199, 211, 251,
 };
-static int16_t table2d_axis_s16[TEST_TABLE2D_SIZE] = {
+static int8_t table2d_axis_i8[TEST_TABLE2D_SIZE] {
+    -127, -101, -59, -5, 5, 23, 59, 101, 127
+};
+static uint16_t table2d_axis_u16[TEST_TABLE2D_SIZE] = {
     123, 2539, 5531, 7537, 11329, 16363, 21323, 26357, 32029,
 };
 
 static table2D table2d_u8_u8;
-static table2D table2d_u8_s16;
-static table2D table2d_s16_u8;
-static table2D table2d_s16_s16;
-
-template <typename dataT, typename axisT>
-void setup_test_subject(table2D &table, dataT *data, axisT *axis)
-{
-    table.valueSize = sizeof(dataT)*CHAR_BIT;
-    table.axisSize = sizeof(axisT)*CHAR_BIT;
-    table.xSize = TEST_TABLE2D_SIZE;
-    table.values = data;
-    table.axisX = axis;
-}
+static table2D table2d_u8_u16;
+static table2D table2d_u16_u8;
+static table2D table2d_u16_u16;
+static table2D table2d_u8_i8;
+static table2D table2d_i16_u8;
 
 static void setup_test_subjects(void)
 {
-    setup_test_subject(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
-    setup_test_subject(table2d_u8_s16, table2d_data_u8, table2d_axis_s16);
-    setup_test_subject(table2d_s16_u8, table2d_data_s16, table2d_axis_u8);
-    setup_test_subject(table2d_s16_s16, table2d_data_s16, table2d_axis_s16);
+    construct2dTable(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
+    construct2dTable(table2d_u8_u16, table2d_data_u8, table2d_axis_u16);
+    construct2dTable(table2d_u16_u8, table2d_data_u16, table2d_axis_u8);
+    construct2dTable(table2d_u16_u16, table2d_data_u16, table2d_axis_u16);
+    construct2dTable(table2d_u8_i8, table2d_data_u8, table2d_axis_i8);
+    construct2dTable(table2d_i16_u8, table2d_data_i16, table2d_axis_u8);
 }
 
+template <typename TValue, typename TAxis>
+static void test_table2dLookup(table2D &table, TValue *data, TAxis *axis, uint8_t binFrac)
+{
+    for (uint8_t i=0; i<TEST_TABLE2D_SIZE-1U; ++i) {
+        TAxis lookupValue = intermediate(axis[i], axis[i+1], binFrac);
+        TValue expected = map(lookupValue, axis[i], axis[i+1], data[i], data[i+1]);
+        TValue result = (TValue)table2D_getValue(&table, lookupValue);
+        char szMsg[128];
+        sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.valueSize, table.axisSize, lookupValue, data[i], data[i+1], binFrac);
+        TEST_ASSERT_INT_WITHIN_MESSAGE(1U, expected, result, szMsg);
+        TEST_ASSERT_EQUAL(i+1, table.lastXMax);
+    }
+}
 
-void test_table2dLookup_50pct(void)
+static void test_table2dLookup_bin_midpoints(void)
 {
     setup_test_subjects();
 
-    uint8_t u8_u8_result = table2D_getValue(&table2d_u8_u8, table2d_axis_u8[3]+((table2d_axis_u8[4]-table2d_axis_u8[3])/2));
-    TEST_ASSERT_EQUAL(147, u8_u8_result);
-    TEST_ASSERT_EQUAL(4, table2d_u8_u8.lastXMax);
-
-    uint8_t u8_s16_result = table2D_getValue(&table2d_u8_s16, table2d_axis_s16[6]+((table2d_axis_s16[7]-table2d_axis_s16[6])/2));
-    TEST_ASSERT_EQUAL(41, u8_s16_result);
-    TEST_ASSERT_EQUAL(7, table2d_u8_s16.lastXMax);
-
-    int16_t s16_u8_result = table2D_getValue(&table2d_s16_u8, table2d_axis_u8[3]+((table2d_axis_u8[4]-table2d_axis_u8[3])/2));
-    TEST_ASSERT_EQUAL(13846, s16_u8_result);
-    TEST_ASSERT_EQUAL(4, table2d_s16_u8.lastXMax);
-
-    int16_t s16_s16_result = table2D_getValue(&table2d_s16_s16, table2d_axis_s16[3]+((table2d_axis_s16[4]-table2d_axis_s16[3])/2));
-    TEST_ASSERT_EQUAL(13846, s16_s16_result);
-    TEST_ASSERT_EQUAL(4, table2d_s16_s16.lastXMax);
+    test_table2dLookup(table2d_u8_u8, table2d_data_u8, table2d_axis_u8, 50U);
+    test_table2dLookup(table2d_u8_u16, table2d_data_u8, table2d_axis_u16, 50U);
+    test_table2dLookup(table2d_u16_u8, table2d_data_u16, table2d_axis_u8, 50U);
+    test_table2dLookup(table2d_u16_u16, table2d_data_u16, table2d_axis_u16, 50U);
+    test_table2dLookup(table2d_u8_i8, table2d_data_u8, table2d_axis_i8, 50U);
+    test_table2dLookup(table2d_i16_u8, table2d_data_i16, table2d_axis_u8, 50U);    
 }
 
-
-void test_table2dLookup_exactAxis(void)
+static void test_table2dLookup_bin_33(void)
 {
     setup_test_subjects();
 
-    uint8_t u8_u8_result = table2D_getValue(&table2d_u8_u8, table2d_axis_u8[7]);
-    TEST_ASSERT_EQUAL(23, u8_u8_result);
-    // TEST_ASSERT_EQUAL(7, table2d_u8_u8.lastXMax);
-
-    uint8_t u8_s16_result = table2D_getValue(&table2d_u8_s16, table2d_axis_s16[1]);
-    TEST_ASSERT_EQUAL(211, u8_s16_result);
-    // TEST_ASSERT_EQUAL(7, table2d_u8_s16.lastXMax);
-
-    int16_t s16_u8_result = table2D_getValue(&table2d_s16_u8, table2d_axis_u8[2]);
-    TEST_ASSERT_EQUAL(21323, s16_u8_result);
-    // TEST_ASSERT_EQUAL(4, table2d_s16_u8.lastXMax);
-
-    int16_t s16_s16_result = table2D_getValue(&table2d_s16_s16, table2d_axis_s16[5]);
-    TEST_ASSERT_EQUAL(7537, s16_s16_result);
-    // TEST_ASSERT_EQUAL(4, table2d_s16_s16.lastXMax);    
+    test_table2dLookup(table2d_u8_u8, table2d_data_u8, table2d_axis_u8, 33U);
+    test_table2dLookup(table2d_u8_u16, table2d_data_u8, table2d_axis_u16, 33U);
+    test_table2dLookup(table2d_u16_u8, table2d_data_u16, table2d_axis_u8, 33U);
+    test_table2dLookup(table2d_u16_u16, table2d_data_u16, table2d_axis_u16, 33U);
+    test_table2dLookup(table2d_u8_i8, table2d_data_u8, table2d_axis_i8, 33U);
+    test_table2dLookup(table2d_i16_u8, table2d_data_i16, table2d_axis_u8, 33U);    
 }
 
-void test_table2dLookup_overMax(void)
+static void test_table2dLookup_bin_66(void)
 {
     setup_test_subjects();
 
-    uint8_t u8_u8_result = table2D_getValue(&table2d_u8_u8, table2d_axis_u8[TEST_TABLE2D_SIZE-1]+1);
-    TEST_ASSERT_EQUAL(5, u8_u8_result);
-    // TEST_ASSERT_EQUAL(8, table2d_u8_u8.lastXMax);
-
-    uint8_t u8_s16_result = table2D_getValue(&table2d_u8_s16, table2d_axis_s16[TEST_TABLE2D_SIZE-1]+1);
-    TEST_ASSERT_EQUAL(5, u8_s16_result);
-    // TEST_ASSERT_EQUAL(8, table2d_u8_s16.lastXMax);
-
-    int16_t s16_u8_result = table2D_getValue(&table2d_s16_u8, table2d_axis_u8[TEST_TABLE2D_SIZE-1]+1);
-    TEST_ASSERT_EQUAL(1237, s16_u8_result);
-    // TEST_ASSERT_EQUAL(8, table2d_s16_u8.lastXMax);
-
-    int16_t s16_s16_result = table2D_getValue(&table2d_s16_s16, table2d_axis_s16[TEST_TABLE2D_SIZE-1]+1);
-    TEST_ASSERT_EQUAL(1237, s16_s16_result);
-    // TEST_ASSERT_EQUAL(8, table2d_s16_s16.lastXMax);    
+    test_table2dLookup(table2d_u8_u8, table2d_data_u8, table2d_axis_u8, 66U);
+    test_table2dLookup(table2d_u8_u16, table2d_data_u8, table2d_axis_u16, 66U);
+    test_table2dLookup(table2d_u16_u8, table2d_data_u16, table2d_axis_u8, 66U);
+    test_table2dLookup(table2d_u16_u16, table2d_data_u16, table2d_axis_u16, 66U);
+    test_table2dLookup(table2d_u8_i8, table2d_data_u8, table2d_axis_i8, 66U);
+    test_table2dLookup(table2d_i16_u8, table2d_data_i16, table2d_axis_u8, 66U);    
 }
 
-void test_table2dLookup_underMin(void)
+template <typename TValue, typename TAxis>
+static void test_table2dLookup_bin_edges(table2D &table, TValue *data, TAxis *axis) {
+    for (uint8_t i=0; i<TEST_TABLE2D_SIZE; ++i) {
+        TValue result = (TValue)table2D_getValue(&table, axis[i]);
+        char szMsg[64];
+        sprintf(szMsg, "%d, %d lookup %d: %d", table.valueSize, table.axisSize, i, axis[i]);
+        TEST_ASSERT_EQUAL_MESSAGE(data[i], result, szMsg);
+        // sprintf(szMsg, "Index %d, lastBinUpperIndex: %d", i, table.lastBinUpperIndex);
+        // TEST_MESSAGE(szMsg);
+        // TEST_ASSERT_EQUAL_MESSAGE((i==0 || i==1) ? 1 : i+1, table.lastBinUpperIndex, szMsg);
+    }
+}
+
+static void test_table2dLookup_bin_edges(void)
 {
     setup_test_subjects();
 
-    uint8_t u8_u8_result = table2D_getValue(&table2d_u8_u8, table2d_axis_u8[0]-1);
-    TEST_ASSERT_EQUAL(251, u8_u8_result);
-    // TEST_ASSERT_EQUAL(0, table2d_u8_u8.lastXMax);
+    test_table2dLookup_bin_edges(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
+    test_table2dLookup_bin_edges(table2d_u8_u16, table2d_data_u8, table2d_axis_u16);
+    test_table2dLookup_bin_edges(table2d_u16_u8, table2d_data_u16, table2d_axis_u8);
+    test_table2dLookup_bin_edges(table2d_u16_u16, table2d_data_u16, table2d_axis_u16);
+    test_table2dLookup_bin_edges(table2d_u8_i8, table2d_data_u8, table2d_axis_i8);
+    test_table2dLookup_bin_edges(table2d_i16_u8, table2d_data_i16, table2d_axis_u8);   
+}
 
-    uint8_t u8_s16_result = table2D_getValue(&table2d_u8_s16, table2d_axis_s16[0]-1);
-    TEST_ASSERT_EQUAL(251, u8_s16_result);
-    // TEST_ASSERT_EQUAL(0, table2d_u8_s16.lastXMax);
+template <typename TValue, typename TAxis>
+static void test_table2dLookup_overMax(table2D &table, TValue *data, TAxis *axis) {
+    TValue result = (TValue)table2D_getValue(&table, axis[TEST_TABLE2D_SIZE-1]+1);
+    TEST_ASSERT_EQUAL(data[TEST_TABLE2D_SIZE-1], result);
+}
 
-    int16_t s16_u8_result = table2D_getValue(&table2d_s16_u8, table2d_axis_u8[0]-1);
-    TEST_ASSERT_EQUAL(32029, s16_u8_result);
-    // TEST_ASSERT_EQUAL(0, table2d_s16_u8.lastXMax);
+static void test_table2dLookup_overMax(void)
+{
+    setup_test_subjects();
 
-    int16_t s16_s16_result = table2D_getValue(&table2d_s16_s16, table2d_axis_s16[0]-1);
-    TEST_ASSERT_EQUAL(32029, s16_s16_result);
-    // TEST_ASSERT_EQUAL(0, table2d_s16_s16.lastXMax);       
+    test_table2dLookup_overMax(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
+    test_table2dLookup_overMax(table2d_u8_u16, table2d_data_u8, table2d_axis_u16);
+    test_table2dLookup_overMax(table2d_u16_u8, table2d_data_u16, table2d_axis_u8);
+    test_table2dLookup_overMax(table2d_u16_u16, table2d_data_u16, table2d_axis_u16);
+    test_table2dLookup_overMax(table2d_u8_i8, table2d_data_u8, table2d_axis_i8);
+    test_table2dLookup_overMax(table2d_i16_u8, table2d_data_i16, table2d_axis_u8); 
+}
+
+template <typename TValue, typename TAxis>
+static void test_table2dLookup_underMin(table2D &table, TValue *data, TAxis *axis) {
+    TValue result = (TValue)table2D_getValue(&table, axis[0]-1);
+    TEST_ASSERT_EQUAL(data[0], result);
+}
+
+static void test_table2dLookup_underMin(void)
+{
+    setup_test_subjects();
+
+    test_table2dLookup_underMin(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
+    test_table2dLookup_underMin(table2d_u8_u16, table2d_data_u8, table2d_axis_u16);
+    test_table2dLookup_underMin(table2d_u16_u8, table2d_data_u16, table2d_axis_u8);
+    test_table2dLookup_underMin(table2d_u16_u16, table2d_data_u16, table2d_axis_u16);
+    test_table2dLookup_underMin(table2d_u8_i8, table2d_data_u8, table2d_axis_i8);
+    test_table2dLookup_underMin(table2d_i16_u8, table2d_data_i16, table2d_axis_u8);      
 }
 
 
-void test_table2d_all_decrementing(void)
+static void test_table2d_all_decrementing(void)
 {
     setup_test_subjects();
 
@@ -146,14 +168,42 @@ void test_table2d_all_decrementing(void)
 }
 
 
+#include "../timer.hpp"
+
+
+static void test_lookup_perf(void) {
+    uint16_t iters = 1000;
+    uint8_t start_index = 0;
+    uint8_t end_index = TEST_TABLE2D_SIZE-1U;
+    uint8_t step = 1;
+
+    timer timerA;
+    uint32_t paramA = 0;
+    auto nativeTest = [] (uint8_t index, uint32_t &checkSum) { 
+        checkSum += table2D_getValue(&table2d_u8_u8, (uint8_t)(table2d_axis_u8[index]+1));
+    };
+    measure_executiontime<uint8_t, uint32_t&>(iters, start_index, end_index, step, timerA, paramA, nativeTest);
+
+    // The checksums will be different due to rounding. This is only
+    // here to force the compiler to run the loops above
+    TEST_ASSERT_INT32_WITHIN(UINT32_MAX/2, UINT32_MAX/2, paramA);
+
+    char buffer[128];
+    sprintf(buffer, "Timing: %" PRIu32, timerA.duration_micros());
+    TEST_MESSAGE(buffer);
+
+}
+
 void testTable2d()
 {
   SET_UNITY_FILENAME() {
-
-    RUN_TEST(test_table2dLookup_50pct);
-    RUN_TEST(test_table2dLookup_exactAxis);
     RUN_TEST(test_table2dLookup_overMax);
     RUN_TEST(test_table2dLookup_underMin);
     RUN_TEST(test_table2d_all_decrementing); 
+    RUN_TEST(test_table2dLookup_bin_midpoints);
+    RUN_TEST(test_table2dLookup_bin_33);
+    RUN_TEST(test_table2dLookup_bin_66);
+    RUN_TEST(test_table2dLookup_bin_edges);
+    RUN_TEST(test_lookup_perf);
   }
 }

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -52,7 +52,7 @@ static void test_table2dLookup(table2D &table, TValue *data, TAxis *axis, uint8_
         char szMsg[128];
         sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.valueType, table.axisType, lookupValue, data[i], data[i+1], binFrac);
         TEST_ASSERT_INT_WITHIN_MESSAGE(1U, expected, result, szMsg);
-        TEST_ASSERT_EQUAL(i+1, table.lastBinUpperIndex);
+        TEST_ASSERT_EQUAL(i+1, table.cache.lastBinUpperIndex);
     }
 }
 

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -50,7 +50,7 @@ static void test_table2dLookup(table2D &table, TValue *data, TAxis *axis, uint8_
         TValue expected = map(lookupValue, axis[i], axis[i+1], data[i], data[i+1]);
         TValue result = (TValue)table2D_getValue(&table, lookupValue);
         char szMsg[128];
-        sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.valueType, table.axisType, lookupValue, data[i], data[i+1], binFrac);
+        sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.values.typeIndicator, table.axis.typeIndicator, lookupValue, data[i], data[i+1], binFrac);
         TEST_ASSERT_INT_WITHIN_MESSAGE(1U, expected, result, szMsg);
         TEST_ASSERT_EQUAL(i+1, table.cache.lastBinUpperIndex);
     }
@@ -97,7 +97,7 @@ static void test_table2dLookup_bin_edges(table2D &table, TValue *data, TAxis *ax
     for (uint8_t i=0; i<TEST_TABLE2D_SIZE; ++i) {
         TValue result = (TValue)table2D_getValue(&table, axis[i]);
         char szMsg[64];
-        sprintf(szMsg, "%d, %d lookup %d: %d", table.valueType, table.axisType, i, axis[i]);
+        sprintf(szMsg, "%d, %d lookup %d: %d", table.values.typeIndicator, table.axis.typeIndicator, i, axis[i]);
         TEST_ASSERT_EQUAL_MESSAGE(data[i], result, szMsg);
         // sprintf(szMsg, "Index %d, lastBinUpperIndex: %d", i, table.lastBinUpperIndex);
         // TEST_MESSAGE(szMsg);

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -25,22 +25,13 @@ static uint16_t table2d_axis_u16[TEST_TABLE2D_SIZE] = {
     123, 2539, 5531, 7537, 11329, 16363, 21323, 26357, 32029,
 };
 
-static table2D table2d_u8_u8;
-static table2D table2d_u8_u16;
-static table2D table2d_u16_u8;
-static table2D table2d_u16_u16;
-static table2D table2d_u8_i8;
-static table2D table2d_i16_u8;
+static table2D table2d_u8_u8(_countof(table2d_data_u8), table2d_data_u8, table2d_axis_u8);
+static table2D table2d_u8_u16(_countof(table2d_data_u8), table2d_data_u8, table2d_axis_u16);
+static table2D table2d_u16_u8(_countof(table2d_data_u16), table2d_data_u16, table2d_axis_u8);
+static table2D table2d_u16_u16(_countof(table2d_data_u16), table2d_data_u16, table2d_axis_u16);
+static table2D table2d_u8_i8(_countof(table2d_data_u8), table2d_data_u8, table2d_axis_i8);
+static table2D table2d_i16_u8(_countof(table2d_data_i16), table2d_data_i16, table2d_axis_u8);
 
-static void setup_test_subjects(void)
-{
-    construct2dTable(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
-    construct2dTable(table2d_u8_u16, table2d_data_u8, table2d_axis_u16);
-    construct2dTable(table2d_u16_u8, table2d_data_u16, table2d_axis_u8);
-    construct2dTable(table2d_u16_u16, table2d_data_u16, table2d_axis_u16);
-    construct2dTable(table2d_u8_i8, table2d_data_u8, table2d_axis_i8);
-    construct2dTable(table2d_i16_u8, table2d_data_i16, table2d_axis_u8);
-}
 
 template <typename TValue, typename TAxis>
 static void test_table2dLookup(const table2D &table, const TValue *data, const TAxis *axis, uint8_t binFrac)
@@ -50,7 +41,7 @@ static void test_table2dLookup(const table2D &table, const TValue *data, const T
         TValue expected = map(lookupValue, axis[i], axis[i+1], data[i], data[i+1]);
         TValue result = (TValue)table2D_getValue(&table, lookupValue);
         char szMsg[128];
-        sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.values.typeIndicator, table.axis.typeIndicator, lookupValue, data[i], data[i+1], binFrac);
+        sprintf(szMsg, "Loop: %d, VT %d, AT %d lookup: %d, data[i]: %d, data[i+1]: %d, binFrac %d", i, table.values.type, table.axis.type, lookupValue, data[i], data[i+1], binFrac);
         TEST_ASSERT_INT_WITHIN_MESSAGE(1U, expected, result, szMsg);
         TEST_ASSERT_EQUAL(i+1, table.cache.lastBinUpperIndex);
     }
@@ -58,8 +49,6 @@ static void test_table2dLookup(const table2D &table, const TValue *data, const T
 
 static void test_table2dLookup_bin_midpoints(void)
 {
-    setup_test_subjects();
-
     test_table2dLookup(table2d_u8_u8, table2d_data_u8, table2d_axis_u8, 50U);
     test_table2dLookup(table2d_u8_u16, table2d_data_u8, table2d_axis_u16, 50U);
     test_table2dLookup(table2d_u16_u8, table2d_data_u16, table2d_axis_u8, 50U);
@@ -70,8 +59,6 @@ static void test_table2dLookup_bin_midpoints(void)
 
 static void test_table2dLookup_bin_33(void)
 {
-    setup_test_subjects();
-
     test_table2dLookup(table2d_u8_u8, table2d_data_u8, table2d_axis_u8, 33U);
     test_table2dLookup(table2d_u8_u16, table2d_data_u8, table2d_axis_u16, 33U);
     test_table2dLookup(table2d_u16_u8, table2d_data_u16, table2d_axis_u8, 33U);
@@ -82,8 +69,6 @@ static void test_table2dLookup_bin_33(void)
 
 static void test_table2dLookup_bin_66(void)
 {
-    setup_test_subjects();
-
     test_table2dLookup(table2d_u8_u8, table2d_data_u8, table2d_axis_u8, 66U);
     test_table2dLookup(table2d_u8_u16, table2d_data_u8, table2d_axis_u16, 66U);
     test_table2dLookup(table2d_u16_u8, table2d_data_u16, table2d_axis_u8, 66U);
@@ -97,17 +82,15 @@ static void test_table2dLookup_bin_edges(const table2D &table, const TValue *dat
     for (uint8_t i=0; i<TEST_TABLE2D_SIZE; ++i) {
         TValue result = (TValue)table2D_getValue(&table, axis[i]);
         char szMsg[64];
-        sprintf(szMsg, "%d, %d lookup %d: %d", table.values.typeIndicator, table.axis.typeIndicator, i, axis[i]);
+        sprintf(szMsg, "%d, %d lookup %d: %d", table.values.type, table.axis.type, i, axis[i]);
         TEST_ASSERT_EQUAL_MESSAGE(data[i], result, szMsg);
-        sprintf(szMsg, "%d, %d lookup %d", table.values.typeIndicator, table.axis.typeIndicator, i);
+        sprintf(szMsg, "%d, %d lookup %d", table.values.type, table.axis.type, i);
         TEST_ASSERT_EQUAL_MESSAGE(i==0  ? 1 : i, table.cache.lastBinUpperIndex, szMsg);
     }
 }
 
 static void test_table2dLookup_bin_edges(void)
 {
-    setup_test_subjects();
-
     test_table2dLookup_bin_edges(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
     test_table2dLookup_bin_edges(table2d_u8_u16, table2d_data_u8, table2d_axis_u16);
     test_table2dLookup_bin_edges(table2d_u16_u8, table2d_data_u16, table2d_axis_u8);
@@ -124,8 +107,6 @@ static void test_table2dLookup_overMax(const table2D &table, const TValue *data,
 
 static void test_table2dLookup_overMax(void)
 {
-    setup_test_subjects();
-
     test_table2dLookup_overMax(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
     test_table2dLookup_overMax(table2d_u8_u16, table2d_data_u8, table2d_axis_u16);
     test_table2dLookup_overMax(table2d_u16_u8, table2d_data_u16, table2d_axis_u8);
@@ -143,8 +124,6 @@ static void test_table2dLookup_underMin(const table2D &table, const TValue *data
 
 static void test_table2dLookup_underMin(void)
 {
-    setup_test_subjects();
-
     test_table2dLookup_underMin(table2d_u8_u8, table2d_data_u8, table2d_axis_u8);
     test_table2dLookup_underMin(table2d_u8_u16, table2d_data_u8, table2d_axis_u16);
     test_table2dLookup_underMin(table2d_u16_u8, table2d_data_u16, table2d_axis_u8);
@@ -156,8 +135,6 @@ static void test_table2dLookup_underMin(void)
 
 static void test_table2d_all_decrementing(void)
 {
-    setup_test_subjects();
-
     uint8_t u8_u8_result_last = UINT8_MAX;
     for (uint8_t loop=table2d_axis_u8[0]; loop<=table2d_axis_u8[TEST_TABLE2D_SIZE-1]; ++loop)
     {

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -8,7 +8,8 @@
 #include <unity.h>
 #include "table2d.h"
 #include "table3d.h"
-
+#include "maths.h"
+#
 template<size_t MAX_LEN, size_t N>
 constexpr void STR_LEN_CHECK(char const (&)[N]) 
 {
@@ -160,4 +161,11 @@ static inline void populate_2dtable_P(table2D *pTable, const TValue values[], co
 #endif
 }
 
-void populateTable(table3d16RpmLoad &table, const table3d_value_t values[], const table3d_axis_t xAxis[], const table3d_axis_t yAxis[]);
+template <typename T>
+T intermediate(T const& min, T const& max, uint8_t const& frac)
+{
+  if (max<min) {
+    return min - percentage(frac, (min - max));
+  }
+  return min + percentage(frac, (max - min));
+}

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -134,7 +134,7 @@ static inline void populate_table_P(table3d_t &table,
 
 // Populate a 2d table with constant values
 static inline void populate_2dtable(table2D *pTable, uint8_t value, uint8_t bin) {
-  for (uint8_t index=0; index<pTable->xSize; ++index) {
+  for (uint8_t index=0; index<pTable->length; ++index) {
     ((uint8_t*)pTable->values)[index] = value;
     ((uint8_t*)pTable->axisX)[index] = bin;
   }
@@ -143,8 +143,8 @@ static inline void populate_2dtable(table2D *pTable, uint8_t value, uint8_t bin)
 
 template <typename TValue, typename TBin>
 static inline void populate_2dtable(table2D *pTable, const TValue values[], const TBin bins[]) {
-  memcpy(pTable->axisX, bins, pTable->xSize * sizeof(TBin));
-  memcpy(pTable->values, values, pTable->xSize * sizeof(TValue));
+  memcpy(pTable->axisX, bins, pTable->length * sizeof(TBin));
+  memcpy(pTable->values, values, pTable->length * sizeof(TValue));
   pTable->cacheTime = UINT8_MAX;
 }
 
@@ -153,8 +153,8 @@ static inline void populate_2dtable(table2D *pTable, const TValue values[], cons
 template <typename TValue, typename TBin>
 static inline void populate_2dtable_P(table2D *pTable, const TValue values[], const TBin bins[]) {
 #if defined(PROGMEM)
-  memcpy_P(pTable->axisX, bins, pTable->xSize * sizeof(TBin));
-  memcpy_P(pTable->values, values, pTable->xSize * sizeof(TValue));
+  memcpy_P(pTable->axisX, bins, pTable->length * sizeof(TBin));
+  memcpy_P(pTable->values, values, pTable->length * sizeof(TValue));
   pTable->cacheTime = UINT8_MAX;
 #else
   populate_2dtable(pTable, values, bins)

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -138,14 +138,14 @@ static inline void populate_2dtable(table2D *pTable, uint8_t value, uint8_t bin)
     ((uint8_t*)pTable->values)[index] = value;
     ((uint8_t*)pTable->axisX)[index] = bin;
   }
-  pTable->cacheTime = UINT8_MAX;
+  pTable->cache.cacheTime = UINT8_MAX;
 }
 
 template <typename TValue, typename TBin>
 static inline void populate_2dtable(table2D *pTable, const TValue values[], const TBin bins[]) {
   memcpy(pTable->axisX, bins, pTable->length * sizeof(TBin));
   memcpy(pTable->values, values, pTable->length * sizeof(TValue));
-  pTable->cacheTime = UINT8_MAX;
+  pTable->cache.cacheTime = UINT8_MAX;
 }
 
 // Populate a 2d table (from PROGMEM if available)
@@ -155,7 +155,7 @@ static inline void populate_2dtable_P(table2D *pTable, const TValue values[], co
 #if defined(PROGMEM)
   memcpy_P(pTable->axisX, bins, pTable->length * sizeof(TBin));
   memcpy_P(pTable->values, values, pTable->length * sizeof(TValue));
-  pTable->cacheTime = UINT8_MAX;
+  pTable->cache.cacheTime = UINT8_MAX;
 #else
   populate_2dtable(pTable, values, bins)
 #endif

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -135,16 +135,16 @@ static inline void populate_table_P(table3d_t &table,
 // Populate a 2d table with constant values
 static inline void populate_2dtable(table2D *pTable, uint8_t value, uint8_t bin) {
   for (uint8_t index=0; index<pTable->length; ++index) {
-    ((uint8_t*)pTable->values)[index] = value;
-    ((uint8_t*)pTable->axisX)[index] = bin;
+    ((uint8_t*)pTable->values.data)[index] = value;
+    ((uint8_t*)pTable->axis.data)[index] = bin;
   }
   pTable->cache.cacheTime = UINT8_MAX;
 }
 
 template <typename TValue, typename TBin>
 static inline void populate_2dtable(table2D *pTable, const TValue values[], const TBin bins[]) {
-  memcpy(pTable->axisX, bins, pTable->length * sizeof(TBin));
-  memcpy(pTable->values, values, pTable->length * sizeof(TValue));
+  memcpy(pTable->axis.data, bins, pTable->length * sizeof(TBin));
+  memcpy(pTable->values.data, values, pTable->length * sizeof(TValue));
   pTable->cache.cacheTime = UINT8_MAX;
 }
 
@@ -153,8 +153,8 @@ static inline void populate_2dtable(table2D *pTable, const TValue values[], cons
 template <typename TValue, typename TBin>
 static inline void populate_2dtable_P(table2D *pTable, const TValue values[], const TBin bins[]) {
 #if defined(PROGMEM)
-  memcpy_P(pTable->axisX, bins, pTable->length * sizeof(TBin));
-  memcpy_P(pTable->values, values, pTable->length * sizeof(TValue));
+  memcpy_P(pTable->axis.data, bins, pTable->length * sizeof(TBin));
+  memcpy_P(pTable->values.data, values, pTable->length * sizeof(TValue));
   pTable->cache.cacheTime = UINT8_MAX;
 #else
   populate_2dtable(pTable, values, bins)

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -143,8 +143,8 @@ static inline void populate_2dtable(table2D *pTable, uint8_t value, uint8_t bin)
 
 template <typename TValue, typename TBin>
 static inline void populate_2dtable(table2D *pTable, const TValue values[], const TBin bins[]) {
-  memcpy(pTable->axis.data, bins, pTable->length * sizeof(TBin));
-  memcpy(pTable->values.data, values, pTable->length * sizeof(TValue));
+  memcpy(const_cast<void*>(pTable->axis.data), bins, pTable->length * sizeof(TBin));
+  memcpy(const_cast<void*>(pTable->values.data), values, pTable->length * sizeof(TValue));
   pTable->cache.cacheTime = UINT8_MAX;
 }
 
@@ -153,8 +153,8 @@ static inline void populate_2dtable(table2D *pTable, const TValue values[], cons
 template <typename TValue, typename TBin>
 static inline void populate_2dtable_P(table2D *pTable, const TValue values[], const TBin bins[]) {
 #if defined(PROGMEM)
-  memcpy_P(pTable->axis.data, bins, pTable->length * sizeof(TBin));
-  memcpy_P(pTable->values.data, values, pTable->length * sizeof(TValue));
+  memcpy_P(const_cast<void*>(pTable->axis.data), bins, pTable->length * sizeof(TBin));
+  memcpy_P(const_cast<void*>(pTable->values.data), values, pTable->length * sizeof(TValue));
   pTable->cache.cacheTime = UINT8_MAX;
 #else
   populate_2dtable(pTable, values, bins)


### PR DESCRIPTION
1. Optimise the size of `table2D` struct: use smallest possible types, delete unnecessary members
2. Constexpr construct `table2D` and it's members.

Total of 132 bytes of memory saved (plus a small performance boost).