### PR TITLE
[STM32] Do protection check on all pins

### DIFF
--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2824,7 +2824,7 @@ void setPinMapping(byte boardID)
   if(ignitionOutputControl == OUTPUT_CONTROL_DIRECT)
   {
     #if defined(CORE_STM32)
-    //Protect against wrong board layout selection, set pin to itsef to force a protection check
+    //Protect against wrong board layout selection, set pin to itself to force a protection check
     pinOutputReassign(pinCoil1, pinCoil1);
     pinOutputReassign(pinCoil2, pinCoil2);
     pinOutputReassign(pinCoil3, pinCoil3);
@@ -2881,7 +2881,7 @@ void setPinMapping(byte boardID)
   if(injectorOutputControl == OUTPUT_CONTROL_DIRECT)
   {
     #if defined(CORE_STM32)
-    //Protect against wrong board layout selection, set pin to itsef to force a protection check
+    //Protect against wrong board layout selection, set pin to itself to force a protection check
     pinOutputReassign(pinInjector1, pinInjector1);
     pinOutputReassign(pinInjector2, pinInjector2);
     pinOutputReassign(pinInjector3, pinInjector3);
@@ -3073,7 +3073,7 @@ void setPinMapping(byte boardID)
   }  
 
   #if defined(CORE_STM32)
-  //Protect against wrong board layout selection, set pin to itsef to force a protection check
+  //Protect against wrong board layout selection, set pin to itself to force a protection check
   pinInputReassign(pinTrigger, pinTrigger);
   pinInputReassign(pinTrigger2, pinTrigger2);
   pinInputReassign(pinTrigger3, pinTrigger3);

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2823,6 +2823,26 @@ void setPinMapping(byte boardID)
 
   if(ignitionOutputControl == OUTPUT_CONTROL_DIRECT)
   {
+    #if defined(CORE_STM32)
+    //Protect against wrong board layout selection, set pin to itsef to force a protection check
+    pinOutputReassign(pinCoil1, pinCoil1);
+    pinOutputReassign(pinCoil2, pinCoil2);
+    pinOutputReassign(pinCoil3, pinCoil3);
+    pinOutputReassign(pinCoil4, pinCoil4);
+    #if (IGN_CHANNELS >= 5)
+    pinOutputReassign(pinCoil5, pinCoil5);
+    #endif
+    #if (IGN_CHANNELS >= 6)
+    pinOutputReassign(pinCoil6, pinCoil6);
+    #endif
+    #if (IGN_CHANNELS >= 7)
+    pinOutputReassign(pinCoil7, pinCoil7);
+    #endif
+    #if (IGN_CHANNELS >= 8)
+    pinOutputReassign(pinCoil8, pinCoil8);
+    #endif
+    #endif /* CORE_STM32 */
+
     pinMode(pinCoil1, OUTPUT);
     pinMode(pinCoil2, OUTPUT);
     pinMode(pinCoil3, OUTPUT);
@@ -2860,6 +2880,26 @@ void setPinMapping(byte boardID)
 
   if(injectorOutputControl == OUTPUT_CONTROL_DIRECT)
   {
+    #if defined(CORE_STM32)
+    //Protect against wrong board layout selection, set pin to itsef to force a protection check
+    pinOutputReassign(pinInjector1, pinInjector1);
+    pinOutputReassign(pinInjector2, pinInjector2);
+    pinOutputReassign(pinInjector3, pinInjector3);
+    pinOutputReassign(pinInjector4, pinInjector4);
+    #if (INJ_CHANNELS >= 5)
+    pinOutputReassign(pinInjector5, pinInjector5);
+    #endif
+    #if (INJ_CHANNELS >= 6)
+    pinOutputReassign(pinInjector6, pinInjector6);
+    #endif
+    #if (INJ_CHANNELS >= 7)
+    pinOutputReassign(pinInjector7, pinInjector7);
+    #endif
+    #if (INJ_CHANNELS >= 8)
+    pinOutputReassign(pinInjector8, pinInjector8);
+    #endif
+    #endif /* CORE_STM32 */
+
     pinMode(pinInjector1, OUTPUT);
     pinMode(pinInjector2, OUTPUT);
     pinMode(pinInjector3, OUTPUT);
@@ -3032,6 +3072,12 @@ void setPinMapping(byte boardID)
     pinMode(pinAirConFan, OUTPUT);
   }  
 
+  #if defined(CORE_STM32)
+  //Protect against wrong board layout selection, set pin to itsef to force a protection check
+  pinInputReassign(pinTrigger, pinTrigger);
+  pinInputReassign(pinTrigger2, pinTrigger2);
+  pinInputReassign(pinTrigger3, pinTrigger3);
+  #endif /* CORE_STM32 */
   //These must come after the above pinMode statements
   triggerPri_pin_port = portInputRegister(digitalPinToPort(pinTrigger));
   triggerPri_pin_mask = digitalPinToBitMask(pinTrigger);


### PR DESCRIPTION
As STM32 peripherals(IE USB/UART) pins are in user selectable range selecting wrong board layout can either stop communications or just cause a dead lock, this adds a check only for STM32 for all pins I remembered and tested that can introduce the bug.

Tested using NO2C layout, but the issue can happen on any board layout which uses pin 21(USB D- on F407) or any protected pins available at board_stm32_official.h@L135.

This affect only STM32.