### PR TITLE
Fix 1283

### DIFF
--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -466,17 +466,8 @@ TESTABLE_INLINE_STATIC bool eventAverageMAPReading(const statuses &current, cons
   return instanteneousMAPReading();
 }
 
-
-TESTABLE_INLINE_STATIC uint16_t validateFilterMapSensorReading(uint16_t reading, uint8_t alpha, uint16_t prior) {
-  //Error check
-  if (isValidMapSensorReading(reading)) { 
-    return LOW_PASS_FILTER(reading, alpha, prior);
-  }
-  return prior;
-}
-
 static inline uint16_t readFilteredMapADC(uint8_t pin, uint8_t alpha, uint16_t prior) {
-  return validateFilterMapSensorReading(readMAPSensor(pin), alpha, prior);
+  return LOW_PASS_FILTER(readMAPSensor(pin), alpha, prior);
 }
 
 static inline map_adc_readings_t readMapSensors(const map_adc_readings_t &previousReadings, const config4 &page4, bool useEMAP) {

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -493,7 +493,7 @@ static inline uint16_t mapADCToMAP(uint16_t mapADC, int8_t mapMin, uint16_t mapM
   return max((int16_t)0, mapped);  //Sanity check
 }
 
-static inline void setMAPValuesFromReadings(const map_adc_readings_t &readings, const config2 &page2, bool useEMAP, statuses &current) 
+TESTABLE_INLINE_STATIC void setMAPValuesFromReadings(const map_adc_readings_t &readings, const config2 &page2, bool useEMAP, statuses &current) 
 {
   current.MAP = mapADCToMAP(readings.mapADC, page2.mapMin, page2.mapMax); //Get the current MAP value
   //Repeat for EMAP if it's enabled

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -247,6 +247,15 @@ void initialiseADC(void)
 static constexpr uint16_t VALID_MAP_MAX=1022U; //The largest ADC value that is valid for the MAP sensor
 static constexpr uint16_t VALID_MAP_MIN=2U; //The smallest ADC value that is valid for the MAP sensor
 
+static inline bool isValidMapSensorReading(uint16_t reading) {
+  return (reading < VALID_MAP_MAX) && (reading > VALID_MAP_MIN);  
+}
+
+TESTABLE_INLINE_STATIC bool isValidMapSensorReadings(const map_adc_readings_t &sensorReadings) {
+  return isValidMapSensorReading(sensorReadings.mapADC)
+  && (sensorReadings.emapADC == UINT16_MAX || isValidMapSensorReading(sensorReadings.emapADC));
+}
+
 TESTABLE_INLINE_STATIC bool instanteneousMAPReading(void)
 {
   // All we need to do it signal that the new readings should be used as-is
@@ -440,9 +449,6 @@ TESTABLE_INLINE_STATIC bool eventAverageMAPReading(const statuses &current, cons
   return instanteneousMAPReading();
 }
 
-static inline bool isValidMapSensorReading(uint16_t reading) {
-  return (reading < VALID_MAP_MAX) && (reading > VALID_MAP_MIN);  
-}
 
 TESTABLE_INLINE_STATIC uint16_t validateFilterMapSensorReading(uint16_t reading, uint8_t alpha, uint16_t prior) {
   //Error check

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -349,8 +349,13 @@ static inline bool cycleMinimumAccumulate(map_cycle_min_t &cycle_min, const map_
 }
 
 static inline void reset(const statuses &current, map_cycle_min_t &cycle_min, const map_adc_readings_t &sensorReadings) {
-  cycle_min.cycleStartIndex = (uint8_t)current.startRevolutions; //Reset the current rev count
-  cycle_min.mapMinimum = sensorReadings.mapADC; //Reset the latest value so the next reading will always be lower
+  if (isValidMapSensorReading(sensorReadings.mapADC)) {
+    cycle_min.cycleStartIndex = (uint8_t)current.startRevolutions; //Reset the current rev count
+    cycle_min.mapMinimum = sensorReadings.mapADC; //Reset the latest value so the next reading will always be lower
+  } else {
+    cycle_min.cycleStartIndex = 0U;
+    cycle_min.mapMinimum = UINT16_MAX;
+  }
 }
 
 static inline bool cycleMinimumEndCycle(const statuses &current, map_cycle_min_t &cycle_min, map_adc_readings_t &sensorReadings) {
@@ -370,7 +375,7 @@ static inline bool isCycleCurrent(const statuses &current, const map_cycle_min_t
 }
 
 TESTABLE_INLINE_STATIC bool cycleMinimumMAPReading(const statuses &current, const config2 &page2, map_cycle_min_t &cycle_min, map_adc_readings_t &sensorReadings) {
-  if (current.RPMdiv100 > page2.mapSwitchPoint) {
+  if ((current.RPMdiv100 > page2.mapSwitchPoint) && isValidMapSensorReadings(sensorReadings)) {
     //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
     if ( isCycleCurrent(current, cycle_min) ) {
       return cycleMinimumAccumulate(cycle_min, sensorReadings);

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -276,7 +276,9 @@ static inline void reset(const statuses &current, map_cycle_average_t &cycle_ave
   cycle_average.mapAdcRunningTotal = 0U;
   cycle_average.emapAdcRunningTotal = 0U;
   cycle_average.cycleStartIndex = (uint8_t)current.startRevolutions;
-  (void)cycleAverageMAPReadingAccumulate(cycle_average, sensorReadings);
+  if (isValidMapSensorReadings(sensorReadings)) {
+    (void)cycleAverageMAPReadingAccumulate(cycle_average, sensorReadings);
+  }
 }
 
 static inline bool cycleAverageEndCycle(const statuses &current, map_cycle_average_t &cycle_average, map_adc_readings_t &sensorReadings) {
@@ -312,15 +314,18 @@ static inline bool isCycleCurrent(const statuses &current, const map_cycle_avera
   return isCycleCurrent(current, cycle_avg.cycleStartIndex);
 }
 
-TESTABLE_INLINE_STATIC bool canUseCycleAverage(const statuses &current, const config2 &page2) {
+TESTABLE_INLINE_STATIC bool canUseCycleAverage(const statuses &current, const config2 &page2, const map_adc_readings_t &sensorReadings) {
   ATOMIC() {
-    return (current.RPMdiv100 > page2.mapSwitchPoint) && HasAnySyncUnsafe(current) && (current.startRevolutions > 1U);
+    return (current.RPMdiv100 > page2.mapSwitchPoint) 
+      && HasAnySyncUnsafe(current) 
+      && (current.startRevolutions > 1U)
+      && isValidMapSensorReadings(sensorReadings);
   }
   return false; // Just here to avoid compiler warning.
 }
 
 TESTABLE_INLINE_STATIC bool cycleAverageMAPReading(const statuses &current, const config2 &page2, map_cycle_average_t &cycle_average, map_adc_readings_t &sensorReadings) {
-  if ( canUseCycleAverage(current, page2) )
+  if ( canUseCycleAverage(current, page2, sensorReadings) )
   {
     //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
     if( isCycleCurrent(current, cycle_average) ) {

--- a/test/test_sensors/test_map_sampling.cpp
+++ b/test/test_sensors/test_map_sampling.cpp
@@ -375,15 +375,6 @@ static void test_eventAverageMAPReading_nosamples(void) {
   TEST_ASSERT_EQUAL_UINT(test_data.sensorReadings.mapADC, test_data.event_average.mapAdcRunningTotal);
 }
 
-extern uint16_t validateFilterMapSensorReading(uint16_t reading, uint8_t alpha, uint16_t prior);
-
-static void test_validateFilterMapSensorReading(void) {
-  TEST_ASSERT_EQUAL_UINT(0, validateFilterMapSensorReading(0, 0, 0));
-  TEST_ASSERT_EQUAL_UINT(100, validateFilterMapSensorReading(0, 0, 100));
-  TEST_ASSERT_EQUAL_UINT(333, validateFilterMapSensorReading(333, 0, 100));
-  TEST_ASSERT_EQUAL_UINT(217, validateFilterMapSensorReading(333, 127, 100));
-}
-
 void test_map_sampling(void) {
   SET_UNITY_FILENAME() {
     RUN_TEST(test_isValidMapSensorReadings);
@@ -398,6 +389,5 @@ void test_map_sampling(void) {
     RUN_TEST(test_eventAverageMAPReading_fallback_instantaneous);
     RUN_TEST(test_eventAverageMAPReading);
     RUN_TEST(test_eventAverageMAPReading_nosamples);
-    RUN_TEST(test_validateFilterMapSensorReading);
   }    
 }

--- a/test/test_sensors/test_map_sampling.cpp
+++ b/test/test_sensors/test_map_sampling.cpp
@@ -8,6 +8,26 @@ static void test_instantaneous(void) {
   TEST_ASSERT_TRUE(instanteneousMAPReading());
 }
 
+extern void setMAPValuesFromReadings(const map_adc_readings_t &readings, const config2 &page2, bool useEMAP, statuses &current);
+
+static void test_setMAPValuesFromReadings(void) {
+  config2 page2;
+  page2.mapMin = page2.EMAPMin = 10;
+  page2.mapMax = page2.EMAPMax = 260;
+  statuses current;
+  setMAPValuesFromReadings({ 0, 0 }, page2, true, current);
+  TEST_ASSERT_EQUAL_UINT(10, current.MAP);
+  TEST_ASSERT_EQUAL_UINT(10, current.EMAP);
+
+  setMAPValuesFromReadings({ 1024, 1024 }, page2, true, current);
+  TEST_ASSERT_EQUAL_UINT(260, current.MAP);
+  TEST_ASSERT_EQUAL_UINT(260, current.EMAP);
+
+  setMAPValuesFromReadings({ 0, 0 }, page2, true, current);
+  TEST_ASSERT_EQUAL_UINT(10, current.MAP);
+  TEST_ASSERT_EQUAL_UINT(10, current.EMAP);
+}
+
 extern bool cycleAverageMAPReading(const statuses &current, const config2 &page2, map_cycle_average_t &cycle_average, map_adc_readings_t &sensorReadings);
 extern bool canUseCycleAverage(const statuses &current, const config2 &page2, const map_adc_readings_t &sensorReadings);
 
@@ -389,5 +409,6 @@ void test_map_sampling(void) {
     RUN_TEST(test_eventAverageMAPReading_fallback_instantaneous);
     RUN_TEST(test_eventAverageMAPReading);
     RUN_TEST(test_eventAverageMAPReading_nosamples);
+    RUN_TEST(test_setMAPValuesFromReadings);
   }    
 }

--- a/test/test_sensors/test_map_sampling.cpp
+++ b/test/test_sensors/test_map_sampling.cpp
@@ -185,26 +185,31 @@ static void setup_cycle_minimum(cycleMinmumMAPReading_test_data &test_data) {
   test_data.cycle_min.mapMinimum = UINT16_MAX;
 }
 
-// static void test_cycleMinimumMAPReading_fallback_instantaneous(void) {
-//   cycleMinmumMAPReading_test_data test_data;
-//   setup_cycle_minimum(test_data);
+static void test_cycleMinimumMAPReading_fallback_instantaneous(void) {
+  cycleMinmumMAPReading_test_data test_data;
+  setup_cycle_minimum(test_data);
 
-//   test_data.current.RPMdiv100 = test_data.page2.mapSwitchPoint - 1U;
-//   test_data.sensorReadings.mapADC = 300;
-//   test_data.sensorReadings.emapADC = 500;  
+  test_data.sensorReadings = INVALID_MAP_READINGS;
+  TEST_ASSERT_TRUE(cycleMinimumMAPReading(test_data.current, test_data.page2, test_data.cycle_min, test_data.sensorReadings));
+  TEST_ASSERT_EQUAL_UINT(UINT16_MAX, test_data.cycle_min.mapMinimum);
+  TEST_ASSERT_EQUAL_UINT(0U, test_data.cycle_min.cycleStartIndex);
 
-//   TEST_ASSERT_TRUE(cycleMinimumMAPReading(test_data.current, test_data.page2, test_data.cycle_min, test_data.sensorReadings));
-//   TEST_ASSERT_EQUAL_UINT(UINT16_MAX, test_data.cycle_min.mapMinimum);
+  // Repeat - should get same result.
+  TEST_ASSERT_TRUE(cycleMinimumMAPReading(test_data.current, test_data.page2, test_data.cycle_min, test_data.sensorReadings));
+  TEST_ASSERT_EQUAL_UINT(UINT16_MAX, test_data.cycle_min.mapMinimum);
+  TEST_ASSERT_EQUAL_UINT(0U, test_data.cycle_min.cycleStartIndex);
 
-//   // Repeat - should get same result.
-//   TEST_ASSERT_TRUE(cycleMinimumMAPReading(test_data.current, test_data.page2, test_data.cycle_min, test_data.sensorReadings));
-//   TEST_ASSERT_EQUAL_UINT(UINT16_MAX, test_data.cycle_min.mapMinimum);
-// }
+  //
+  test_data.current.RPMdiv100 = test_data.page2.mapSwitchPoint - 1U;
+  test_data.sensorReadings = VALID_MAP_READINGS;
+  TEST_ASSERT_TRUE(cycleMinimumMAPReading(test_data.current, test_data.page2, test_data.cycle_min, test_data.sensorReadings));
+  TEST_ASSERT_EQUAL_UINT(test_data.sensorReadings.mapADC, test_data.cycle_min.mapMinimum);
+  TEST_ASSERT_EQUAL_UINT(test_data.current.startRevolutions, test_data.cycle_min.cycleStartIndex);
+}
 
 static void test_cycleMinimumMAPReading(void) {
   cycleMinmumMAPReading_test_data test_data;
   setup_cycle_minimum(test_data);
-
 
   test_data.cycle_min.cycleStartIndex = test_data.current.startRevolutions;
   test_data.sensorReadings.mapADC = 100;
@@ -377,7 +382,7 @@ void test_map_sampling(void) {
     RUN_TEST(test_cycleAverageMAPReading_fallback_instantaneous);
     RUN_TEST(test_cycleAverageMAPReading);
     RUN_TEST(test_cycleAverageMAPReading_nosamples);
-    // RUN_TEST(test_cycleMinimumMAPReading_fallback_instantaneous);
+    RUN_TEST(test_cycleMinimumMAPReading_fallback_instantaneous);
     RUN_TEST(test_cycleMinimumMAPReading);
     RUN_TEST(test_canUseEventAverage);
     RUN_TEST(test_eventAverageMAPReading_fallback_instantaneous);


### PR DESCRIPTION
We were filtering out invalid map sensor readings in all modes, including instantaneous.