### PR TITLE
Update Jeep2000 decoder to be sequential compatible.

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -9,7 +9,7 @@
    versionInfo    = "S" ;This info is what is displayed to user
 
 [TunerStudio]
-   iniSpecVersion = 3.78
+   iniSpecVersion = 3.64
 
 ;-------------------------------------------------------------------------------
 
@@ -180,6 +180,7 @@
     #define trigger_Rover				        = 25
     #define trigger_K6A  				        = 26
     #define trigger_HondaJ32            = 27
+    #define trigger_Jeep2000_4cyl	= 28
 
 [Constants]
 
@@ -512,7 +513,7 @@ page = 4
       TrigEdge   = bits,   U08,      5,[0:0],    "RISING", "FALLING"
       TrigSpeed  = bits,   U08,      5,[1:1],    "Crank Speed", "Cam Speed"
       IgInv      = bits,   U08,      5,[2:2],    "Going Low",        "Going High"
-      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Ford ST170", "DRZ400", "Chrysler NGC", "Yamaha Vmax 1990+", "Renix", "Rover MEMS", "K6A", "Honda J32", "INVALID", "INVALID", "INVALID", "INVALID"
+      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Ford ST170", "DRZ400", "Chrysler NGC", "Yamaha Vmax 1990+", "Renix", "Rover MEMS", "K6A", "Honda J32", "Jeep 2000 4cyl", "INVALID", "INVALID", "INVALID"
       TrigEdgeSec= bits,   U08,      6,[0:0],    "RISING", "FALLING"
       fuelPumpPin= bits  , U08,      6,[1:6],    "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
       useResync  = bits,   U08,      6,[7:7],    "No",        "Yes"
@@ -765,8 +766,8 @@ page = 6
       fanSP        = scalar, U08,     121,        "C",        1.0,       -40,     -40,     215.0,    0
       fanHyster    = scalar, U08,     122,        "C",        1.0,       0.0,  0.0,     40,    0
   #else
-      fanSP        = scalar, U08,     121,        "F",        1.8,       -22.23,    -40,     419.0,    0
-      fanHyster    = scalar, U08,     122,        "F",        1.8,       0,    0,    72,      0
+      fanSP        = scalar, U08,     121,        "F",        1.8,       -22.23,  -40,     419.0,    0
+      fanHyster    = scalar, U08,     122,        "F",        1.0,       0.0,  0.0,     40,    0
   #endif
       fanFreq      = scalar, U08 ,    123,        "Hz",        2.0,        0.0,    10,     511,       0
   #if CELSIUS
@@ -1879,8 +1880,8 @@ page = 15
     defaultValue = vssSmoothing, 50
 
     ;pinLayout     = bits,   U08,      15, [0:7],  "Speeduino v0.1", "Speeduino v0.2", "Speeduino v0.3", "Speeduino v0.4", "INVALID", "INVALID", "01-05 MX5 PNP", "INVALID", "96-97 MX5 PNP", "NA6 MX5 PNP", "Turtana PCB", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "Plazomat I/O 0.1", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "Daz V6 Shield 0.1", "BMW PnP", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "NO2C", "UA4C", "INVALID", "INVALID", "INVALID", "DIY-EFI CORE4 v1.0", "INVALID", "INVALID", "INVALID", "INVALID", "dvjcodec Teensy RevA", "dvjcodec Teensy RevB", "INVALID", "INVALID", "INVALID", "DropBear", "INVALID", "INVALID", "INVALID", "INVALID", "Black STM32F407VET6 V0.1", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-    defaultValue = boardFuelOutputs,                4                 4                 4                 4                 4           4         4                 4         4                 4               4             4          4          4         4           4         4           4         4           4         4                   4           4         4           4          4          4         4           4         4           4                    6          4          4          4         4           4         4           4          4          4       4       4           4         4         4                     4           4         4           4         4                       4                       4          4          4          8          4           4           4         4         8                           4          4          4           4          4          4          4          4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4     
