### PR TITLE
Refactor dfco for better readability and minor performance improvement

### DIFF
--- a/speeduino/bit_manip.h
+++ b/speeduino/bit_manip.h
@@ -14,9 +14,6 @@
 /** @brief Is bit pos (0-7) in byte var set? */
 #define BIT_CHECK(var,pos) !!((var) & (1U<<(pos)))
 
-/** @brief Is bit pos (0-7) in byte var clear? */
-#define IS_BIT_CLEAR(var,pos) !((var) & (1U<<(pos)))
-
 /** @brief Toggle the value of bit pos (0-7) in byte var */
 #define BIT_TOGGLE(var,pos) ((var)^= 1UL << (pos))
 

--- a/speeduino/bit_manip.h
+++ b/speeduino/bit_manip.h
@@ -14,6 +14,9 @@
 /** @brief Is bit pos (0-7) in byte var set? */
 #define BIT_CHECK(var,pos) !!((var) & (1U<<(pos)))
 
+/** @brief Is bit pos (0-7) in byte var clear? */
+#define IS_BIT_CLEAR(var,pos) !((var) & (1U<<(pos)))
+
 /** @brief Toggle the value of bit pos (0-7) in byte var */
 #define BIT_TOGGLE(var,pos) ((var)^= 1UL << (pos))
 

--- a/speeduino/config_pages.h
+++ b/speeduino/config_pages.h
@@ -473,7 +473,7 @@ struct config4 {
   byte dwellCorrectionValues[6]; ///< Correction table for dwell vs battery voltage
   byte iatRetBins[6]; ///< Inlet Air Temp timing retard curve bins (Unit: ...)
   byte iatRetValues[6]; ///< Inlet Air Temp timing retard curve values (Unit: ...)
-  byte dfcoRPM;       ///< RPM at which DFCO turns off/on at
+  byte dfcoRPM;       ///< RPM (divided by 10) at which DFCO turns off/on at
   byte dfcoHyster;    //Hysteris RPM for DFCO
   byte dfcoTPSThresh; //TPS must be below this figure for DFCO to engage (Unit: ...)
 

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -561,7 +561,7 @@ bool isDfcoOngoing(void)
   if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO)) 
   {
     // if dfco is ongoing
-    // check that RPM is not too low and throttle is still off
+    // check that RPM is not too low and throttle is still closed
     return 
       currentStatus.RPM > ( configPage4.dfcoRPM * 10) && 
       currentStatus.TPS < configPage4.dfcoTPSThresh;
@@ -589,7 +589,8 @@ bool isDfcoOngoing(void)
     return false;
   }
 
-  //Reset delay timer and activate DFCO
+  // Reset delay timer and activate DFCO
+  // when conditions are met and delay timer has ended
   dfcoDelay = 0;
   return true;
 }

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -138,7 +138,7 @@ uint16_t correctionsFuel(void)
   currentStatus.launchCorrection = correctionLaunch();
   if (currentStatus.launchCorrection != 100) { sumCorrections = div100(sumCorrections * currentStatus.launchCorrection); }
 
-  bitWrite(currentStatus.status1, BIT_STATUS1_DFCO, isDfcoOngoing());
+  BIT_WRITE(currentStatus.status1, BIT_STATUS1_DFCO, isDfcoOngoing());
   byte dfcoTaperCorrection = getDfcoFuelCorrectionPercentage();
   if (dfcoTaperCorrection == 0) { sumCorrections = 0; }
   else if (dfcoTaperCorrection != 100) { sumCorrections = div100(sumCorrections * dfcoTaperCorrection); }
@@ -559,7 +559,7 @@ bool isDfcoOngoing(void)
 
   if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 1) // Is dfco ongoing?
   {
-    return // continue dfco if
+    return // keep dfco activated if
       currentStatus.TPS < configPage4.dfcoTPSThresh && // throttle still closed  
       currentStatus.RPM > (unsigned int)(configPage4.dfcoRPM * 10); // rpm high enough
   }
