### PR TITLE
Shrink coolant calibration tables

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -445,7 +445,7 @@ static uint8_t toTemperature(byte lo, byte hi)
  * @param values The table values
  * @param bins The table bin values
  */
-static void processTemperatureCalibrationTableUpdate(uint16_t calibrationLength, SensorCalibrationTable calibrationPage, uint16_t *values, uint16_t *bins)
+static void processTemperatureCalibrationTableUpdate(uint16_t calibrationLength, SensorCalibrationTable calibrationPage, uint8_t *values, uint16_t *bins)
 {
   //Temperature calibrations are sent as 32 16-bit values
   if(calibrationLength == 64U)

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -48,6 +48,16 @@ static bool isMap(void) {
 #pragma GCC optimize ("Os") 
 #endif
 
+template <typename axis_t, typename value_t, uint8_t sizeT>
+static void print2dTable(Stream &serial, axis_t (&axis)[sizeT], value_t (&values)[sizeT]) {
+  for (uint8_t x = 0U; x < sizeT; ++x)
+  {
+    serial.print(axis[x]);
+    serial.print(", ");
+    serial.println(values[x]);
+  }
+}
+
 /** Processes the incoming data on the serial buffer based on the command sent.
 Can be either data for a new command or a continuation of data for command that is already in progress:
 - cmdPending = If a command has started but is waiting on further data to complete
@@ -454,33 +464,13 @@ void legacySerialCommand(void)
     case 'Z': //Totally non-standard testing function. Will be removed once calibration testing is completed. This function takes 1.5kb of program space! :S
     #ifndef SMALL_FLASH_MODE
       primarySerial.println(F("Coolant"));
-      for (int x = 0; x < 32; x++)
-      {
-        primarySerial.print(cltCalibrationTable.axis[x]);
-        primarySerial.print(", ");
-        primarySerial.println(cltCalibrationTable.values[x]);
-      }
+      print2dTable(primarySerial, cltCalibrationTable.axis, cltCalibrationTable.values);
       primarySerial.println(F("Inlet temp"));
-      for (int x = 0; x < 32; x++)
-      {
-        primarySerial.print(iatCalibrationTable.axis[x]);
-        primarySerial.print(", ");
-        primarySerial.println(iatCalibrationTable.values[x]);
-      }
+      print2dTable(primarySerial, iatCalibrationTable.axis, iatCalibrationTable.values);
       primarySerial.println(F("O2"));
-      for (int x = 0; x < 32; x++)
-      {
-        primarySerial.print(o2CalibrationTable.axis[x]);
-        primarySerial.print(", ");
-        primarySerial.println(o2CalibrationTable.values[x]);
-      }
+      print2dTable(primarySerial, o2CalibrationTable.axis, o2CalibrationTable.values);
       primarySerial.println(F("WUE"));
-      for (int x = 0; x < 10; x++)
-      {
-        primarySerial.print(configPage4.wueBins[x]);
-        primarySerial.print(F(", "));
-        primarySerial.println(configPage2.wueValues[x]);
-      }
+      print2dTable(primarySerial, configPage4.wueBins, configPage2.wueValues);
       primarySerial.flush();
     #endif
       break;

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -116,6 +116,7 @@ void initialiseAll(void)
     setStorageAPI(getEEPROMStorageApi());
     processResetStorageRequest();
     loadAllPages();
+    loadAllCalibrationTables(); 
     doUpdates(); //Check if any data items need updating (Occurs with firmware updates)
 #endif
 
@@ -133,9 +134,6 @@ void initialiseAll(void)
 
     pPrimarySerial = &Serial; //Default to standard Serial interface
     currentStatus.allowLegacyComms = true; //Flag legacy comms as being allowed on startup
-    
-    //Setup the calibration tables
-    loadAllCalibrationTables();
 
     //Set the pin mappings
     if((configPage2.pinMapping == 255) || (configPage2.pinMapping == 0)) //255 = EEPROM value in a blank AVR; 0 = EEPROM value in new FRAM

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -40,11 +40,11 @@ volatile uint32_t flexPulseWidth = 0U;
 static map_algorithm_t mapAlgorithmState;
 
 static uint16_t cltCalibration_bins[32];
-static uint16_t cltCalibration_values[32];
-table2D_u16_u16_32 cltCalibrationTable(&cltCalibration_bins, &cltCalibration_values);
+static uint8_t cltCalibration_values[32];
+table2D_u16_u8_32 cltCalibrationTable(&cltCalibration_bins, &cltCalibration_values);
 static uint16_t iatCalibration_bins[32];
-static uint16_t iatCalibration_values[32];
-table2D_u16_u16_32 iatCalibrationTable(&iatCalibration_bins, &iatCalibration_values);
+static uint8_t iatCalibration_values[32];
+table2D_u16_u8_32 iatCalibrationTable(&iatCalibration_bins, &iatCalibration_values);
 static uint16_t o2Calibration_bins[32];
 static uint8_t o2Calibration_values[32];
 table2D_u16_u8_32 o2CalibrationTable(&o2Calibration_bins, &o2Calibration_values); 

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -97,8 +97,8 @@ int16_t getMAPDelta(void);
 /** @brief Get the time in µS between the last 2 MAP readings */
 uint32_t getMAPDeltaTime(void);
 
-extern table2D_u16_u16_32 cltCalibrationTable;
-extern table2D_u16_u16_32 iatCalibrationTable;
+extern table2D_u16_u8_32 cltCalibrationTable;
+extern table2D_u16_u8_32 iatCalibrationTable;
 extern table2D_u16_u8_32 o2CalibrationTable; 
 
 #endif // SENSORS_H

--- a/speeduino/updates.cpp
+++ b/speeduino/updates.cpp
@@ -15,21 +15,21 @@
 #include "pages.h"
 #include "comms_CAN.h"
 #include "units.h"
-#include "preprocessor.h"
+#include "unit_testing.h"
 
 // Minimize flash usage of the non-performance critical code in this file.
 #pragma GCC optimize ("Os") 
 
-static void updateTable(table2D_u16_u8_32 &targetTable, uint16_t oldEEpromBinAddress)
+TESTABLE_STATIC void updateTableU16toU8(table2D_u16_u8_32 &targetTable, uint16_t u16EEpromBinAddress)
 {
     uint16_t oldValues[32];
     static_assert(targetTable.size()==32U, "Calibration size change - fix this!");
 
     // Re-read the table axis from the old location
-    (void)loadObject(getStorageAPI(), oldEEpromBinAddress, targetTable.axis);
+    (void)loadObject(getStorageAPI(), u16EEpromBinAddress, targetTable.axis);
 
     // Read old values and update table
-    (void)loadObject(getStorageAPI(), oldEEpromBinAddress+sizeof(oldValues), oldValues);
+    (void)loadObject(getStorageAPI(), u16EEpromBinAddress+sizeof(oldValues), oldValues);
     for (uint8_t i = 0; i < targetTable.size(); i++)
     {
       targetTable.values[i] = (uint8_t)oldValues[i];
@@ -37,7 +37,7 @@ static void updateTable(table2D_u16_u8_32 &targetTable, uint16_t oldEEpromBinAdd
 }
 
 // V26 changed coolant and IAT calibration table **values** from uint16_t to uint8_t
-static void upgradeV25toV26(void) {
+TESTABLE_STATIC void upgradeV25toV26(void) {
   if(loadEEPROMVersion() == 25U)
   {
     // Old EEPROM locations
@@ -51,8 +51,8 @@ static void upgradeV25toV26(void) {
     constexpr uint16_t V25_EEPROM_CALIBRATION_O2_BINS =   V25_EEPROM_CALIBRATION_O2_VALUES-(uint16_t)sizeof(decltype(o2CalibrationTable)::axis);
     constexpr uint16_t V25_EEPROM_LAST_BARO = (V25_EEPROM_CALIBRATION_O2_BINS-(uint16_t)1);
 
-    updateTable(cltCalibrationTable, V25_EEPROM_CALIBRATION_CLT_BINS);
-    updateTable(iatCalibrationTable, V25_EEPROM_CALIBRATION_IAT_BINS);
+    updateTableU16toU8(cltCalibrationTable, V25_EEPROM_CALIBRATION_CLT_BINS);
+    updateTableU16toU8(iatCalibrationTable, V25_EEPROM_CALIBRATION_IAT_BINS);
     // Read O2 data from old location directly into table
     (void)loadObject(getStorageAPI(), V25_EEPROM_CALIBRATION_O2_BINS, o2CalibrationTable.axis);
     (void)loadObject(getStorageAPI(), V25_EEPROM_CALIBRATION_O2_VALUES, o2CalibrationTable.values);

--- a/speeduino/updates.cpp
+++ b/speeduino/updates.cpp
@@ -17,6 +17,9 @@
 #include "units.h"
 #include "preprocessor.h"
 
+// Minimize flash usage of the non-performance critical code in this file.
+#pragma GCC optimize ("Os") 
+
 static void updateTable(table2D_u16_u8_32 &targetTable, uint16_t oldEEpromBinAddress)
 {
     uint16_t oldValues[32];

--- a/speeduino/updates.cpp
+++ b/speeduino/updates.cpp
@@ -17,9 +17,53 @@
 #include "units.h"
 #include "preprocessor.h"
 
+static void updateTable(table2D_u16_u8_32 &targetTable, uint16_t oldEEpromBinAddress)
+{
+    uint16_t oldValues[32];
+    static_assert(targetTable.size()==32U, "Calibration size change - fix this!");
+
+    // Re-read the table axis from the old location
+    (void)loadObject(getStorageAPI(), oldEEpromBinAddress, targetTable.axis);
+
+    // Read old values and update table
+    (void)loadObject(getStorageAPI(), oldEEpromBinAddress+sizeof(oldValues), oldValues);
+    for (uint8_t i = 0; i < targetTable.size(); i++)
+    {
+      targetTable.values[i] = (uint8_t)oldValues[i];
+    }
+}
+
+// V26 changed coolant and IAT calibration table **values** from uint16_t to uint8_t
+static void upgradeV25toV26(void) {
+  if(loadEEPROMVersion() == 25U)
+  {
+    // Old EEPROM locations
+    constexpr uint16_t OLD_VALUE_SIZE = sizeof(table2D_u16_u16_32::values);
+    constexpr uint16_t STORAGE_END = 0xFFF;
+    constexpr uint16_t V25_EEPROM_CALIBRATION_CLT_VALUES = STORAGE_END-OLD_VALUE_SIZE;
+    constexpr uint16_t V25_EEPROM_CALIBRATION_CLT_BINS =  V25_EEPROM_CALIBRATION_CLT_VALUES-(uint16_t)sizeof(decltype(o2CalibrationTable)::axis);
+    constexpr uint16_t V25_EEPROM_CALIBRATION_IAT_VALUES = V25_EEPROM_CALIBRATION_CLT_BINS-OLD_VALUE_SIZE;
+    constexpr uint16_t V25_EEPROM_CALIBRATION_IAT_BINS = V25_EEPROM_CALIBRATION_IAT_VALUES-(uint16_t)sizeof(decltype(o2CalibrationTable)::axis);
+    constexpr uint16_t V25_EEPROM_CALIBRATION_O2_VALUES = V25_EEPROM_CALIBRATION_IAT_BINS-(uint16_t)sizeof(decltype(o2CalibrationTable)::values);
+    constexpr uint16_t V25_EEPROM_CALIBRATION_O2_BINS =   V25_EEPROM_CALIBRATION_O2_VALUES-(uint16_t)sizeof(decltype(o2CalibrationTable)::axis);
+    constexpr uint16_t V25_EEPROM_LAST_BARO = (V25_EEPROM_CALIBRATION_O2_BINS-(uint16_t)1);
+
+    updateTable(cltCalibrationTable, V25_EEPROM_CALIBRATION_CLT_BINS);
+    updateTable(iatCalibrationTable, V25_EEPROM_CALIBRATION_IAT_BINS);
+    // Read O2 data from old location directly into table
+    (void)loadObject(getStorageAPI(), V25_EEPROM_CALIBRATION_O2_BINS, o2CalibrationTable.axis);
+    (void)loadObject(getStorageAPI(), V25_EEPROM_CALIBRATION_O2_VALUES, o2CalibrationTable.values);
+    
+    saveLastBaro(getStorageAPI().read(V25_EEPROM_LAST_BARO));
+    saveAllCalibrationTables();
+
+    saveEEPROMVersion(26);
+  }
+}
+
 void doUpdates(void)
 {
-  #define CURRENT_DATA_VERSION    25
+  #define CURRENT_DATA_VERSION    26
   //Only the latest update for small flash devices must be retained
    #ifndef SMALL_FLASH_MODE
 
@@ -797,13 +841,10 @@ void doUpdates(void)
   if(loadEEPROMVersion() == 24)
   {
     //202504
-
-
-    saveAllPages();
     saveEEPROMVersion(25);
   }
-  
-  
+  upgradeV25toV26();
+
   //Final check is always for 255 and 0 (Brand new arduino)
   if( (loadEEPROMVersion() == 0) || (loadEEPROMVersion() == 255) )
   {

--- a/test/test_storage/fake_storage.cpp
+++ b/test/test_storage/fake_storage.cpp
@@ -1,0 +1,35 @@
+#include "fake_storage.h"
+
+one_byte_eeprom_t oneByteEeprom;
+
+static byte oneByteRead(uint16_t)
+{
+    ++oneByteEeprom.readCount;
+    return oneByteEeprom.readValue;
+}
+
+void oneBytWrite(uint16_t, byte value)
+{
+    ++oneByteEeprom.writeCount;
+    oneByteEeprom.lastWriteValue = value;
+}
+
+uint16_t oneByteLength(void)
+{
+    return oneByteEeprom._length;
+}
+
+uint16_t oneByteGetMaxWriteBlockSize(const statuses&)
+{
+    return oneByteEeprom._blockSize;
+}
+
+storage_api_t getOneByteStorageApi(uint16_t length, uint16_t blockSize, char readValue)
+{
+    oneByteEeprom.readValue = readValue;
+    oneByteEeprom._length = length;
+    oneByteEeprom._blockSize = blockSize;
+    oneByteEeprom.readCount = 0U;
+    oneByteEeprom.writeCount = 0U;
+    return { .read = oneByteRead, .write = oneBytWrite, .length = oneByteLength, .getMaxWriteBlockSize = oneByteGetMaxWriteBlockSize };
+}

--- a/test/test_storage/fake_storage.h
+++ b/test/test_storage/fake_storage.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "storage_api.h"
+
+struct one_byte_eeprom_t
+{
+    char readValue;
+    char lastWriteValue;
+    uint16_t _length;
+    uint16_t _blockSize;
+    uint16_t readCount;
+    uint16_t writeCount;
+};
+extern one_byte_eeprom_t oneByteEeprom;
+storage_api_t getOneByteStorageApi(uint16_t length, uint16_t blockSize, char readValue);

--- a/test/test_storage/main.cpp
+++ b/test/test_storage/main.cpp
@@ -6,10 +6,12 @@ void runAllStorageTests(void)
     extern void test_layout(void);
     extern void testStorageApi(void);
     extern void test_storage(void);
+    extern void test_update(void);
 
     test_layout();
     testStorageApi();
     test_storage();
+    test_update();
 }
 
 TEST_HARNESS(runAllStorageTests)

--- a/test/test_storage/test_layout.cpp
+++ b/test/test_storage/test_layout.cpp
@@ -155,9 +155,12 @@ const char *getEntityName(const page_iterator_t &it) {
 
 static void print_entity(const page_iterator_t &entity)
 {
-    char msg[128];
-    sprintf(msg, "%" PRIu8 ", %" PRIu8 ", %s, %s, %" PRIu16 ", %" PRIu16, entity.location.page, entity.location.index, getEntityName(entity), getEntityType(entity), getEntityStartAddress(entity), entity.address.size);
-    UnityPrint(msg); UNITY_PRINT_EOL();
+    if (EntityType::NoEntity!=entity.type)
+    {
+        char msg[128];
+        sprintf(msg, "%" PRIu8 ", %" PRIu8 ", %s, %s, %" PRIu16 ", %" PRIu16, entity.location.page, entity.location.index, getEntityName(entity), getEntityType(entity), getEntityStartAddress(entity), entity.address.size);
+        UnityPrint(msg); UNITY_PRINT_EOL();
+    }
 }
 
 static void print_page_layout(uint8_t pageNum)
@@ -179,11 +182,11 @@ static void print_eeprom_layout(void) {
 
     #define GET_VARIABLE_NAME(Variable) (#Variable)
     char msg[128];
-    sprintf(msg, "Calib. CRC, %d, %s, CRC, %" PRIu16 ", %zu", (int)SensorCalibrationTable::CoolantSensor, GET_VARIABLE_NAME(CoolantSensor), getSensorCalibrationCrcAddress(SensorCalibrationTable::CoolantSensor), sizeof(uint32_t));
+    sprintf(msg, "Calib CRC, %d, %s, CRC, %" PRIu16 ", %" PRIu16, (int)SensorCalibrationTable::CoolantSensor, GET_VARIABLE_NAME(CoolantSensor), getSensorCalibrationCrcAddress(SensorCalibrationTable::CoolantSensor), (uint16_t)sizeof(uint32_t));
     UnityPrint(msg); UNITY_PRINT_EOL();
-    sprintf(msg, "Calib. CRC, %d, %s, CRC, %" PRIu16 ", %zu", (int)SensorCalibrationTable::IntakeAirTempSensor, GET_VARIABLE_NAME(IntakeAirTempSensor), getSensorCalibrationCrcAddress(SensorCalibrationTable::IntakeAirTempSensor), sizeof(uint32_t));
+    sprintf(msg, "Calib CRC, %d, %s, CRC, %" PRIu16 ", %" PRIu16, (int)SensorCalibrationTable::IntakeAirTempSensor, GET_VARIABLE_NAME(IntakeAirTempSensor), getSensorCalibrationCrcAddress(SensorCalibrationTable::IntakeAirTempSensor), (uint16_t)sizeof(uint32_t));
     UnityPrint(msg); UNITY_PRINT_EOL();
-    sprintf(msg, "Calib. CRC, %d, %s, CRC, %" PRIu16 ", %zu", (int)SensorCalibrationTable::O2Sensor, GET_VARIABLE_NAME(O2Sensor), getSensorCalibrationCrcAddress(SensorCalibrationTable::O2Sensor), sizeof(uint32_t));
+    sprintf(msg, "Calib CRC, %d, %s, CRC, %" PRIu16 ", %" PRIu16, (int)SensorCalibrationTable::O2Sensor, GET_VARIABLE_NAME(O2Sensor), getSensorCalibrationCrcAddress(SensorCalibrationTable::O2Sensor), (uint16_t)sizeof(uint32_t));
     UnityPrint(msg); UNITY_PRINT_EOL();
     sprintf(msg, "Calibrations, 0, Calib, Calib, %" PRIu16 ", %" PRIu16, MAX_PAGE_ADDRESS, (uint16_t)(STORAGE_SIZE-MAX_PAGE_ADDRESS));
     UnityPrint(msg); UNITY_PRINT_EOL();

--- a/test/test_storage/test_storage.cpp
+++ b/test/test_storage/test_storage.cpp
@@ -3,60 +3,18 @@
 #include "storage.h"
 #include "pages.h"
 #include "sensors.h"
-
-struct infinite_eeprom_t
-{
-    char readValue;
-    uint16_t _length;
-    uint16_t _blockSize;
-    bool wasRead;
-    bool wasWritten;
-};
-
-static infinite_eeprom_t infiniteBuffer;
-
-static byte infiniteRead(uint16_t)
-{
-    infiniteBuffer.wasRead = true;
-    return infiniteBuffer.readValue;
-}
-
-void infniteWrite(uint16_t, byte)
-{
-    infiniteBuffer.wasWritten = true;
-}
-
-uint16_t infniteLength(void)
-{
-    return infiniteBuffer._length;
-}
-
-uint16_t infiniteGetMaxWriteBlockSize(const statuses&)
-{
-    return infiniteBuffer._blockSize;
-}
-
-static void setupInfniteStorageApi(uint16_t length, uint16_t blockSize, char readValue)
-{
-    infiniteBuffer.readValue = readValue;
-    infiniteBuffer._length = length;
-    infiniteBuffer._blockSize = blockSize;
-    infiniteBuffer.wasRead = false;
-    infiniteBuffer.wasWritten = false;
-    storage_api_t storage = { .read = infiniteRead, .write = infniteWrite, .length = infniteLength, .getMaxWriteBlockSize = infiniteGetMaxWriteBlockSize };
-    setStorageAPI(storage);
-}
+#include "fake_storage.h"
 
 constexpr char WRITE_MARKER = 'X';
 constexpr char BUFFER_MARKER = 'A';
 
 static void test_saveAllPages(void)
 {
-    setupInfniteStorageApi(8192, 8192, BUFFER_MARKER);
+    setStorageAPI(getOneByteStorageApi(8192, 8192, BUFFER_MARKER));
     saveAllPages();
     TEST_ASSERT_FALSE(isEepromWritePending());
 
-    setupInfniteStorageApi(8192, 16, BUFFER_MARKER);
+    setStorageAPI(getOneByteStorageApi(8192, 16, BUFFER_MARKER));
     saveAllPages();
     TEST_ASSERT_TRUE(isEepromWritePending());
 }
@@ -82,7 +40,7 @@ static void assert_page(uint8_t pageNum, char expectedContent)
 
 static void test_loadAllPages(void)
 {
-    setupInfniteStorageApi(8192, 8192, BUFFER_MARKER);
+    setStorageAPI(getOneByteStorageApi(8192, 8192, BUFFER_MARKER));
     loadAllPages();
     for (uint8_t page = MIN_PAGE_NUM; page<MAX_PAGE_NUM; ++page) {
         assert_page(page, BUFFER_MARKER);
@@ -102,7 +60,7 @@ static void assert_2dtable(const table2D<axis_t, value_t, sizeT> &table, axis_t 
 
 static void test_loadAllCalibrationTables(void)
 {
-    setupInfniteStorageApi(8192, 8192, BUFFER_MARKER);
+    setStorageAPI(getOneByteStorageApi(8192, 8192, BUFFER_MARKER));
     loadAllCalibrationTables();
     uint16_t U16_MARKER = word(BUFFER_MARKER, BUFFER_MARKER);
     constexpr uint8_t U8_MARKER = BUFFER_MARKER;
@@ -131,15 +89,15 @@ static void test_saveAllCalibrationTables(void)
     load_2dtable(iatCalibrationTable, U16_MARKER, U8_MARKER);
     load_2dtable(cltCalibrationTable, U16_MARKER, U8_MARKER);
 
-    setupInfniteStorageApi(8192, 8192, BUFFER_MARKER);
+    setStorageAPI(getOneByteStorageApi(8192, 8192, BUFFER_MARKER));
     saveAllCalibrationTables();
-    TEST_ASSERT_TRUE(infiniteBuffer.wasRead);
-    TEST_ASSERT_TRUE(infiniteBuffer.wasWritten);
+    TEST_ASSERT_GREATER_THAN(0, oneByteEeprom.readCount);
+    TEST_ASSERT_GREATER_THAN(0, oneByteEeprom.writeCount);
 
-    setupInfniteStorageApi(8192, 8192, BUFFER_MARKER);
+    setStorageAPI(getOneByteStorageApi(8192, 8192, BUFFER_MARKER));
     saveCalibrationTable((SensorCalibrationTable)-1);
-    TEST_ASSERT_FALSE(infiniteBuffer.wasRead);
-    TEST_ASSERT_FALSE(infiniteBuffer.wasWritten);
+    TEST_ASSERT_EQUAL(0, oneByteEeprom.readCount);
+    TEST_ASSERT_EQUAL(0, oneByteEeprom.writeCount);
 }
 
 void test_storage(void) {

--- a/test/test_storage/test_storage.cpp
+++ b/test/test_storage/test_storage.cpp
@@ -108,8 +108,8 @@ static void test_loadAllCalibrationTables(void)
     constexpr uint8_t U8_MARKER = BUFFER_MARKER;
 
     assert_2dtable(o2CalibrationTable, U16_MARKER, U8_MARKER);
-    assert_2dtable(iatCalibrationTable, U16_MARKER, U16_MARKER);
-    assert_2dtable(cltCalibrationTable, U16_MARKER, U16_MARKER);
+    assert_2dtable(iatCalibrationTable, U16_MARKER, U8_MARKER);
+    assert_2dtable(cltCalibrationTable, U16_MARKER, U8_MARKER);
 }
 
 template <typename axis_t, typename value_t, uint8_t sizeT>
@@ -128,8 +128,8 @@ static void test_saveAllCalibrationTables(void)
     constexpr uint8_t U8_MARKER = WRITE_MARKER;
 
     load_2dtable(o2CalibrationTable, U16_MARKER, U8_MARKER);
-    load_2dtable(iatCalibrationTable, U16_MARKER, U16_MARKER);
-    load_2dtable(cltCalibrationTable, U16_MARKER, U16_MARKER);
+    load_2dtable(iatCalibrationTable, U16_MARKER, U8_MARKER);
+    load_2dtable(cltCalibrationTable, U16_MARKER, U8_MARKER);
 
     setupInfniteStorageApi(8192, 8192, BUFFER_MARKER);
     saveAllCalibrationTables();

--- a/test/test_storage/test_update.cpp
+++ b/test/test_storage/test_update.cpp
@@ -1,0 +1,38 @@
+#include <unity.h>
+#include "../test_utils.h"
+#include "storage.h"
+#include "fake_storage.h"
+#include "table2d.h"
+
+extern void updateTableU16toU8(table2D_u16_u8_32 &targetTable, uint16_t u16EEpromBinAddress);
+
+static void test_updateTableU16toU8(void)
+{
+    uint8_t values[32];
+    uint16_t axis[32];
+    table2D_u16_u8_32 testSubject(&axis, &values);
+    constexpr uint16_t OLD_AXIS = UINT16_MAX;
+    constexpr uint8_t OLD_VALUE = 0U;
+    populate_2dtable(&testSubject, OLD_VALUE, OLD_AXIS);
+
+    constexpr uint8_t EEPROM_BYTE = 127U;
+    setStorageAPI(getOneByteStorageApi(0xFFF, 0xFFF, EEPROM_BYTE));
+    updateTableU16toU8(testSubject, 1024 /* Address doesn't matter */);
+
+    // Reads but no writes
+    TEST_ASSERT_NOT_EQUAL(0, oneByteEeprom.readCount);
+    TEST_ASSERT_EQUAL(0, oneByteEeprom.writeCount);
+
+    // Table has been updated
+    constexpr uint16_t NEW_AXIS_VALUE = ((uint16_t)EEPROM_BYTE << 8U) | EEPROM_BYTE;
+    static_assert(NEW_AXIS_VALUE!=OLD_AXIS, "Old & new need to be different for a valid test");
+    static_assert(EEPROM_BYTE!=OLD_VALUE, "Old & new need to be different for a valid test");
+    TEST_ASSERT_EACH_EQUAL_UINT16(NEW_AXIS_VALUE, axis, _countof(axis));
+    TEST_ASSERT_EACH_EQUAL_UINT8(EEPROM_BYTE, values, _countof(values));
+}
+
+void test_update(void) {
+    SET_UNITY_FILENAME() { 
+        RUN_TEST(test_updateTableU16toU8);    
+    }
+}

--- a/test/test_storage/test_update.cpp
+++ b/test/test_storage/test_update.cpp
@@ -3,8 +3,16 @@
 #include "storage.h"
 #include "fake_storage.h"
 #include "table2d.h"
+#include "sensors.h"
 
 extern void updateTableU16toU8(table2D_u16_u8_32 &targetTable, uint16_t u16EEpromBinAddress);
+extern void upgradeV25toV26(void);
+
+static void assert_2dTable(table2D_u16_u8_32 &testSubject, uint16_t newAxis, uint8_t newValue)
+{
+    TEST_ASSERT_EACH_EQUAL_UINT16(newAxis, testSubject.axis, testSubject.size());
+    TEST_ASSERT_EACH_EQUAL_UINT8(newValue, testSubject.values, testSubject.size());
+}
 
 static void test_updateTableU16toU8(void)
 {
@@ -27,12 +35,68 @@ static void test_updateTableU16toU8(void)
     constexpr uint16_t NEW_AXIS_VALUE = ((uint16_t)EEPROM_BYTE << 8U) | EEPROM_BYTE;
     static_assert(NEW_AXIS_VALUE!=OLD_AXIS, "Old & new need to be different for a valid test");
     static_assert(EEPROM_BYTE!=OLD_VALUE, "Old & new need to be different for a valid test");
-    TEST_ASSERT_EACH_EQUAL_UINT16(NEW_AXIS_VALUE, axis, _countof(axis));
-    TEST_ASSERT_EACH_EQUAL_UINT8(EEPROM_BYTE, values, _countof(values));
+    assert_2dTable(testSubject, NEW_AXIS_VALUE, EEPROM_BYTE);
+}
+
+static storage_api_t innerApi;
+static uint8_t eepromVersion = 0;
+
+static byte eepromVersionReadWrapper(uint16_t address)
+{
+    byte read = innerApi.read(address);
+    if (address==0U)
+    {
+        read = eepromVersion;
+    }
+    return read;
+}
+static storage_api_t setupEepromReadApi(uint8_t version, storage_api_t inner)
+{
+    eepromVersion = version;
+    innerApi = inner;
+    storage_api_t wrapper = inner;
+    wrapper.read = eepromVersionReadWrapper;
+    return wrapper;
+}
+
+static void test_upgradeV25toV26_positive(void)
+{
+    constexpr uint16_t OLD_AXIS = UINT16_MAX;
+    constexpr uint8_t OLD_VALUE = 0U;
+    populate_2dtable(&cltCalibrationTable, OLD_VALUE, OLD_AXIS);
+    populate_2dtable(&iatCalibrationTable, OLD_VALUE, OLD_AXIS);
+    populate_2dtable(&o2CalibrationTable, OLD_VALUE, OLD_AXIS);
+   
+    constexpr uint8_t EEPROM_BYTE = 127U;
+    setStorageAPI(setupEepromReadApi(25U, getOneByteStorageApi(0xFFF, 0xFFF, EEPROM_BYTE)));
+    upgradeV25toV26();
+
+    TEST_ASSERT_EQUAL(644, oneByteEeprom.readCount);
+    TEST_ASSERT_EQUAL(1, oneByteEeprom.writeCount);
+
+    // Tables have been updated
+    constexpr uint16_t NEW_AXIS_VALUE = ((uint16_t)EEPROM_BYTE << 8U) | EEPROM_BYTE;
+    static_assert(NEW_AXIS_VALUE!=OLD_AXIS, "Old & new need to be different for a valid test");
+    static_assert(EEPROM_BYTE!=OLD_VALUE, "Old & new need to be different for a valid test");
+    assert_2dTable(o2CalibrationTable, NEW_AXIS_VALUE, EEPROM_BYTE);
+    assert_2dTable(iatCalibrationTable, NEW_AXIS_VALUE, EEPROM_BYTE);
+    assert_2dTable(cltCalibrationTable, NEW_AXIS_VALUE, EEPROM_BYTE);
+}
+
+static void test_upgradeV25toV26_negative(void)
+{
+    constexpr uint8_t EEPROM_BYTE = 127U;
+    setStorageAPI(setupEepromReadApi(24U, getOneByteStorageApi(0xFFF, 0xFFF, EEPROM_BYTE)));
+    upgradeV25toV26();
+
+    TEST_ASSERT_EQUAL(1, oneByteEeprom.readCount);
+    TEST_ASSERT_EQUAL(0, oneByteEeprom.writeCount);
 }
 
 void test_update(void) {
     SET_UNITY_FILENAME() { 
-        RUN_TEST(test_updateTableU16toU8);    
+        RUN_TEST(test_updateTableU16toU8); 
+        RUN_TEST(test_upgradeV25toV26_positive);  
+        RUN_TEST(test_upgradeV25toV26_negative); 
     }
 }


### PR DESCRIPTION
Summary: convert coolant sensor calibration table values to `uint8_t` - saves RAM & increases speed.

The coolant and IAT calibration tables map from `uint16_t` sensor readings to `uint16_t` coolant values. But:
1. Everywhere else we store coolant values as `uint8_t`
2. The table lookup value is silently converted to `uint8_t` before being used:
```
static inline void readCLT(void)
{
  currentStatus.cltADC = LOW_PASS_FILTER(readAnalogSensor(pinCLT), configPage4.ADCFILTER_CLT, currentStatus.cltADC);
  currentStatus.coolant = temperatureRemoveOffset(table2D_getValue(&cltCalibrationTable, currentStatus.cltADC)); 
}
```
3. When populating the table we silently convert from `uint8_t` to `uint16_t`:
```
/**
 * @brief Convert 2 bytes into an offset temperature in degrees Celsius
 * @attention Returned value will be in storage temperatures
 */
static uint8_t toTemperature(byte lo, byte hi)
```