-    defaultValue = boardIgnOutputs,                 4                 4                 4                 4                 4           4         4                 4         4                 4               4             4          4          4         4           4         4           4         4           4         4                   4           4         4           4          4          4         4           4         4           4                    6          4          4          4         4           4         4           4          4          4       4       4           4         4         4                     4           4         4           4         4                       4                       4          4          4          8          4           4           4         4         8                           4          4          4           4          4          4          4          4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4     
+    defaultValue = boardFuelOutputs,                4                 4                 4                 6                 4           4         4                 4         4                 4               4             4          4          4         4           4         4           4         4           4         4                   4           4         4           4          4          4         4           4         4           4                    6          4          4          4         4           4         4           4          4          4       4       4           4         4         4                     4           4         4           4         4                       4                       4          4          4          8          4           4           4         4         8                           4          4          4           4          4          4          4          4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4     
+    defaultValue = boardIgnOutputs,                 4                 4                 4                 3                 4           4         4                 4         4                 4               4             4          4          4         4           4         4           4         4           4         4                   4           4         4           4          4          4         4           4         4           4                    6          4          4          4         4           4         4           4          4          4       4       4           4         4         4                     4           4         4           4         4                       4                       4          4          4          8          4           4           4         4         8                           4          4          4           4          4          4          4          4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4     
     defaultValue = boardHasRTC,                     0                 0                 0                 0                 0           0         0                 0         0                 0               0             0          0          0         0           0         0           0         0           0         0                   0           0         0           0          0          0         0           0         0           0                    6          0          0          0         0           0         0           0          0          0       0       0           0         0         0                     0           0         0           0         0                       0                       0          0          0          1          0           0           0         0         8                           0          0          0           0          0          0          0          0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0         0           0     
 
     controllerPriority = bootloaderCaps
@@ -2070,7 +2071,7 @@ menuDialog = main
         subMenu = vvtTbl,               "VVT Target/Duty", 8,  { vvtEnabled }
         subMenu = vvt2Tbl,              "VVT2 Target/Duty", 8,  { vvtEnabled && vvt2Enabled }
         subMenu = std_separator
-        subMenu = wmiSettings,          "WMI Control"
+        subMenu = wmiSettings,          "WMI Control", { !vvt2Enabled }
         subMenu = wmiTbl,               "WMI duty cycle", 8,  { !vvt2Enabled && wmiEnabled && wmiMode > 1 }  
         subMenu = std_separator
         subMenu = tacho,                "Tacho Output"
@@ -2088,7 +2089,6 @@ menuDialog = main
 
   menuDialog = main
    menu = "Tools"
-        subMenu = std_tpscal,       "Calibrate TPS"
         subMenu = mapCal,           "Calibrate Pressure Sensors"
         subMenu = batCal,           "Calibrate Voltage Reading"
         subMenu = std_ms2gentherm,  "Calibrate Temperature Sensors", 0
@@ -3417,7 +3417,7 @@ menuDialog = main
         field = "D",                                boostKD,       { boostEnabled && boostMode && boostType == 1 }
 
     dialog = vvt2, "Second VVT output"
-       field = "!VVT2 PWM is shared with WMI. VVT2 cannot be used while WMI is enabled.", , {}, { wmiEnabled }, { wmiEnabled }
+        field = "!VVT2 PWM is shared with WMI. The 2 cannot be used at the same time.", {}, {}, { wmiEnabled }
         field = "VVT2 Control Enabled",    vvt2Enabled,       { !wmiEnabled }
         field = "VVT2 output pin",         vvt2Pin,           { vvt2Enabled }
         field = "VVT2 Trigger edge",       TrigEdgeThrd,      { vvt2Enabled }
@@ -3448,7 +3448,7 @@ menuDialog = main
         field = "VVT Minimum CLT",        vvtMinClt,        { vvtEnabled }
         field = "VVT Delay",              vvtDelay,         { vvtEnabled }
         field = "VVT Mode",               vvtMode,          { vvtEnabled }
-        field = "#Note: Closed loop is currently experimental and available on Miata and missing tooth patterns ONLY", , {}, { vvtMode == 2 }, { vvtMode == 2 }
+        field = "#Note: Closed loop is currently experimental and available on Miata and missing tooth patterns ONLY", {}, {}, { vvtMode == 2 }
         field = "Load source",            vvtLoadSource,    { vvtEnabled }
         field = "VVT output pin",         vvt1Pin,          { vvtEnabled }
         field = "VVT solenoid freq.",     vvtFreq,          { vvtEnabled }