@@ -568,11 +568,11 @@ bool isDfcoOngoing(void)
     currentStatus.coolant < (int)(configPage2.dfcoMinCLT - CALIBRATION_TEMPERATURE_OFFSET) || // engine too cold
     currentStatus.RPM <= (unsigned int)((configPage4.dfcoRPM * 10) + (configPage4.dfcoHyster * 2))) // rpm too low
   {
-    dfcoDelay = 0; // Reset delay when DFCO conditions are not met
-    return false;
+    dfcoDelay = 0;
+    return false; // Reset delay and keep DFCO deactivated when conditions are not met
   }
 
-  if (dfcoDelay >= configPage2.dfcoDelay) // delay ellapsed, reset delay, enable dfco
+  if (dfcoDelay >= configPage2.dfcoDelay) // delay ellapsed, reset delay, activate dfco
   {
     dfcoDelay = 0;
     return true;
@@ -580,9 +580,9 @@ bool isDfcoOngoing(void)
   
   if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_10HZ)) 
   {
-    dfcoDelay++; //delay still running
+    dfcoDelay++;
   }
-  return false;
+  return false; //delay still running, keep DFCO deactivated
 }
 
 /** Flex fuel adjustment to vary fuel based on ethanol content.

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -557,22 +557,22 @@ bool isDfcoOngoing(void)
     return false;
   }
 
-  if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO)) // Is dfco ongoing?
+  if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 1) // Is dfco ongoing?
   {
     return // continue dfco if
-      (currentStatus.RPM > ( configPage4.dfcoRPM * 10) && // rpm not too low
-      currentStatus.TPS < configPage4.dfcoTPSThresh); // throttle still closed
+      currentStatus.TPS < configPage4.dfcoTPSThresh && // throttle still closed  
+      currentStatus.RPM > (unsigned int)(configPage4.dfcoRPM * 10); // rpm high enough
   }
 
-  if ((currentStatus.TPS >= configPage4.dfcoTPSThresh) || // throttle open
-    (currentStatus.coolant < (int)(configPage2.dfcoMinCLT - CALIBRATION_TEMPERATURE_OFFSET)) || // engine too cold
-    (currentStatus.RPM <= (unsigned int)((configPage4.dfcoRPM * 10) + (configPage4.dfcoHyster * 2)))) //rpm too low
+  if (currentStatus.TPS >= configPage4.dfcoTPSThresh || // throttle open
+    currentStatus.coolant < (int)(configPage2.dfcoMinCLT - CALIBRATION_TEMPERATURE_OFFSET) || // engine too cold
+    currentStatus.RPM <= (unsigned int)((configPage4.dfcoRPM * 10) + (configPage4.dfcoHyster * 2))) // rpm too low
   {
     dfcoDelay = 0; // Reset delay when DFCO conditions are not met
     return false;
   }
 
-  if (dfcoDelay >= configPage2.dfcoDelay) // delay ellapsed, enable dfco, reset delay
+  if (dfcoDelay >= configPage2.dfcoDelay) // delay ellapsed, reset delay, enable dfco
   {
     dfcoDelay = 0;
     return true;

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -552,7 +552,7 @@ byte getDfcoFuelCorrectionPercentage(void)
  */
 bool isDfcoOngoing(void)
 {
-  if (!configPage2.dfcoEnabled)
+  if (configPage2.dfcoEnabled == 0)
   {
     // not enabled in configuration
     return false;
@@ -560,26 +560,26 @@ bool isDfcoOngoing(void)
 
   if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO)) 
   {
-    // if dfco is ongoing
+    // If dfco is ongoing
     // check that RPM is not too low and throttle is still closed
     return 
       currentStatus.RPM > ( configPage4.dfcoRPM * 10) && 
       currentStatus.TPS < configPage4.dfcoTPSThresh;
   }
 
