### PR TITLE
Add Custom Firing Order Support for Injectors and Ignition

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -236,7 +236,7 @@
 
     endianness          = little
     nPages              = 15
-    pageSize            = 128,   288,     288,    128,     288,    128,    240,     384,    192,    192,    288,    192,    128,    288,    256
+    pageSize            = 129,   288,     288,    128,     288,    128,    240,     384,    192,    192,    288,    192,    128,    288,    256
 
     ; New commands
     pageIdentifier      = "\$tsCanId\x01", "\$tsCanId\x02", "\$tsCanId\x03", "\$tsCanId\x04", "\$tsCanId\x05", "\$tsCanId\x06", "\$tsCanId\x07", "\$tsCanId\x08", "\$tsCanId\x09", "\$tsCanId\x0A", "\$tsCanId\x0B", "\$tsCanId\x0C", "\$tsCanId\x0D", "\$tsCanId\x0E", "\$tsCanId\x0F"
@@ -483,6 +483,12 @@ page = 1
       canWBO                    = bits,   U08,  126, [2:3], "Off", "rusEFI WBO", "AEM", "INVALID"
       vssAuxCh                  = bits,   U08,  126, [4:7], "Aux0", "Aux1", "Aux2", "Aux3", "Aux4", "Aux5", "Aux6", "Aux7", "Aux8", "Aux9", "Aux10", "Aux11", "Aux12", "Aux13", "Aux14", "Aux15"
       decelAmount               = scalar, U08,  127,        "%",  1.0,       0.0,   0.0,     150.0,    0
+      
+      firingOrder3  = bits,   U08,      128, [0:0], "Default: 1-2-3", "1-3-2"
+      firingOrder4  = bits,   U08,      128, [1:2], "Default: 1-2-3-4","1-3-4-2", "1-2-4-3", "1-4-3-2"
+      firingOrder5  = bits,   U08,      128, [3:3], "Default: 1-2-3-4-5", "1-2-4-5-3"
+      firingOrder6  = bits,   U08,      128, [4:5], "Default: 1-2-3-4-5-6", "1-5-3-6-2-4", "1-2-4-6-5-3", "1-4-2-5-3-6"
+      firingOrder8  = bits,   U08,      128, [6:7], "Default: 1-2-3-4-5-6-7-8", "1-8-4-3-6-5-7-2", "1-8-7-2-6-5-4-3", "1-3-7-2-6-5-4-8"
 
 ;Page 2 is the fuel map and axis bins only
 page = 2
@@ -2597,13 +2603,21 @@ menuDialog = main
         panel = std_injection, North
         panel = engine_constants_southwest
 
+    dialog = firingOrderDialog, "Firing Order"
+        field = "3 Cylinders engine", firingOrder3 { nCylinders == 3 }
+        field = "4 Cylinders engine", firingOrder4 { nCylinders == 4 }
+        field = "5 Cylinders engine", firingOrder5 { nCylinders == 5 }
+        field = "6 Cylinders engine", firingOrder6 { nCylinders == 6 }
+        field = "8 Cylinders engine", firingOrder8 { nCylinders == 8 }
+
     dialog = engine_constants_northeast, "Oddfire Angles"
         field = "Channel 2 angle", oddfire2,                { engineType == 1 }
         field = "Channel 3 angle", oddfire3,                { engineType == 1 && nCylinders >= 3 }
         field = "Channel 4 angle", oddfire4,                { engineType == 1 && nCylinders >= 4 }
 
     dialog = engine_constants_east, ""
-        panel = engine_constants_northeast, North
+        panel = firingOrderDialog, North
+        panel = engine_constants_northeast, South
         field = ""
 
     dialog = engine_constants_warning, ""

--- a/speeduino/config_pages.h
+++ b/speeduino/config_pages.h
@@ -406,6 +406,12 @@ struct config2 {
 
   byte decelAmount;
 
+  byte firingOrder3: 1;
+  byte firingOrder4: 2;
+  byte firingOrder5: 1;
+  byte firingOrder6: 2;
+  byte firingOrder8: 2;
+
 #if defined(CORE_AVR)
   };
 #else

--- a/speeduino/pages.cpp
+++ b/speeduino/pages.cpp
@@ -24,7 +24,7 @@
 //  2. Offset to intra-entity byte
 
 // Page sizes as defined in the .ini file
-constexpr const uint16_t PROGMEM ini_page_sizes[] = { 0, 128, 288, 288, 128, 288, 128, 240, 384, 192, 192, 288, 192, 128, 288, 256 };
+constexpr const uint16_t PROGMEM ini_page_sizes[] = { 0, 129, 288, 288, 128, 288, 128, 240, 384, 192, 192, 288, 192, 128, 288, 256 };
 
 // ========================= Table size calculations =========================
 // Note that these should be computed at compile time, assuming the correct


### PR DESCRIPTION
This draft pull request introduces support for custom firing orders in Speeduino, allowing users to configure the firing sequence via TunerStudio. The goal is to make the system more flexible without requiring manual rewiring for different engine configurations.

![image](https://github.com/user-attachments/assets/26d371b6-16b1-4828-8bee-cbc7bab71424)


**Current Issue:**
- I’ve hit a roadblock with the ignition (IGN) scheduling. While I managed to adjust the injector outputs (`INJ`), I couldn’t figure out where to apply similar changes for the ignition outputs (`IGN`). The ignition logic seems more complex with additional parameters (e.g., timing angles, dwell), and I’m not sure which part of the code to modify.

**Request for Help:**
- Could someone review the changes I’ve made for the injectors and suggest how to extend this to the ignition scheduling? I’d appreciate pointers on which functions (e.g., `ignitionScheduling()`) or variables to tweak to align the IGN outputs with the custom firing order.

This is a draft, so I’m open to feedback on the overall approach, especially regarding the `pageSize` change and the best way to handle ignition. Thanks in advance for any assistance!