@@ -3457,8 +3457,8 @@ menuDialog = main
         panel = vvt2,                                       { vvtEnabled }
 
     dialog = wmiSettings, "WMI Control"
-        field = "!WMI PWM frequency is the same as VVT2. WMI PWM cannot be used while VVT2 is enabled.", , {}, { vvt2Enabled && vvtEnabled }, { vvt2Enabled && vvtEnabled }
-        field = "WMI Control Enabled",    wmiEnabled,       { !vvt2Enabled || !vvtEnabled }
+        field = "!WMI PWM is shared with VVT2. The 2 cannot be used at the same time.", {}, {}, { vvt2Enabled }
+        field = "WMI Control Enabled",    wmiEnabled,       { !vvt2Enabled }
         field = "WMI Mode",               wmiMode,          { wmiEnabled }
         field = "WMI min TPS",            wmiTPS,           { wmiEnabled }
         field = "WMI min RPM",            wmiRPM ,          { wmiEnabled }
@@ -3468,6 +3468,7 @@ menuDialog = main
         field = "WMI offset",             wmiOffset,        { wmiEnabled && wmiMode == 3}
         field = ""
         field = "WMI PWM output pin",     vvt2Pin,          { wmiEnabled }
+        field = "!WMI PWM frequency is the same as VVT. The 2 cannot be set independently.", {}, {}, { vvt2Enabled }
         field = "WMI PWM freq.",          vvtFreq,          { wmiEnabled }
         field = ""
         field = "WMI enabled output pin", wmiEnabledPin,    { wmiEnabled }
@@ -5739,7 +5740,7 @@ cmdVSSratio6 =      "E\x99\x06"
   
 
   entry = knockEventCount,  "Current Knock Events",       int,      "%d",   { knock_mode }
-  entry = knockCor,         "Knock Retard",               int,      "%d",   { knock_mode }
+  entry = knockCor,         "Knkock Retard",              int,      "%d",   { knock_mode }
   entry = knockActive,      "Knock Detected",             int,      "onOff", { knock_mode }
 
 [LoggerDefinition]

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -2168,7 +2168,7 @@ void triggerSetup_Jeep2000_4cyl(void)
   toothAngles[14] = 154;
   toothAngles[15] = 174;
 
-  MAX_STALL_TIME = ((MICROS_PER_DEG_1_RPM/50U) * 60U); //Minimum 50rpm. (3333uS is the time per degree at 50rpm). Largest gap between teeth is 60 degrees.
+  MAX_STALL_TIME = ((MICROS_PER_DEG_1_RPM/50U) * 120U); //Minimum 50rpm. (3333uS is the time per degree at 50rpm). Largest gap between teeth is 60 degrees.
   if(currentStatus.initialisationComplete == false) { toothCurrentCount = 17; toothLastToothTime = micros(); } //Set a startup value here to avoid filter errors when starting. This MUST have the initial check to prevent the fuel pump just staying on all the time
   BIT_CLEAR(decoderState, BIT_DECODER_2ND_DERIV);
   BIT_SET(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT);

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -2094,10 +2094,6 @@ void triggerSec_Jeep2000(void)
   } else {
     toothCurrentCount = 0; //All we need to do is reset the tooth count back to zero, indicating that we're at the beginning of a new revolution
   }
-  
-  
-  toothCurrentCount = 0; //All we need to do is reset the tooth count back to zero, indicating that we're at the beginning of a new revolution
-  return;
 }
 
 uint16_t getRPM_Jeep2000(void)

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -41,6 +41,7 @@
 #define DECODER_ROVERMEMS		      25
 #define DECODER_SUZUKI_K6A        26
 #define DECODER_HONDA_J32         27
+#define DECODER_JEEP2000_4cyl     28
 
 #define BIT_DECODER_2ND_DERIV           0 //The use of the 2nd derivative calculation is limited to certain decoders. This is set to either true or false in each decoders setup routine
 #define BIT_DECODER_IS_SEQUENTIAL       1 //Whether or not the decoder supports sequential operation

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -135,6 +135,13 @@ uint16_t getRPM_Jeep2000(void);
 int getCrankAngle_Jeep2000(void);
 void triggerSetEndTeeth_Jeep2000(void);
 