-  //do not start DFCO if throttle pressed
-  //or engine temperature below treshold
-  //or engine rpm below treshold
+  // Do not start DFCO if throttle is not closed
+  // or engine temperature below treshold
+  // or engine rpm below treshold
   if ((currentStatus.TPS >= configPage4.dfcoTPSThresh) ||
     (currentStatus.coolant < (int)(configPage2.dfcoMinCLT - CALIBRATION_TEMPERATURE_OFFSET)) ||
     (currentStatus.RPM <= (unsigned int)( (configPage4.dfcoRPM * 10) + (configPage4.dfcoHyster * 2)) ))
   {
-    //reset delay timer when any of DFCO conditions are not met
+    // Reset delay timer when any of DFCO conditions are not met
     dfcoDelay = 0;
     return false;
   }
 
-  //do not activate DFCO while delay timer is running
+  // Do not activate DFCO while delay timer is running
   if (dfcoDelay < configPage2.dfcoDelay)
   {
     if( BIT_CHECK(LOOP_TIMER, BIT_TIMER_10HZ) ) 

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -53,8 +53,8 @@ uint8_t idleAdvTaper;
 uint8_t crankingEnrichTaper;
 uint8_t dfcoTaper;
 
-#define PERCENT_100 100;
-#define PERCENT_0 0;
+#define PERCENTS_100 100;
+#define PERCENTS_0 0;
 
 /** Initialise instances and vars related to corrections (at ECU boot-up).
  */
@@ -525,27 +525,25 @@ byte correctionLaunch(void)
 */
 byte getDfcoFuelCorrectionPercentage(void)
 {
-  if (!BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO))
+  if (IS_BIT_CLEAR(currentStatus.status1, BIT_STATUS1_DFCO))
   {
     //Keep updating the duration until DFCO is active
     dfcoTaper = configPage9.dfcoTaperTime;
-    return PERCENT_100;
+    return PERCENTS_100;
   }
 
   if (!configPage9.dfcoTaperEnable || dfcoTaper == 0)
   {
     //Taper ended or disabled, disable fuel
-    return PERCENT_0;
+    return PERCENTS_0;
   }
 
   dfcoTaper = min(dfcoTaper, configPage9.dfcoTaperTime);
-  const byte percentage = map(
-    dfcoTaper, configPage9.dfcoTaperTime, 0, 100, configPage9.dfcoTaperFuel);
   if( BIT_CHECK(LOOP_TIMER, BIT_TIMER_10HZ) ) 
   { 
     dfcoTaper--;
   }
-  return percentage;
+  return map(dfcoTaper, configPage9.dfcoTaperTime, 0, 100, configPage9.dfcoTaperFuel);
 }
 
 /*

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -139,7 +139,7 @@ uint16_t correctionsFuel(void)
   if (currentStatus.launchCorrection != 100) { sumCorrections = div100(sumCorrections * currentStatus.launchCorrection); }
 
   BIT_WRITE(currentStatus.status1, BIT_STATUS1_DFCO, isDfcoOngoing());
-  byte dfcoTaperCorrection = getDfcoFuelCorrectionPercentage();
+  byte dfcoTaperCorrection = getDfcoFuelCorrection();
   if (dfcoTaperCorrection == 0) { sumCorrections = 0; }
   else if (dfcoTaperCorrection != 100) { sumCorrections = div100(sumCorrections * dfcoTaperCorrection); }
 
@@ -523,16 +523,16 @@ byte correctionLaunch(void)
  * Returns fuel correction in percents during DFCO tapering
  * Mutates: dfcoTaper (global Deceleration fuel cutoff taper countdown)
 */
-byte getDfcoFuelCorrectionPercentage(void)
+byte getDfcoFuelCorrection(void)
 {
-  if (IS_BIT_CLEAR(currentStatus.status1, BIT_STATUS1_DFCO))
+  if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 0)
   {
     //Keep updating the duration until DFCO is active
     dfcoTaper = configPage9.dfcoTaperTime;
     return PERCENTS_100;
   }
 
