### PR TITLE
fix stepper driver overheating - unaccessible pinStepperEnable set if cool time is set to 0

### DIFF
--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -314,17 +314,10 @@ static inline byte checkForStepping(void)
         //Means we're currently in a step, but it needs to be turned off
         digitalWrite(pinStepperStep, LOW); //Turn off the step
         idleStepper.stepStartTime = micros_safe();
-        
-        // if there is no cool time we can miss that step out completely.
-        if (iacCoolTime_uS > 0)
-        {
-          idleStepper.stepperStatus = COOLING; //'Cooling' is the time the stepper needs to sit in LOW state before the next step can be made
-        }
-        else
-        {
-          idleStepper.stepperStatus = SOFF;  
-        }
-          
+
+	//Set status to COOLING. In next cycle, status will be set to SOFF and set stepper power OFF based on given settings
+        idleStepper.stepperStatus = COOLING; //'Cooling' is the time the stepper needs to sit in LOW state before the next step can be made
+                  
         isStepping = true;
       }
       else


### PR DESCRIPTION
If user set iacCoolTime to 0, program run will newer get to 'stepper motor enable pin setting' part. 
Explanation:
Stepper status have to be STEPPING or COOLING to get into condition on line 300, then there is next condition for STEPPING status and power disable check is in else statement, so only status COOLING can get there. But if iacCoolTime=0, status is set to SOFF and stepper motor remains enabled.