+void triggerSetup_Jeep2000_4cyl(void);
+void triggerPri_Jeep2000_4cyl(void);
+void triggerSec_Jeep2000_4cyl(void);
+uint16_t getRPM_Jeep2000_4cyl(void);
+int getCrankAngle_Jeep2000_4cyl(void);
+void triggerSetEndTeeth_Jeep2000_4cyl(void);
+
 void triggerSetup_Audi135(void);
 void triggerPri_Audi135(void);
 void triggerSec_Audi135(void);

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -40,10 +40,10 @@
   #define CORE_AVR
   #define BOARD_H "board_avr2560.h"
   #ifndef INJ_CHANNELS
-    #define INJ_CHANNELS 4
+    #define INJ_CHANNELS 6  //must change from 5 if using 6 sequential injectors
   #endif
   #ifndef IGN_CHANNELS
-    #define IGN_CHANNELS 5
+    #define IGN_CHANNELS 3  //must change from 4 if using 6 sequential injectors
   #endif
 
   #if defined(__AVR_ATmega2561__)

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -3264,6 +3264,22 @@ void initialiseTriggers(void)
       attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
+    case DECODER_JEEP2000_4cyl:
+      triggerSetup_Jeep2000_4cyl();
+      triggerHandler = triggerPri_Jeep2000_4cyl;
+      triggerSecondaryHandler = triggerSec_Jeep2000_4cyl;
+      getRPM = getRPM_Jeep2000_4cyl;
+      getCrankAngle = getCrankAngle_Jeep2000_4cyl;
+      triggerSetEndTeeth = triggerSetEndTeeth_Jeep2000_4cyl;
+
+      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
+      else { primaryTriggerEdge = FALLING; }
+      secondaryTriggerEdge = CHANGE;
+
+      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
+      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
+      break;
+
     case DECODER_AUDI135:
       triggerSetup_Audi135();
       triggerHandler = triggerPri_Audi135;

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -1368,8 +1368,8 @@ void setPinMapping(byte boardID)
       pinCoil1 = 40; //Pin for coil 1
       pinCoil2 = 38; //Pin for coil 2
       pinCoil3 = 52; //Pin for coil 3
-      pinCoil4 = 50; //Pin for coil 4
-      pinCoil5 = 34; //Pin for coil 5 PLACEHOLDER value for now
+      //pinCoil4 = 50; //Pin for coil 4
+      //pinCoil5 = 34; //Pin for coil 5 PLACEHOLDER value for now
       pinTrigger = 19; //The CAS pin
       pinTrigger2 = 18; //The Cam Sensor pin
       pinTrigger3 = 3; //The Cam sensor 2 pin
@@ -1381,10 +1381,10 @@ void setPinMapping(byte boardID)
       pinBat = A4; //Battery reference voltage pin
       pinDisplayReset = 48; // OLED reset pin
       pinTachOut = 49; //Tacho output pin  (Goes to ULN2803)
-      pinIdle1 = 5; //Single wire idle control
+      //pinIdle1 = 5; //Single wire idle control
       pinIdle2 = 6; //2 wire idle control
       pinBoost = 7; //Boost control
-      pinVVT_1 = 4; //Default VVT output
+      //pinVVT_1 = 4; //Default VVT output
       pinVVT_2 = 48; //Default VVT2 output
       pinFuelPump = 45; //Fuel pump output  (Goes to ULN2803)
       pinStepperDir = 16; //Direction pin  for DRV8825 driver


### PR DESCRIPTION
The Jeep2000 decoder is compatible with Jeep engines from '91 to 2006. It did not support sequential injection/ignition, even though sequential operation can be selected in TunerStudio. Adding the remaining 360 degrees of tooth angles and changing the secondary trigger to only trigger going low (instead of both) was all it took to get sequential working. Tested with a mega2560 and 0.4.3d board.

DRAFT NOTE: This exact code, which includes conditionals to allow batched mode to still work, has not yet been tested, but the sequential code itself is tested and working. I hope to properly test this code this week. I also will see if I can make it 4 and 6 cylinder compatible.