-  if (!configPage9.dfcoTaperEnable || dfcoTaper == 0)
+  if (configPage9.dfcoTaperEnable == 0 || dfcoTaper == 0)
   {
     //Taper ended or disabled, disable fuel
     return PERCENTS_0;

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -23,7 +23,7 @@ byte correctionIATDensity(void); //Inlet temp density correction
 byte correctionBaro(void); //Barometric pressure correction
 byte correctionLaunch(void); //Launch control correction
 byte getDfcoFuelCorrectionPercentage(void); //DFCO taper correction
-bool correctionDFCO(void); //Decelleration fuel cutoff
+bool isDfcoOngoing(void); //Decelleration fuel cutoff
 
 int8_t correctionsIgn(int8_t advance);
 int8_t correctionFixedTiming(int8_t advance);

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -22,7 +22,7 @@ byte correctionBatVoltage(void); //Battery voltage correction
 byte correctionIATDensity(void); //Inlet temp density correction
 byte correctionBaro(void); //Barometric pressure correction
 byte correctionLaunch(void); //Launch control correction
-byte getDfcoFuelCorrectionPercentage(void); //DFCO taper correction
+byte getDfcoFuelCorrection(void); //DFCO taper correction
 bool isDfcoOngoing(void); //Decelleration fuel cutoff
 
 int8_t correctionsIgn(int8_t advance);

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -22,7 +22,7 @@ byte correctionBatVoltage(void); //Battery voltage correction
 byte correctionIATDensity(void); //Inlet temp density correction
 byte correctionBaro(void); //Barometric pressure correction
 byte correctionLaunch(void); //Launch control correction
-byte correctionDFCOfuel(void); //DFCO taper correction
+byte getDfcoFuelCorrectionPercentage(void); //DFCO taper correction
 bool correctionDFCO(void); //Decelleration fuel cutoff
 
 int8_t correctionsIgn(int8_t advance);

--- a/speeduino/statuses.h
+++ b/speeduino/statuses.h
@@ -227,6 +227,7 @@ struct statuses {
   byte airConStatus;
 };
 
+
 /**
  * @brief Non-atomic version of HasAnySync. **Should only be called in an ATOMIC() block***
  * 

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -738,7 +738,7 @@ static void test_corrections_launch(void)
   RUN_TEST_P(test_corrections_launch_both);
 }
 
-extern bool correctionDFCO(void);
+extern bool isDfcoOngoing(void);
 
 static void setup_DFCO_on_taper_off_no_delay()
 {
@@ -757,7 +757,7 @@ static void setup_DFCO_on_taper_off_no_delay()
   configPage2.dfcoDelay = 0;
   configPage9.dfcoTaperEnable = 0; //Enable
 
-  correctionDFCO();
+  isDfcoOngoing();
 }
 
 //**********************************************************************************************************************
@@ -766,7 +766,7 @@ static void test_corrections_dfco_on(void)
   //Test under ideal conditions that DFCO goes active
   setup_DFCO_on_taper_off_no_delay();
 
-  TEST_ASSERT_TRUE(correctionDFCO());
+  TEST_ASSERT_TRUE(isDfcoOngoing());
 }
 
 static void test_corrections_dfco_off_RPM()
@@ -774,9 +774,9 @@ static void test_corrections_dfco_off_RPM()
   //Test that DFCO comes on and then goes off when the RPM drops below threshold
   setup_DFCO_on_taper_off_no_delay();
 
-  TEST_ASSERT_TRUE(correctionDFCO()); //Make sure DFCO is on initially
+  TEST_ASSERT_TRUE(isDfcoOngoing()); //Make sure DFCO is on initially
   currentStatus.RPM = 1000; //Set the current simulated RPM below the threshold + hyster
-  TEST_ASSERT_FALSE(correctionDFCO()); //Test DFCO is now off
+  TEST_ASSERT_FALSE(isDfcoOngoing()); //Test DFCO is now off
 }
 
 static void test_corrections_dfco_off_TPS()
@@ -784,9 +784,9 @@ static void test_corrections_dfco_off_TPS()
   //Test that DFCO comes on and then goes off when the TPS goes above the required threshold (ie not off throttle)
   setup_DFCO_on_taper_off_no_delay();
 
-  TEST_ASSERT_TRUE(correctionDFCO()); //Make sure DFCO is on initially
+  TEST_ASSERT_TRUE(isDfcoOngoing()); //Make sure DFCO is on initially
   currentStatus.TPS = 10; //Set the current simulated TPS to be above the threshold
-  TEST_ASSERT_FALSE(correctionDFCO()); //Test DFCO is now off
+  TEST_ASSERT_FALSE(isDfcoOngoing()); //Test DFCO is now off
 }
 
 static void test_corrections_dfco_off_delay()
@@ -799,10 +799,10 @@ static void test_corrections_dfco_off_delay()
   configPage2.dfcoDelay = 5;
   
   for (uint8_t index = 0; index < configPage2.dfcoDelay; ++index) {
-    TEST_ASSERT_FALSE(correctionDFCO()); //Make sure DFCO does not come on...
+    TEST_ASSERT_FALSE(isDfcoOngoing()); //Make sure DFCO does not come on...
   }
   // ...until simulated delay period expires
-  TEST_ASSERT_TRUE(correctionDFCO()); 
+  TEST_ASSERT_TRUE(isDfcoOngoing()); 
 }
 
 static void setup_DFCO_on_taper_on_no_delay()
@@ -1565,7 +1565,7 @@ static void test_corrections_correctionsFuel_ae_modes(void) {
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionFlex(), "correctionFlex");
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionFuelTemp(), "correctionFuelTemp");
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionLaunch(), "correctionLaunch");
-  TEST_ASSERT_FALSE(correctionDFCO());
+  TEST_ASSERT_FALSE(isDfcoOngoing());
   TEST_ASSERT_EQUAL_MESSAGE(100, getDfcoFuelCorrectionPercentage(), "getDfcoFuelCorrectionPercentage");
 
   // Acceeleration
@@ -1636,7 +1636,7 @@ static void test_corrections_correctionsFuel_clip_limit(void) {
   TEST_ASSERT_EQUAL_MESSAGE(255, correctionFlex(), "correctionFlex");
   TEST_ASSERT_EQUAL_MESSAGE(255, correctionFuelTemp(), "correctionFuelTemp");
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionLaunch(), "correctionLaunch");
-  TEST_ASSERT_FALSE(correctionDFCO());
+  TEST_ASSERT_FALSE(isDfcoOngoing());
   TEST_ASSERT_EQUAL_MESSAGE(100, getDfcoFuelCorrectionPercentage(), "getDfcoFuelCorrectionPercentage");
 
   TEST_ASSERT_EQUAL(1500U, correctionsFuel());

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -815,39 +815,39 @@ static void setup_DFCO_on_taper_on_no_delay()
   configPage9.dfcoTaperAdvance = 20; //Reduce 20deg until full fuel cut
 }
 
-extern byte correctionDFCOfuel(void);
+extern byte getDfcoFuelCorrectionPercentage(void);
 
-static void test_correctionDFCOfuel_DFCO_off()
+static void test_getDfcoFuelCorrectionPercentage_DFCO_off()
 {
   setup_DFCO_on_taper_off_no_delay();
 
   BIT_CLEAR(currentStatus.status1, BIT_STATUS1_DFCO);
-  TEST_ASSERT_EQUAL(100, correctionDFCOfuel());
+  TEST_ASSERT_EQUAL(100, getDfcoFuelCorrectionPercentage());
 }
 
-static void test_correctionDFCOfuel_notaper()
+static void test_getDfcoFuelCorrectionPercentage_notaper()
 {
   setup_DFCO_on_taper_off_no_delay();
 
   configPage9.dfcoTaperEnable = 0; //Disable
   BIT_SET(currentStatus.status1, BIT_STATUS1_DFCO);
-  TEST_ASSERT_EQUAL(0, correctionDFCOfuel());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
 }
 
 static inline void reset_dfco_taper(void) {
   BIT_CLEAR(currentStatus.status1, BIT_STATUS1_DFCO);
-  TEST_ASSERT_EQUAL(100, correctionDFCOfuel());
+  TEST_ASSERT_EQUAL(100, getDfcoFuelCorrectionPercentage());
   TEST_ASSERT_EQUAL(20, correctionDFCOignition(20));
 }
 
 static inline void advance_dfco_taper(uint8_t count) {
   BIT_SET(LOOP_TIMER, BIT_TIMER_10HZ);
   for (uint8_t index = 0; index < count; ++index) {
-    (void)correctionDFCOfuel();
+    (void)getDfcoFuelCorrectionPercentage();
   }
 }
 
-static void test_correctionDFCOfuel_taper()
+static void test_getDfcoFuelCorrectionPercentage_taper()
 {
   setup_DFCO_on_taper_on_no_delay();
 
@@ -858,23 +858,23 @@ static void test_correctionDFCOfuel_taper()
   // 50% test
   advance_dfco_taper(configPage9.dfcoTaperTime/2);
   BIT_CLEAR(LOOP_TIMER, BIT_TIMER_10HZ);
-  TEST_ASSERT_EQUAL(50, correctionDFCOfuel());
+  TEST_ASSERT_EQUAL(50, getDfcoFuelCorrectionPercentage());
 
   // 75% test
   advance_dfco_taper(configPage9.dfcoTaperTime/4);
   BIT_CLEAR(LOOP_TIMER, BIT_TIMER_10HZ);
-  TEST_ASSERT_EQUAL(25, correctionDFCOfuel());
+  TEST_ASSERT_EQUAL(25, getDfcoFuelCorrectionPercentage());
 
   // Advance taper to 100%
   advance_dfco_taper(configPage9.dfcoTaperTime/4);
 
   // 100% & beyond test
   BIT_SET(LOOP_TIMER, BIT_TIMER_10HZ);
-  TEST_ASSERT_EQUAL(0, correctionDFCOfuel());
-  TEST_ASSERT_EQUAL(0, correctionDFCOfuel());
-  TEST_ASSERT_EQUAL(0, correctionDFCOfuel());
-  TEST_ASSERT_EQUAL(0, correctionDFCOfuel());
-  TEST_ASSERT_EQUAL(0, correctionDFCOfuel());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
 }
 
 extern int8_t correctionDFCOignition(int8_t advance);
@@ -931,9 +931,9 @@ static void test_corrections_dfco()
   RUN_TEST_P(test_corrections_dfco_off_RPM);
   RUN_TEST_P(test_corrections_dfco_off_TPS);
   RUN_TEST_P(test_corrections_dfco_off_delay);
-  RUN_TEST_P(test_correctionDFCOfuel_DFCO_off);
-  RUN_TEST_P(test_correctionDFCOfuel_notaper);
-  RUN_TEST_P(test_correctionDFCOfuel_taper);
+  RUN_TEST_P(test_getDfcoFuelCorrectionPercentage_DFCO_off);
+  RUN_TEST_P(test_getDfcoFuelCorrectionPercentage_notaper);
+  RUN_TEST_P(test_getDfcoFuelCorrectionPercentage_taper);
   RUN_TEST_P(test_correctionDFCOignition_DFCO_off);
   RUN_TEST_P(test_correctionDFCOignition_notaper);
   RUN_TEST_P(test_correctionDFCOignition_taper);
@@ -1566,7 +1566,7 @@ static void test_corrections_correctionsFuel_ae_modes(void) {
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionFuelTemp(), "correctionFuelTemp");
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionLaunch(), "correctionLaunch");
   TEST_ASSERT_FALSE(correctionDFCO());
-  TEST_ASSERT_EQUAL_MESSAGE(100, correctionDFCOfuel(), "correctionDFCOfuel");
+  TEST_ASSERT_EQUAL_MESSAGE(100, getDfcoFuelCorrectionPercentage(), "getDfcoFuelCorrectionPercentage");
 
   // Acceeleration
   configPage2.aeApplyMode = AE_MODE_MULTIPLIER;
@@ -1637,7 +1637,7 @@ static void test_corrections_correctionsFuel_clip_limit(void) {
   TEST_ASSERT_EQUAL_MESSAGE(255, correctionFuelTemp(), "correctionFuelTemp");
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionLaunch(), "correctionLaunch");
   TEST_ASSERT_FALSE(correctionDFCO());
-  TEST_ASSERT_EQUAL_MESSAGE(100, correctionDFCOfuel(), "correctionDFCOfuel");
+  TEST_ASSERT_EQUAL_MESSAGE(100, getDfcoFuelCorrectionPercentage(), "getDfcoFuelCorrectionPercentage");
 
   TEST_ASSERT_EQUAL(1500U, correctionsFuel());
 }

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -888,39 +888,39 @@ static void setup_DFCO_on_taper_on_no_delay()
   configPage9.dfcoTaperAdvance = 20; //Reduce 20deg until full fuel cut
 }
 
-extern byte getDfcoFuelCorrectionPercentage(void);
+extern byte getDfcoFuelCorrection(void);
 
-static void test_getDfcoFuelCorrectionPercentage_DFCO_off()
+static void test_getDfcoFuelCorrection_DFCO_off()
 {
   setup_and_start_DFCO();
 
   BIT_CLEAR(currentStatus.status1, BIT_STATUS1_DFCO);
-  TEST_ASSERT_EQUAL(100, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(100, getDfcoFuelCorrection());
 }
 
-static void test_getDfcoFuelCorrectionPercentage_notaper()
+static void test_getDfcoFuelCorrection_notaper()
 {
   setup_and_start_DFCO();
 
   configPage9.dfcoTaperEnable = 0; //Disable
   BIT_SET(currentStatus.status1, BIT_STATUS1_DFCO);
-  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrection());
 }
 
 static inline void reset_dfco_taper(void) {
   BIT_CLEAR(currentStatus.status1, BIT_STATUS1_DFCO);
-  TEST_ASSERT_EQUAL(100, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(100, getDfcoFuelCorrection());
   TEST_ASSERT_EQUAL(20, correctionDFCOignition(20));
 }
 
 static inline void advance_dfco_taper(uint8_t count) {
   BIT_SET(LOOP_TIMER, BIT_TIMER_10HZ);
   for (uint8_t index = 0; index < count; ++index) {
-    (void)getDfcoFuelCorrectionPercentage();
+    (void)getDfcoFuelCorrection();
   }
 }
 
-static void test_getDfcoFuelCorrectionPercentage_taper()
+static void test_getDfcoFuelCorrection_taper()
 {
   setup_DFCO_on_taper_on_no_delay();
 
@@ -931,23 +931,23 @@ static void test_getDfcoFuelCorrectionPercentage_taper()
   // 50% test
   advance_dfco_taper(configPage9.dfcoTaperTime/2);
   BIT_CLEAR(LOOP_TIMER, BIT_TIMER_10HZ);
-  TEST_ASSERT_EQUAL(50, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(50, getDfcoFuelCorrection());
 
   // 75% test
   advance_dfco_taper(configPage9.dfcoTaperTime/4);
   BIT_CLEAR(LOOP_TIMER, BIT_TIMER_10HZ);
-  TEST_ASSERT_EQUAL(25, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(25, getDfcoFuelCorrection());
 
   // Advance taper to 100%
   advance_dfco_taper(configPage9.dfcoTaperTime/4);
 
   // 100% & beyond test
   BIT_SET(LOOP_TIMER, BIT_TIMER_10HZ);
-  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
-  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
-  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
-  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
-  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrectionPercentage());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrection());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrection());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrection());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrection());
+  TEST_ASSERT_EQUAL(0, getDfcoFuelCorrection());
 }
 
 extern int8_t correctionDFCOignition(int8_t advance);
@@ -1010,9 +1010,9 @@ static void test_corrections_dfco()
   RUN_TEST_P(test_dfco_goes_active_and_delay_resets_when_conditions_are_met_and_delay_ellapsed);
   RUN_TEST_P(test_dfco_goes_active_only_after_delay);
 
-  RUN_TEST_P(test_getDfcoFuelCorrectionPercentage_DFCO_off);
-  RUN_TEST_P(test_getDfcoFuelCorrectionPercentage_notaper);
-  RUN_TEST_P(test_getDfcoFuelCorrectionPercentage_taper);
+  RUN_TEST_P(test_getDfcoFuelCorrection_DFCO_off);
+  RUN_TEST_P(test_getDfcoFuelCorrection_notaper);
+  RUN_TEST_P(test_getDfcoFuelCorrection_taper);
   RUN_TEST_P(test_correctionDFCOignition_DFCO_off);
   RUN_TEST_P(test_correctionDFCOignition_notaper);
   RUN_TEST_P(test_correctionDFCOignition_taper);
@@ -1645,7 +1645,7 @@ static void test_corrections_correctionsFuel_ae_modes(void) {
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionFuelTemp(), "correctionFuelTemp");
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionLaunch(), "correctionLaunch");
   TEST_ASSERT_FALSE(isDfcoOngoing());
-  TEST_ASSERT_EQUAL_MESSAGE(100, getDfcoFuelCorrectionPercentage(), "getDfcoFuelCorrectionPercentage");
+  TEST_ASSERT_EQUAL_MESSAGE(100, getDfcoFuelCorrection(), "getDfcoFuelCorrection");
 
   // Acceeleration
   configPage2.aeApplyMode = AE_MODE_MULTIPLIER;
@@ -1716,7 +1716,7 @@ static void test_corrections_correctionsFuel_clip_limit(void) {
   TEST_ASSERT_EQUAL_MESSAGE(255, correctionFuelTemp(), "correctionFuelTemp");
   TEST_ASSERT_EQUAL_MESSAGE(100, correctionLaunch(), "correctionLaunch");
   TEST_ASSERT_FALSE(isDfcoOngoing());
-  TEST_ASSERT_EQUAL_MESSAGE(100, getDfcoFuelCorrectionPercentage(), "getDfcoFuelCorrectionPercentage");
+  TEST_ASSERT_EQUAL_MESSAGE(100, getDfcoFuelCorrection(), "getDfcoFuelCorrection");
 
   TEST_ASSERT_EQUAL(1500U, correctionsFuel());
 }


### PR DESCRIPTION
Decided to open a can of worms here :)

Refactored two following methods. MISRA is not violated since single return is only recommendation and these methods do not allocate resources that needs to be released before return.


1. DFCO fuel correction calculation method for cleaner code: 
a) gave it a name with verb in it - getDfcoFuelCorrection
b) moved early exit conditions to top
c) replaced comparing condition with min()
d) replaced deep nesting and else statements with simple one level conditions

2. Refactored DFCO Activation and status reading method for cleaner code:
a) gave it a name with verb in it - isDfcoOngoing
b) moved early exit conditions to top
c) got rid of condition that checked if dfco is off when it was on to reset dfcoDelay. Now dfcoDelay is reset when state changes. Should give minor performance improvement while dfco is running.
d) swapped dfco conditions so that the fastest one would be executed first
e) replaced deep nesting and else statements with simple one level conditions
f) added more tests and gave existing ones longer names

Code was compiled, built and unit tested for Teensy 4.1