### PR TITLE
STM32F407 USB failure when SD and Secundary serial are enabled

### DIFF
--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -345,6 +345,13 @@ STM32RTC& rtc = STM32RTC::getInstance();
     #endif
 
     Serial.begin(baudRate);
+
+    #if defined(STM32F407xx)
+	  uint32_t usbStart = millis();
+      while (!Serial && (millis() - usbStart < 2000)) {
+        yield();
+      }
+	#endif
   }
 
   uint16_t freeRam()


### PR DESCRIPTION
This fix prevents the permanent hang-up of the Native USB port on STM32F407 boards when SD card and secundary serial are initialized during boot.