### PR TITLE
Fix SonarCloud-flagged reliability bugs and replace deprecated volatile ++/--

### DIFF
--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -184,9 +184,12 @@ constexpr table2D_u8_s16_6 flexBoostTable(&configPage10.flexBoostBins, &configPa
 
 //Old PID method. Retained in case the new one has issues
 //integerPID boostPID(&MAPx100, &boost_pwm_target_value, &boostTargetx100, configPage6.boostKP, configPage6.boostKI, configPage6.boostKD, DIRECT);
-static integerPID_ideal boostPID(&currentStatus.MAP, &currentStatus.boostDuty , &currentStatus.boostTarget, &configPage10.boostSens, &configPage10.boostIntv, configPage6.boostKP, configPage6.boostKI, configPage6.boostKD, DIRECT); //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
-static integerPID vvtPID(&vvt_pid_current_angle, &currentStatus.vvt1Duty, &vvt_pid_target_angle, configPage10.vvtCLKP, configPage10.vvtCLKI, configPage10.vvtCLKD, configPage6.vvtPWMdir); //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
-static integerPID vvt2PID(&vvt2_pid_current_angle, &currentStatus.vvt2Duty, &vvt2_pid_target_angle, configPage10.vvtCLKP, configPage10.vvtCLKI, configPage10.vvtCLKD, configPage4.vvt2PWMdir); //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
+// Gains and PWM direction are reapplied at runtime by SetTunings() (see boostControl/vvtControl)
+// before the PID is ever used, so we initialise them to 0/DIRECT here to avoid reading from
+// configPage globals at static-init time (cross-TU init order is unspecified).
+static integerPID_ideal boostPID(&currentStatus.MAP, &currentStatus.boostDuty , &currentStatus.boostTarget, &configPage10.boostSens, &configPage10.boostIntv, 0, 0, 0, DIRECT);
+static integerPID vvtPID(&vvt_pid_current_angle, &currentStatus.vvt1Duty, &vvt_pid_target_angle, 0, 0, 0, DIRECT);
+static integerPID vvt2PID(&vvt2_pid_current_angle, &currentStatus.vvt2Duty, &vvt2_pid_target_angle, 0, 0, 0, DIRECT);
 
 static inline void checkAirConCoolantLockout(void);
 static inline void checkAirConTPSLockout(void);

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -135,10 +135,10 @@ void flushRXbuffer(void)
  * */
 static __attribute__((noinline)) uint32_t reverse_bytes(uint32_t i)
 {
-  return  ((i>>24) & 0xffU) | // move byte 3 to byte 0
-          ((i<<8 ) & 0xff0000U) | // move byte 1 to byte 2
-          ((i>>8 ) & 0xff00U) | // move byte 2 to byte 1
-          ((i<<24) & 0xff000000U);
+  return  (((uint32_t)i >> 24) & 0xffU) | // move byte 3 to byte 0
+          (((uint32_t)i <<  8) & 0xff0000U) | // move byte 1 to byte 2
+          (((uint32_t)i >>  8) & 0xff00U) | // move byte 2 to byte 1
+          (((uint32_t)i << 24) & 0xff000000U);
 }
 
 // ====================================== Blocking IO Support ================================
@@ -172,19 +172,17 @@ static void readSerialTimeout(char *buffer, size_t length) {
  * @tparam TIntegral The integral type. E.g. uint16_t 
  */
 template <typename TIntegral>
-static __attribute__((noinline)) TIntegral readSerialIntegralTimeout(void) 
+static __attribute__((noinline)) TIntegral readSerialIntegralTimeout(void)
 {
-  // We use type punning to read into a buffer and convert to the appropriate type
-  union {
-    char raw[sizeof(TIntegral)];
-    TIntegral value;
-  } buffer;
-  readSerialTimeout(buffer.raw, sizeof(buffer.raw));
+  char raw[sizeof(TIntegral)];
+  readSerialTimeout(raw, sizeof(raw));
 
   if(isRxTimeout()) {
     return TIntegral();
   }
-  return buffer.value;
+  TIntegral value;
+  (void)memcpy(&value, raw, sizeof(value));
+  return value;
 }
 
 /** @brief Write a uint32_t to Serial 
@@ -804,10 +802,10 @@ void processSerialCommand(void)
 
           //Max blocks (4 bytes)
           uint32_t sectors = sectorCount();
-          serialPayload[5] = ((sectors >> 24) & 255);
-          serialPayload[6] = ((sectors >> 16) & 255);
-          serialPayload[7] = ((sectors >> 8) & 255);
-          serialPayload[8] = (sectors & 255);
+          serialPayload[5] = (uint8_t)(((uint32_t)sectors >> 24) & 255U);
+          serialPayload[6] = (uint8_t)(((uint32_t)sectors >> 16) & 255U);
+          serialPayload[7] = (uint8_t)(((uint32_t)sectors >> 8) & 255U);
+          serialPayload[8] = (uint8_t)(sectors & 255U);
 
           //Max roots (Number of files)
           uint16_t numLogFiles = getNextSDLogFileNumber() - 2; // -1 because this returns the NEXT file name not the current one and -1 because TS expects a 0 based index
@@ -1039,7 +1037,7 @@ void processSerialCommand(void)
             uint8_t sector3 = serialPayload[9];
             uint8_t sector4 = serialPayload[10];
             //SDreadStartSector = (sector1 << 24) | (sector2 << 16) | (sector3 << 8) | sector4;
-            SDreadStartSector = (sector4 << 24) | (sector3 << 16) | (sector2 << 8) | sector1;
+            SDreadStartSector = ((uint32_t)sector4 << 24) | ((uint32_t)sector3 << 16) | ((uint32_t)sector2 << 8) | sector1;
             //SDreadStartSector = sector4 | (sector3 << 8) | (sector2 << 16) | (sector1 << 24);
 
             //Next 4 bytes are the number of sectors to write
@@ -1047,7 +1045,7 @@ void processSerialCommand(void)
             uint8_t sectorCount2 = serialPayload[12];
             uint8_t sectorCount3 = serialPayload[13];
             uint8_t sectorCount4 = serialPayload[14];
-            SDreadNumSectors = (sectorCount1 << 24) | (sectorCount2 << 16) | (sectorCount3 << 8) | sectorCount4;
+            SDreadNumSectors = ((uint32_t)sectorCount1 << 24) | ((uint32_t)sectorCount2 << 16) | ((uint32_t)sectorCount3 << 8) | sectorCount4;
 
             //Reset the sector counter
             SDreadCompletedSectors = 0;

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -802,11 +802,10 @@ void processSerialCommand(void)
 
           //Max blocks (4 bytes)
           uint32_t sectors = sectorCount();
-          uint32_t sectorsHi = sectors >> 16;
-          serialPayload[5] = (uint8_t)(sectorsHi >> 8);
-          serialPayload[6] = (uint8_t)sectorsHi;
-          serialPayload[7] = (uint8_t)(sectors >> 8);
-          serialPayload[8] = (uint8_t)sectors;
+          serialPayload[5] = (uint8_t)((sectors / 0x01000000UL) & 0xFFU);
+          serialPayload[6] = (uint8_t)((sectors / 0x00010000UL) & 0xFFU);
+          serialPayload[7] = (uint8_t)((sectors / 0x00000100UL) & 0xFFU);
+          serialPayload[8] = (uint8_t)(sectors & 0xFFU);
 
           //Max roots (Number of files)
           uint16_t numLogFiles = getNextSDLogFileNumber() - 2; // -1 because this returns the NEXT file name not the current one and -1 because TS expects a 0 based index

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -802,10 +802,11 @@ void processSerialCommand(void)
 
           //Max blocks (4 bytes)
           uint32_t sectors = sectorCount();
-          serialPayload[5] = (uint8_t)((sectors >> 24) & 255U);
-          serialPayload[6] = (uint8_t)((sectors >> 16) & 255U);
-          serialPayload[7] = (uint8_t)((sectors >> 8) & 255U);
-          serialPayload[8] = (uint8_t)(sectors & 255U);
+          uint32_t sectorsHi = sectors >> 16;
+          serialPayload[5] = (uint8_t)(sectorsHi >> 8);
+          serialPayload[6] = (uint8_t)sectorsHi;
+          serialPayload[7] = (uint8_t)(sectors >> 8);
+          serialPayload[8] = (uint8_t)sectors;
 
           //Max roots (Number of files)
           uint16_t numLogFiles = getNextSDLogFileNumber() - 2; // -1 because this returns the NEXT file name not the current one and -1 because TS expects a 0 based index

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -135,10 +135,10 @@ void flushRXbuffer(void)
  * */
 static __attribute__((noinline)) uint32_t reverse_bytes(uint32_t i)
 {
-  return  (((uint32_t)i >> 24) & 0xffU) | // move byte 3 to byte 0
-          (((uint32_t)i <<  8) & 0xff0000U) | // move byte 1 to byte 2
-          (((uint32_t)i >>  8) & 0xff00U) | // move byte 2 to byte 1
-          (((uint32_t)i << 24) & 0xff000000U);
+  return  ((i >> 24) & 0xffU) | // move byte 3 to byte 0
+          ((i <<  8) & 0xff0000U) | // move byte 1 to byte 2
+          ((i >>  8) & 0xff00U) | // move byte 2 to byte 1
+          ((i << 24) & 0xff000000U);
 }
 
 // ====================================== Blocking IO Support ================================
@@ -174,13 +174,13 @@ static void readSerialTimeout(char *buffer, size_t length) {
 template <typename TIntegral>
 static __attribute__((noinline)) TIntegral readSerialIntegralTimeout(void)
 {
-  char raw[sizeof(TIntegral)];
+  char raw[sizeof(TIntegral)] = {};
   readSerialTimeout(raw, sizeof(raw));
 
   if(isRxTimeout()) {
     return TIntegral();
   }
-  TIntegral value;
+  TIntegral value{};
   (void)memcpy(&value, raw, sizeof(value));
   return value;
 }
@@ -802,9 +802,9 @@ void processSerialCommand(void)
 
           //Max blocks (4 bytes)
           uint32_t sectors = sectorCount();
-          serialPayload[5] = (uint8_t)(((uint32_t)sectors >> 24) & 255U);
-          serialPayload[6] = (uint8_t)(((uint32_t)sectors >> 16) & 255U);
-          serialPayload[7] = (uint8_t)(((uint32_t)sectors >> 8) & 255U);
+          serialPayload[5] = (uint8_t)((sectors >> 24) & 255U);
+          serialPayload[6] = (uint8_t)((sectors >> 16) & 255U);
+          serialPayload[7] = (uint8_t)((sectors >> 8) & 255U);
           serialPayload[8] = (uint8_t)(sectors & 255U);
 
           //Max roots (Number of files)
@@ -1032,20 +1032,18 @@ void processSerialCommand(void)
           else if((SD_arg1 == SD_WRITE_COMP_ARG1) && (SD_arg2 == SD_WRITE_COMP_ARG2))
           {
             //Prepare to read a 2024 byte chunk of data from the SD card
-            uint8_t sector1 = serialPayload[7];
-            uint8_t sector2 = serialPayload[8];
-            uint8_t sector3 = serialPayload[9];
-            uint8_t sector4 = serialPayload[10];
-            //SDreadStartSector = (sector1 << 24) | (sector2 << 16) | (sector3 << 8) | sector4;
-            SDreadStartSector = ((uint32_t)sector4 << 24) | ((uint32_t)sector3 << 16) | ((uint32_t)sector2 << 8) | sector1;
-            //SDreadStartSector = sector4 | (sector3 << 8) | (sector2 << 16) | (sector1 << 24);
+            uint32_t sector1 = serialPayload[7];
+            uint32_t sector2 = serialPayload[8];
+            uint32_t sector3 = serialPayload[9];
+            uint32_t sector4 = serialPayload[10];
+            SDreadStartSector = (sector4 << 24) | (sector3 << 16) | (sector2 << 8) | sector1;
 
             //Next 4 bytes are the number of sectors to write
-            uint8_t sectorCount1 = serialPayload[11];
-            uint8_t sectorCount2 = serialPayload[12];
-            uint8_t sectorCount3 = serialPayload[13];
-            uint8_t sectorCount4 = serialPayload[14];
-            SDreadNumSectors = ((uint32_t)sectorCount1 << 24) | ((uint32_t)sectorCount2 << 16) | ((uint32_t)sectorCount3 << 8) | sectorCount4;
+            uint32_t sectorCount1 = serialPayload[11];
+            uint32_t sectorCount2 = serialPayload[12];
+            uint32_t sectorCount3 = serialPayload[13];
+            uint32_t sectorCount4 = serialPayload[14];
+            SDreadNumSectors = (sectorCount1 << 24) | (sectorCount2 << 16) | (sectorCount3 << 8) | sectorCount4;
 
             //Reset the sector counter
             SDreadCompletedSectors = 0;

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -1093,7 +1093,7 @@ void sendToothLog(void)
     while(toothHistoryIndex < _countof(toothHistory))
     {
       toothHistory[toothHistoryIndex] = 0;
-      toothHistoryIndex++;
+      toothHistoryIndex = toothHistoryIndex + 1U;
     }
   }
 
@@ -1142,7 +1142,7 @@ void sendCompositeLog(void)
     {
       toothHistory[toothHistoryIndex] = toothHistory[toothHistoryIndex-1U]; //Composite logger needs a realistic time value to display correctly. Copy the last value
       compositeLogHistory[toothHistoryIndex] = 0U;
-      toothHistoryIndex++;
+      toothHistoryIndex = toothHistoryIndex + 1U;
     }
   }
 

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -561,10 +561,10 @@ void legacySerialHandler(byte cmd, Stream &targetPort, SerialStatus &targetStatu
         uint32_t CRC32_val = calculatePageCRC32( targetPort.read() );
         
         //Split the 4 bytes of the CRC32 value into individual bytes and send
-        targetPort.write( ((CRC32_val >> 24) & 255) );
-        targetPort.write( ((CRC32_val >> 16) & 255) );
-        targetPort.write( ((CRC32_val >> 8) & 255) );
-        targetPort.write( (CRC32_val & 255) );
+        targetPort.write( (uint8_t)(((uint32_t)CRC32_val >> 24) & 255U) );
+        targetPort.write( (uint8_t)(((uint32_t)CRC32_val >> 16) & 255U) );
+        targetPort.write( (uint8_t)(((uint32_t)CRC32_val >> 8) & 255U) );
+        targetPort.write( (uint8_t)(CRC32_val & 255U) );
         
         targetStatusFlag = SERIAL_INACTIVE;
       }
@@ -1178,10 +1178,10 @@ void sendToothLog_legacy(byte startOffset) /* Blocking */
       serialStatusFlag = SERIAL_TRANSMIT_TOOTH_INPROGRESS_LEGACY; 
       for (uint8_t x = startOffset; x < _countof(toothHistory); ++x)
       {
-        primarySerial.write(toothHistory[x] >> 24);
-        primarySerial.write(toothHistory[x] >> 16);
-        primarySerial.write(toothHistory[x] >> 8);
-        primarySerial.write(toothHistory[x]);
+        primarySerial.write((uint8_t)((uint32_t)toothHistory[x] >> 24));
+        primarySerial.write((uint8_t)((uint32_t)toothHistory[x] >> 16));
+        primarySerial.write((uint8_t)((uint32_t)toothHistory[x] >> 8));
+        primarySerial.write((uint8_t)toothHistory[x]);
       }
       currentStatus.isToothLog1Full = false;
       serialStatusFlag = SERIAL_INACTIVE; 
@@ -1216,10 +1216,10 @@ void sendCompositeLog_legacy(byte startOffset) /* Non-blocking */
 
         uint32_t inProgressCompositeTime = toothHistory[x]; //This combined runtime (in us) that the log was going for by this record)
         
-        primarySerial.write(inProgressCompositeTime >> 24);
-        primarySerial.write(inProgressCompositeTime >> 16);
-        primarySerial.write(inProgressCompositeTime >> 8);
-        primarySerial.write(inProgressCompositeTime);
+        primarySerial.write((uint8_t)(inProgressCompositeTime >> 24));
+        primarySerial.write((uint8_t)(inProgressCompositeTime >> 16));
+        primarySerial.write((uint8_t)(inProgressCompositeTime >> 8));
+        primarySerial.write((uint8_t)inProgressCompositeTime);
 
         primarySerial.write(compositeLogHistory[x]); //The status byte (Indicates the trigger edge, whether it was a pri/sec pulse, the sync status)
       }

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -561,9 +561,9 @@ void legacySerialHandler(byte cmd, Stream &targetPort, SerialStatus &targetStatu
         uint32_t CRC32_val = calculatePageCRC32( targetPort.read() );
         
         //Split the 4 bytes of the CRC32 value into individual bytes and send
-        targetPort.write( (uint8_t)(((uint32_t)CRC32_val >> 24) & 255U) );
-        targetPort.write( (uint8_t)(((uint32_t)CRC32_val >> 16) & 255U) );
-        targetPort.write( (uint8_t)(((uint32_t)CRC32_val >> 8) & 255U) );
+        targetPort.write( (uint8_t)((CRC32_val >> 24) & 255U) );
+        targetPort.write( (uint8_t)((CRC32_val >> 16) & 255U) );
+        targetPort.write( (uint8_t)((CRC32_val >> 8) & 255U) );
         targetPort.write( (uint8_t)(CRC32_val & 255U) );
         
         targetStatusFlag = SERIAL_INACTIVE;
@@ -1178,9 +1178,9 @@ void sendToothLog_legacy(byte startOffset) /* Blocking */
       serialStatusFlag = SERIAL_TRANSMIT_TOOTH_INPROGRESS_LEGACY; 
       for (uint8_t x = startOffset; x < _countof(toothHistory); ++x)
       {
-        primarySerial.write((uint8_t)((uint32_t)toothHistory[x] >> 24));
-        primarySerial.write((uint8_t)((uint32_t)toothHistory[x] >> 16));
-        primarySerial.write((uint8_t)((uint32_t)toothHistory[x] >> 8));
+        primarySerial.write((uint8_t)(toothHistory[x] >> 24));
+        primarySerial.write((uint8_t)(toothHistory[x] >> 16));
+        primarySerial.write((uint8_t)(toothHistory[x] >> 8));
         primarySerial.write((uint8_t)toothHistory[x]);
       }
       currentStatus.isToothLog1Full = false;

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -1177,7 +1177,7 @@ static inline int8_t correctionKnockTiming(int8_t advance)
           if((micros() - knockStartTime) > (configPage10.knock_stepTime * 1000UL))
           {
             //Recalculate the amount timing being pulled
-            currentStatus.knockCount++;
+            currentStatus.knockCount = currentStatus.knockCount + 1U;
             tmpKnockRetard = configPage10.knock_firstStep + ((currentStatus.knockCount - configPage10.knock_count) * configPage10.knock_stepSize);
             knockStartTime = micros();
             knockLastRecoveryStep = 0;
@@ -1210,7 +1210,7 @@ static inline int8_t correctionKnockTiming(int8_t advance)
 
         if(tmpKnockReading > configPage10.knock_threshold)
         {
-          currentStatus.knockCount++;
+          currentStatus.knockCount = currentStatus.knockCount + 1U;
           tmpKnockRetard = configPage10.knock_firstStep + ((currentStatus.knockCount - configPage10.knock_count) * configPage10.knock_stepSize);
           knockStartTime = micros();
           knockLastRecoveryStep = 0;

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -42,7 +42,10 @@ static long PID_AFRTarget;
 * Needs to be global as it maintains state outside of each function call.
 * Comes from Arduino (?) PID library.
 */
-static PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, configPage6.egoKP, configPage6.egoKI, configPage6.egoKD, REVERSE);
+// Gains are reapplied at runtime by SetTunings() in correctionAFRClosedLoop() before the PID is
+// ever used, so we initialise them to 0 here to avoid reading from configPage6 at static-init
+// time (cross-TU init order is unspecified).
+static PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, 0, 0, 0, REVERSE);
 
 static uint16_t aeActivatedReading; //The mapDOT/tpsDOT value seen when the MAE/TAE was activated. 
 

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -1638,12 +1638,11 @@ static void triggerPri_4G63(void)
         //trigger filter is turned off.
         triggerFilterTime = 0;
         if( (toothCurrentCount == 1) || (toothCurrentCount == 3) || (toothCurrentCount == 5) || (toothCurrentCount == 7) || (toothCurrentCount == 9) || (toothCurrentCount == 11) )
-        { 
-          if(configPage2.nCylinders == 4) { triggerToothAngle = 70; }
-          else  { triggerToothAngle = 70; }
-        } 
-        else 
-        { 
+        {
+          triggerToothAngle = 70;
+        }
+        else
+        {
           if(configPage2.nCylinders == 4) { triggerToothAngle = 110; }
           else  { triggerToothAngle = 50; }
         }
@@ -4293,15 +4292,8 @@ static void triggerSec_420a(void)
 static uint16_t getRPM_420a(void)
 {
   uint16_t tempRPM = 0;
-  if( currentStatus.RPM < currentStatus.crankRPM)
-  {
-    //Possibly look at doing special handling for cranking in the future, but for now just use the standard method
-    tempRPM = stdGetRPM(CAM_SPEED);
-  }
-  else
-  {
-    tempRPM = stdGetRPM(CAM_SPEED);
-  }
+  //Possibly look at doing special handling for cranking in the future (when RPM < crankRPM), but for now just use the standard method
+  tempRPM = stdGetRPM(CAM_SPEED);
   return tempRPM;
 }
 

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -202,7 +202,7 @@ static inline void addToothLogEntry(unsigned long toothTime, byte whichTooth)
     if(valueLogged == true)
     {
       currentStatus.isToothLog1Full = toothHistoryIndex >= (_countof(toothHistory)-1);
-      if (!currentStatus.isToothLog1Full) { ++toothHistoryIndex; }
+      if (!currentStatus.isToothLog1Full) { toothHistoryIndex = toothHistoryIndex + 1U; }
     }
 
 
@@ -563,7 +563,7 @@ static void triggerPri_missingTooth(void)
    curGap = curTime - toothLastToothTime;
    if ( curGap >= triggerFilterTime ) //Pulses should never be less than triggerFilterTime, so if they are it means a false trigger. (A 36-1 wheel at 8000pm will have triggers approx. every 200uS)
    {
-     toothCurrentCount++; //Increment the tooth counter
+     toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
      decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
       if( (toothLastToothTime > 0) && (toothLastMinusOneToothTime > 0) )
@@ -594,15 +594,15 @@ static void triggerPri_missingTooth(void)
             { 
                 //This occurs when we're at tooth #1, but haven't seen all the other teeth. This indicates a signal issue so we flag lost sync so this will attempt to resync on the next revolution.
                 decoderStatus.syncStatus = SyncStatus::None;
-                currentStatus.syncLossCounter++;
+                currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
             }
             //This is to handle a special case on startup where sync can be obtained and the system immediately thinks the revs have jumped:
             else
             {
                 if(decoderStatus.syncStatus!=SyncStatus::None)
                 {
-                  currentStatus.startRevolutions++; //Counter
-                  if ( configPage4.TrigSpeed == CAM_SPEED ) { currentStatus.startRevolutions++; } //Add an extra revolution count if we're running at cam speed
+                  currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
+                  if ( configPage4.TrigSpeed == CAM_SPEED ) { currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; } //Add an extra revolution count if we're running at cam speed
                 }
                 else { currentStatus.startRevolutions = 0; }
                 
@@ -701,7 +701,7 @@ static void triggerSec_missingTooth(void)
         else
         {
           triggerSecFilterTime = curGap2 >> 2; //Set filter at 25% of the current speed. Filter can only be recalc'd for the regular teeth, not the missing one.
-          secondaryToothCount++;
+          secondaryToothCount = secondaryToothCount + 1U;
         }
         break;
 
@@ -716,14 +716,14 @@ static void triggerSec_missingTooth(void)
         //Standard single tooth cam trigger
         revolutionOne = 1; //Sequential revolution reset
         triggerSecFilterTime = curGap2 >> 1; //Next secondary filter is half the current gap
-        secondaryToothCount++;
+        secondaryToothCount = secondaryToothCount + 1U;
         triggerRecordVVT1Angle();
         break;
 
       case SEC_TRIGGER_TOYOTA_3:
         // designed for Toyota VVTI (2JZ) engine - 3 triggers on the cam. 
         // the 2 teeth for this are within 1 rotation (1 tooth first 360, 2 teeth second 360)
-        secondaryToothCount++;
+        secondaryToothCount = secondaryToothCount + 1U;
         if(secondaryToothCount == 2)
         { 
           revolutionOne = 1; // sequential revolution reset
@@ -944,7 +944,7 @@ static void triggerPri_DualWheel(void)
     curGap = curTime - toothLastToothTime;
     if ( curGap >= triggerFilterTime )
     {
-      toothCurrentCount++; //Increment the tooth counter
+      toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
       decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
       toothLastMinusOneToothTime = toothLastToothTime;
@@ -958,8 +958,8 @@ static void triggerPri_DualWheel(void)
           revolutionOne = !revolutionOne; //Flip sequential revolution tracker
           toothOneMinusOneTime = toothOneTime;
           toothOneTime = curTime;
-          currentStatus.startRevolutions++; //Counter
-          if ( configPage4.TrigSpeed == CAM_SPEED ) { currentStatus.startRevolutions++; } //Add an extra revolution count if we're running at cam speed
+          currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
+          if ( configPage4.TrigSpeed == CAM_SPEED ) { currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; } //Add an extra revolution count if we're running at cam speed
         }
 
         setFilter(curGap); //Recalc the new filter value
@@ -1003,7 +1003,7 @@ static void triggerSec_DualWheel(void)
     }
     else 
     {
-      if ( (toothCurrentCount != configPage4.triggerTeeth) && (currentStatus.startRevolutions > 2)) { currentStatus.syncLossCounter++; } //Indicates likely sync loss.
+      if ( (toothCurrentCount != configPage4.triggerTeeth) && (currentStatus.startRevolutions > 2)) { currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U; } //Indicates likely sync loss.
       if (configPage4.useResync == 1) { toothCurrentCount = configPage4.triggerTeeth; }
     }
 
@@ -1159,18 +1159,18 @@ static void triggerPri_BasicDistributor(void)
       toothOneMinusOneTime = toothOneTime;
       toothOneTime = curTime;
       decoderStatus.syncStatus = SyncStatus::Full;
-      currentStatus.startRevolutions++; //Counter
+      currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
     }
     else
     {
-      if( (toothCurrentCount < triggerActualTeeth) ) { toothCurrentCount++; } //Increment the tooth counter
+      if( (toothCurrentCount < triggerActualTeeth) ) { toothCurrentCount = toothCurrentCount + 1U; } //Increment the tooth counter
       else
       {
         //This means toothCurrentCount is greater than triggerActualTeeth, which is bad.
         //If we have sync here then there's a problem. Throw a sync loss
         if( decoderStatus.syncStatus==SyncStatus::Full ) 
         { 
-          currentStatus.syncLossCounter++;
+          currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
           decoderStatus.syncStatus = SyncStatus::None;
         }
       }
@@ -1363,7 +1363,7 @@ static void triggerPri_GM7X(void)
     lastGap = curGap;
     curTime = micros();
     curGap = curTime - toothLastToothTime;
-    toothCurrentCount++; //Increment the tooth counter
+    toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
     if( (toothLastToothTime > 0) && (toothLastMinusOneToothTime > 0) )
@@ -1384,7 +1384,7 @@ static void triggerPri_GM7X(void)
           toothCurrentCount = 3;
           decoderStatus.syncStatus = SyncStatus::Full;
           decoderStatus.toothAngleIsCorrect = false; //The tooth angle is double at this point
-          currentStatus.startRevolutions++; //Counter
+          currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
         }
         else
         {
@@ -1516,14 +1516,14 @@ static void triggerPri_4G63(void)
     toothLastMinusOneToothTime = toothLastToothTime;
     toothLastToothTime = curTime;
 
-    toothCurrentCount++;
+    toothCurrentCount = toothCurrentCount + 1U;
 
     if( (toothCurrentCount == 1) || (toothCurrentCount > triggerActualTeeth) ) //Trigger is on CHANGE, hence 4 pulses = 1 crank rev (or 6 pulses for 6 cylinders)
     {
        toothCurrentCount = 1; //Reset the counter
        toothOneMinusOneTime = toothOneTime;
        toothOneTime = curTime;
-       currentStatus.startRevolutions++; //Counter
+       currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
     }
 
     if (decoderStatus.syncStatus==SyncStatus::Full)
@@ -1749,7 +1749,7 @@ static void triggerSec_4G63(void)
           { 
             // This should never be true, except when there's noise
             decoderStatus.syncStatus = SyncStatus::None;
-            currentStatus.syncLossCounter++;
+            currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
           } 
           else { toothCurrentCount = 8; } //Why? Just why?
         }
@@ -1953,12 +1953,12 @@ static void triggerPri_24X(void)
        toothOneTime = curTime;
        revolutionOne = !revolutionOne; //Sequential revolution flip
        decoderStatus.syncStatus = SyncStatus::Full;
-       currentStatus.startRevolutions++; //Counter
+       currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
        triggerToothAngle = 15; //Always 15 degrees for tooth #15
     }
     else
     {
-      toothCurrentCount++; //Increment the tooth counter
+      toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
       triggerToothAngle = toothAngles[(toothCurrentCount-1)] - toothAngles[(toothCurrentCount-2)]; //Calculate the last tooth gap in degrees
     }
 
@@ -2081,12 +2081,12 @@ static void triggerPri_Jeep2000(void)
          toothOneMinusOneTime = toothOneTime;
          toothOneTime = curTime;
          decoderStatus.syncStatus = SyncStatus::Full;
-         currentStatus.startRevolutions++; //Counter
+         currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
          triggerToothAngle = 60; //There are groups of 4 pulses (Each 20 degrees apart), with each group being 60 degrees apart. Hence #1 is always 60
       }
       else
       {
-        toothCurrentCount++; //Increment the tooth counter
+        toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
         triggerToothAngle = toothAngles[(toothCurrentCount-1)] - toothAngles[(toothCurrentCount-2)]; //Calculate the last tooth gap in degrees
       }
 
@@ -2183,7 +2183,7 @@ static void triggerPri_Audi135(void)
    curGap = curTime - toothSystemLastToothTime;
    if ( (curGap > triggerFilterTime) || (currentStatus.startRevolutions == 0) )
    {
-     toothSystemCount++;
+     toothSystemCount = toothSystemCount + 1U;
 
      if ( decoderStatus.syncStatus!=SyncStatus::Full ) { toothLastToothTime = curTime; }
      else
@@ -2195,7 +2195,7 @@ static void triggerPri_Audi135(void)
          decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
          toothSystemLastToothTime = curTime;
          toothSystemCount = 0;
-         toothCurrentCount++; //Increment the tooth counter
+         toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
 
          if ( (toothCurrentCount == 1) || (toothCurrentCount > 45) )
          {
@@ -2203,7 +2203,7 @@ static void triggerPri_Audi135(void)
            toothOneMinusOneTime = toothOneTime;
            toothOneTime = curTime;
            revolutionOne = !revolutionOne;
-           currentStatus.startRevolutions++; //Counter
+           currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
          }
 
          setFilter(curGap); //Recalc the new filter value
@@ -2307,7 +2307,7 @@ static void triggerPri_HondaD17(void)
    lastGap = curGap;
    curTime = micros();
    curGap = curTime - toothLastToothTime;
-   toothCurrentCount++; //Increment the tooth counter
+   toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
 
    decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
@@ -2320,7 +2320,7 @@ static void triggerPri_HondaD17(void)
    {
      toothOneMinusOneTime = toothOneTime;
      toothOneTime = curTime;
-     currentStatus.startRevolutions++; //Counter
+     currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
 
      toothLastMinusOneToothTime = toothLastToothTime;
      toothLastToothTime = curTime;
@@ -2432,18 +2432,18 @@ static void triggerPri_HondaJ32(void)
   
   if (decoderStatus.syncStatus==SyncStatus::Full) // We have sync
   {
-    toothCurrentCount++;
+    toothCurrentCount = toothCurrentCount + 1U;
 
     if (toothCurrentCount == 25) { // handle rollover.  Normal sized tooth here
       toothCurrentCount = 1;
       toothOneMinusOneTime = toothOneTime;
       toothOneTime = curTime;
-      currentStatus.startRevolutions++;
+      currentStatus.startRevolutions = currentStatus.startRevolutions + 1U;
       SetRevolutionTime(toothOneTime - toothOneMinusOneTime);
     }
     else if (toothCurrentCount == 23 || toothCurrentCount == 15) // This is the first tooth after a missing tooth
     {
-      toothCurrentCount++; // account for missing tooth
+      toothCurrentCount = toothCurrentCount + 1U; // account for missing tooth
       if (curGap < (lastGap >> 1) * 3) // This should be a big gap, if we find it's not actually big, we lost sync
       {
         decoderStatus.syncStatus = SyncStatus::None;
@@ -2460,7 +2460,7 @@ static void triggerPri_HondaJ32(void)
   else // we do not have sync yet. While syncing, treat tooth 14 and 22 as normal teeth
   {
     if (curGap < (lastGap >> 1) * 3 || lastGap == 0){ // Regular tooth, lastGap == 0 at startup
-      toothCurrentCount++;  // Increment teeth between gaps
+      toothCurrentCount = toothCurrentCount + 1U;  // Increment teeth between gaps
       lastGap = curGap;
     }
     else { // First tooth after the missing tooth
@@ -2558,14 +2558,14 @@ static void triggerPri_Miata9905(void)
   curGap = curTime - toothLastToothTime;
   if ( (curGap >= triggerFilterTime) || (currentStatus.startRevolutions == 0) )
   {
-    toothCurrentCount++;
+    toothCurrentCount = toothCurrentCount + 1U;
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
     if( (toothCurrentCount == (triggerActualTeeth + 1)) )
     {
        toothCurrentCount = 1; //Reset the counter
        toothOneMinusOneTime = toothOneTime;
        toothOneTime = curTime;
-       currentStatus.startRevolutions++; //Counter
+       currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
     }
     else
     {
@@ -2652,7 +2652,7 @@ static void triggerSec_Miata9905(void)
   {
     toothLastSecToothTime = curTime2;
     lastGap = curGap2;
-    secondaryToothCount++;
+    secondaryToothCount = secondaryToothCount + 1U;
 
     //TODO Add some secondary filtering here
 
@@ -2842,14 +2842,14 @@ static void triggerPri_MazdaAU(void)
   {
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
-    toothCurrentCount++;
+    toothCurrentCount = toothCurrentCount + 1U;
     if( (toothCurrentCount == 1) || (toothCurrentCount == 5) ) //Trigger is on CHANGE, hence 4 pulses = 1 crank rev
     {
        toothCurrentCount = 1; //Reset the counter
        toothOneMinusOneTime = toothOneTime;
        toothOneTime = curTime;
        decoderStatus.syncStatus = SyncStatus::Full;
-       currentStatus.startRevolutions++; //Counter
+       currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
     }
 
     if (decoderStatus.syncStatus==SyncStatus::Full)
@@ -2897,7 +2897,7 @@ static void triggerSec_MazdaAU(void)
         secondaryToothCount = 2;
       }
     }
-    secondaryToothCount++;
+    secondaryToothCount = secondaryToothCount + 1U;
   }
 }
 
@@ -3065,7 +3065,7 @@ static void triggerPri_Nissan360(void)
    curGap = curTime - toothLastToothTime;
    if ( curGap < triggerFilterTime ) { return; }
    
-   toothCurrentCount++; //Increment the tooth counter
+   toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
    decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
    toothLastMinusOneToothTime = toothLastToothTime;
@@ -3078,7 +3078,7 @@ static void triggerPri_Nissan360(void)
        toothCurrentCount = 1;
        toothOneMinusOneTime = toothOneTime;
        toothOneTime = curTime;
-       currentStatus.startRevolutions++; //Counter
+       currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
      }
      //Recalc the new filter value
      setFilter(curGap);
@@ -3148,7 +3148,7 @@ static void triggerSec_Nissan360(void)
           toothCurrentCount = 274; //End of fourth window is after 90+90+90+4 primary teeth
           decoderStatus.syncStatus = SyncStatus::Full;
         }
-        else { decoderStatus.syncStatus = SyncStatus::None; currentStatus.syncLossCounter++; } //This should really never happen
+        else { decoderStatus.syncStatus = SyncStatus::None; currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U; } //This should really never happen
       }
       else if(configPage2.nCylinders == 6)
       {
@@ -3310,8 +3310,8 @@ static void triggerPri_Subaru67(void)
   if ( curGap < triggerFilterTime ) 
   { return; }
 
-  toothCurrentCount++; //Increment the tooth counter
-  toothSystemCount++; //Used to count the number of primary pulses that have occurred since the last secondary. Is part of the noise filtering system.
+  toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
+  toothSystemCount = toothSystemCount + 1U; //Used to count the number of primary pulses that have occurred since the last secondary. Is part of the noise filtering system.
   decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
   toothLastMinusOneToothTime = toothLastToothTime;
@@ -3322,7 +3322,7 @@ static void triggerPri_Subaru67(void)
   {
     toothCurrentCount = 0; 
     decoderStatus.syncStatus = SyncStatus::None; 
-    currentStatus.syncLossCounter++;
+    currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
   } 
 
   //Sync is determined by counting the number of cam teeth that have passed between the crank teeth
@@ -3339,7 +3339,7 @@ static void triggerPri_Subaru67(void)
       else
       { 
         decoderStatus.syncStatus = SyncStatus::None; 
-        currentStatus.syncLossCounter++;     
+        currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;     
         toothCurrentCount = 5; // we don't know if its 5 or 11, but we'll be right 50% of the time and speed up getting sync 50%
       }
       secondaryToothCount = 0;
@@ -3351,7 +3351,7 @@ static void triggerPri_Subaru67(void)
       else
       { 
         decoderStatus.syncStatus = SyncStatus::None;
-        currentStatus.syncLossCounter++;
+        currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
         toothCurrentCount = 8;
       }          
       secondaryToothCount = 0;
@@ -3363,7 +3363,7 @@ static void triggerPri_Subaru67(void)
       else
       {  
         decoderStatus.syncStatus = SyncStatus::None; 
-        currentStatus.syncLossCounter++;
+        currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
         toothCurrentCount = 2;
       }
       secondaryToothCount = 0;
@@ -3373,7 +3373,7 @@ static void triggerPri_Subaru67(void)
       //Almost certainly due to noise or cranking stop/start
       decoderStatus.syncStatus = SyncStatus::None;
       decoderStatus.toothAngleIsCorrect = false;
-      currentStatus.syncLossCounter++;
+      currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
       secondaryToothCount = 0;
       break;
   }
@@ -3393,7 +3393,7 @@ static void triggerPri_Subaru67(void)
       toothCurrentCount = 1;
       toothOneMinusOneTime = toothOneTime;
       toothOneTime = curTime;
-      currentStatus.startRevolutions++; //Counter
+      currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
     }
 
     //Set the last angle between teeth for better calc accuracy
@@ -3432,7 +3432,7 @@ static void triggerSec_Subaru67(void)
     if ( curGap2 > triggerSecFilterTime ) 
     {
       toothLastSecToothTime = curTime2;
-      secondaryToothCount++;
+      secondaryToothCount = secondaryToothCount + 1U;
       toothSystemCount = 0;
       
       if(secondaryToothCount > 1)
@@ -3453,7 +3453,7 @@ static void triggerSec_Subaru67(void)
       toothSystemCount = 0; 
       secondaryToothCount = 1;
       decoderStatus.syncStatus = SyncStatus::None; // impossible to have more than 3 crank teeth between cam teeth - must have noise but can't have sync
-      currentStatus.syncLossCounter++;
+      currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
     }
     secondaryToothCount = 0;
   }
@@ -3594,7 +3594,7 @@ static void triggerPri_Daihatsu(void)
 
   //if ( curGap >= triggerFilterTime || (currentStatus.startRevolutions == 0 )
   {
-    toothSystemCount++;
+    toothSystemCount = toothSystemCount + 1U;
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
     if (decoderStatus.syncStatus==SyncStatus::Full)
@@ -3605,14 +3605,14 @@ static void triggerPri_Daihatsu(void)
          toothOneMinusOneTime = toothOneTime;
          toothOneTime = curTime;
          decoderStatus.syncStatus = SyncStatus::Full;
-         currentStatus.startRevolutions++; //Counter
+         currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
 
          //Need to set a special filter time for the next tooth
          triggerFilterTime = 20; //Fix this later
       }
       else
       {
-        toothCurrentCount++; //Increment the tooth counter
+        toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
         setFilter(curGap); //Recalc the new filter value
       }
 
@@ -3767,7 +3767,7 @@ static void triggerPri_Harley(void)
     {
         decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
         targetGap = lastGap ; //Gap is the Time to next toothtrigger, so we know where we are
-        toothCurrentCount++;
+        toothCurrentCount = toothCurrentCount + 1U;
         if (curGap > targetGap)
         {
           toothCurrentCount = 1;
@@ -3785,11 +3785,11 @@ static void triggerPri_Harley(void)
         }
         toothLastMinusOneToothTime = toothLastToothTime;
         toothLastToothTime = curTime;
-        currentStatus.startRevolutions++; //Counter
+        currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
     }
     else
     {
-      if (decoderStatus.syncStatus==SyncStatus::Full) { currentStatus.syncLossCounter++; }
+      if (decoderStatus.syncStatus==SyncStatus::Full) { currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U; }
       decoderStatus.syncStatus = SyncStatus::None;
       toothCurrentCount = 0;
     } //Primary trigger high
@@ -3899,7 +3899,7 @@ static void triggerPri_ThirtySixMinus222(void)
    curGap = curTime - toothLastToothTime;
    if ( curGap >= triggerFilterTime ) //Pulses should never be less than triggerFilterTime, so if they are it means a false trigger. (A 36-1 wheel at 8000pm will have triggers approx. every 200uS)
    {
-     toothCurrentCount++; //Increment the tooth counter
+     toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
      decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
      //Begin the missing tooth detection
@@ -3926,8 +3926,8 @@ static void triggerPri_ThirtySixMinus222(void)
          {
            //We've seen a missing tooth set, but do not yet know whether it is the single one or the double one.
            toothSystemCount = 1;
-           toothCurrentCount++;
-           toothCurrentCount++; //Accurately reflect the actual tooth count, including the skipped ones
+           toothCurrentCount = toothCurrentCount + 1U;
+           toothCurrentCount = toothCurrentCount + 1U; //Accurately reflect the actual tooth count, including the skipped ones
          }
          decoderStatus.toothAngleIsCorrect = false; //The tooth angle is double at this point
          triggerFilterTime = 0; //This is used to prevent a condition where serious intermittent signals (Eg someone furiously plugging the sensor wire in and out) can leave the filter in an unrecoverable state
@@ -3942,7 +3942,7 @@ static void triggerPri_ThirtySixMinus222(void)
          revolutionOne = !revolutionOne; //Flip sequential revolution tracker
          toothOneMinusOneTime = toothOneTime;
          toothOneTime = curTime;
-         currentStatus.startRevolutions++; //Counter
+         currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
 
        }
        else if(toothSystemCount == 1)
@@ -4078,7 +4078,7 @@ static void triggerPri_ThirtySixMinus21(void)
    curGap = curTime - toothLastToothTime;
    if ( curGap >= triggerFilterTime ) //Pulses should never be less than triggerFilterTime, so if they are it means a false trigger. (A 36-1 wheel at 8000pm will have triggers approx. every 200uS)
    {
-     toothCurrentCount++; //Increment the tooth counter
+     toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
      decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
      //Begin the missing tooth detection
@@ -4117,7 +4117,7 @@ static void triggerPri_ThirtySixMinus21(void)
          revolutionOne = !revolutionOne; //Flip sequential revolution tracker
          toothOneMinusOneTime = toothOneTime;
          toothOneTime = curTime;
-         currentStatus.startRevolutions++; //Counter
+         currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
 
        }
 
@@ -4211,7 +4211,7 @@ static void triggerPri_420a(void)
   curGap = curTime - toothLastToothTime;
   if ( curGap >= triggerFilterTime ) //Pulses should never be less than triggerFilterTime, so if they are it means a false trigger. (A 36-1 wheel at 8000pm will have triggers approx. every 200uS)
   {
-    toothCurrentCount++; //Increment the tooth counter
+    toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
     if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { curGap = 0; }
@@ -4222,7 +4222,7 @@ static void triggerPri_420a(void)
       toothCurrentCount = 1;
       toothOneMinusOneTime = toothOneTime;
       toothOneTime = curTime;
-      currentStatus.startRevolutions++; //Counter
+      currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
     }
 
     //Filter can only be recalculated for the regular teeth, not the missing one.
@@ -4262,7 +4262,7 @@ static void triggerSec_420a(void)
       //If we DO have sync, then check that the tooth count matches what we expect
       if(toothCurrentCount != 13)
       {
-        currentStatus.syncLossCounter++;
+        currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
         toothCurrentCount = 13;
       }
     }
@@ -4282,7 +4282,7 @@ static void triggerSec_420a(void)
       //If we DO have sync, then check that the tooth count matches what we expect
       if(toothCurrentCount != 5)
       {
-        currentStatus.syncLossCounter++;
+        currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
         toothCurrentCount = 5;
       }
     }
@@ -4395,7 +4395,7 @@ static void triggerPri_Webber(void)
   curGap = curTime - toothLastToothTime;
   if ( curGap >= triggerFilterTime )
   {
-    toothCurrentCount++; //Increment the tooth counter
+    toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
     if (checkSyncToothCount > 0) { checkSyncToothCount++; }
     if ( triggerSecFilterTime <= curGap ) { triggerSecFilterTime = curGap + (curGap>>1); } //150% crank tooth
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
@@ -4411,7 +4411,7 @@ static void triggerPri_Webber(void)
         revolutionOne = !revolutionOne; //Flip sequential revolution tracker
         toothOneMinusOneTime = toothOneTime;
         toothOneTime = curTime;
-        currentStatus.startRevolutions++; //Counter
+        currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
       }
 
       setFilter(curGap); //Recalc the new filter value
@@ -4449,7 +4449,7 @@ static void triggerSec_Webber(void)
       }
       else
       {
-        if ( (toothCurrentCount != (configPage4.triggerTeeth-1U)) && (currentStatus.startRevolutions > 2U)) { currentStatus.syncLossCounter++; } //Indicates likely sync loss.
+        if ( (toothCurrentCount != (configPage4.triggerTeeth-1U)) && (currentStatus.startRevolutions > 2U)) { currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U; } //Indicates likely sync loss.
         if (configPage4.useResync == 1) { toothCurrentCount = configPage4.triggerTeeth-1; }
       }
       revolutionOne = 1; //Sequential revolution reset
@@ -4468,7 +4468,7 @@ static void triggerSec_Webber(void)
     else
     {
       triggerSecFilterTime = curGap + (curGap>>1); //150% crank tooth
-      secondaryToothCount++;
+      secondaryToothCount = secondaryToothCount + 1U;
       checkSyncToothCount = 1; //Tooth 1 considered as already been seen
     } //First time might fall here, second CAM tooth will
   }
@@ -4519,7 +4519,7 @@ static void triggerSec_FordST170(void)
       else
       {
         triggerSecFilterTime = curGap2 >> 2; //Set filter at 25% of the current speed. Filter can only be recalculated for the regular teeth, not the missing one.
-        secondaryToothCount++;
+        secondaryToothCount = secondaryToothCount + 1U;
       }
 
     toothLastSecToothTime = curTime2;
@@ -4665,7 +4665,7 @@ static void triggerSec_DRZ400(void)
       toothLastToothTime = micros();
       toothLastMinusOneToothTime = micros() - ((MICROS_PER_MIN/10U) / configPage4.triggerTeeth); //Fixes RPM at 10rpm until a full revolution has taken place
       toothCurrentCount = configPage4.triggerTeeth;
-      currentStatus.syncLossCounter++;
+      currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
       decoderStatus.syncStatus = SyncStatus::Full;
     }
     else 
@@ -4728,7 +4728,7 @@ static void triggerPri_NGC(void)
   curGap = curTime - toothLastToothTime;
   if ( curGap >= triggerFilterTime ) //Pulses should never be less than triggerFilterTime, so if they are it means a false trigger.
   {
-    toothCurrentCount++;
+    toothCurrentCount = toothCurrentCount + 1U;
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
     bool isMissingTooth = false;
 
@@ -4751,7 +4751,7 @@ static void triggerPri_NGC(void)
             toothOneMinusOneTime = toothOneTime;
             toothOneTime = curTime;
 
-            if (decoderStatus.syncStatus==SyncStatus::Full) { currentStatus.startRevolutions++; }
+            if (decoderStatus.syncStatus==SyncStatus::Full) { currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; }
             else { currentStatus.startRevolutions = 0; }
           }
           else {
@@ -4781,7 +4781,7 @@ static void triggerPri_NGC(void)
             }
             // If tooth counters are not valid, set half sync bit
             else {
-              if (decoderStatus.syncStatus==SyncStatus::Full) { currentStatus.syncLossCounter++; }
+              if (decoderStatus.syncStatus==SyncStatus::Full) { currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U; }
               decoderStatus.syncStatus = SyncStatus::Partial; //If there is primary trigger but no secondary we only have half sync.
             }
           }
@@ -4790,7 +4790,7 @@ static void triggerPri_NGC(void)
         }
         else {
           // If we have found a missing tooth and don't get the next one at the correct tooth we end up here -> Resync
-          if (decoderStatus.syncStatus==SyncStatus::Full) { currentStatus.syncLossCounter++; }
+          if (decoderStatus.syncStatus==SyncStatus::Full) { currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U; }
           decoderStatus.syncStatus = SyncStatus::None;
         }
       }
@@ -4847,7 +4847,7 @@ static void triggerSec_NGC4(void)
   {
     if ( toothLastSecToothTime > 0 && toothLastMinusOneSecToothTime > 0 ) //Make sure we have enough tooth information to calculate tooth lengths
     {
-      if (secondaryToothCount > 0) { secondaryToothCount++; }
+      if (secondaryToothCount > 0) { secondaryToothCount = secondaryToothCount + 1U; }
 
       if (curGap2 >= ((3 * (toothLastSecToothTime - toothLastMinusOneSecToothTime)) >> 1)) // Check if we have a bigger gap, that is a long tooth
       {
@@ -4901,7 +4901,7 @@ static void triggerSec_NGC68(void)
         //toothAngles is reused to store the cam pattern
         if (secondaryToothCount > 0 && secondaryToothLastCount > 0) { // Only check for cam sync if we have actually detected two groups and can get cam sync
           if (toothSystemCount > 0 && secondaryToothCount == (unsigned int)toothAngles[toothSystemCount+1]) { // Do a quick check if we already have cam sync
-            toothSystemCount++;
+            toothSystemCount = toothSystemCount + 1U;
             if (toothSystemCount > configPage2.nCylinders) { toothSystemCount = 1; }
           }
           else { // Check for a pair of matching groups which tells us which group we are at, this should only happen when we don't have cam sync
@@ -4924,7 +4924,7 @@ static void triggerSec_NGC68(void)
       }
       else if (secondaryToothCount > 0) {
         //Normal tooth
-        secondaryToothCount++;
+        secondaryToothCount = secondaryToothCount + 1U;
         triggerSecFilterTime = curGap2 >> 2; //Set filter at 25% of the current speed
       }
     }
@@ -5086,7 +5086,7 @@ static void triggerPri_Vmax(void)
             decoderStatus.syncStatus = SyncStatus::Full;
             //setFilter((curGap/1.75));//Angle to this tooth is 70, next is in 40, compensating.
             setFilter( ((curGap*4)/7) );//Angle to this tooth is 70, next is in 40, compensating.
-            currentStatus.startRevolutions++; //Counter
+            currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
           }
           else if (toothCurrentCount==2)
           {
@@ -5144,16 +5144,16 @@ static void triggerPri_Vmax(void)
           decoderStatus.syncStatus = SyncStatus::Full;
         }
         else{//Wide lobe seen where it shouldn't, adding a sync error.
-          currentStatus.syncLossCounter++;
+          currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
         }
         toothCurrentCount = 1;
     }
     else if(toothCurrentCount == 6){//The 6th lobe should be wide, adding a sync error.
         toothCurrentCount = 1;
-        currentStatus.syncLossCounter++;
+        currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
     }
     else{// Small lobe, just add 1 to the toothCurrentCount.
-      toothCurrentCount++;
+      toothCurrentCount = toothCurrentCount + 1U;
     }
     lastGap = curGapLocal;
     return;
@@ -5273,7 +5273,7 @@ static void triggerPri_Renix(void)
   if ( curGap >= triggerFilterTime )   
   {
        
-    toothSystemCount++;
+    toothSystemCount = toothSystemCount + 1U;
 
     if( renixSystemLastToothTime != 0 && renixSystemLastMinusOneToothTime != 0)
     { targetGap = (2 * (renixSystemLastToothTime - renixSystemLastMinusOneToothTime));}  // in real world the physical 2 tooth gap is bigger than 2 teeth - more like 2.5
@@ -5283,14 +5283,14 @@ static void triggerPri_Renix(void)
     if( curGap >= targetGap )
     { 
       /* add two teeth to account for the gap we've just seen */      
-      toothSystemCount++;
-      toothSystemCount++;
+      toothSystemCount = toothSystemCount + 1U;
+      toothSystemCount = toothSystemCount + 1U;
    
       if( toothSystemCount != 12) // if not 12 (the first tooth after the gap) then we've lost sync
       {
         // lost sync
         decoderStatus.syncStatus = SyncStatus::None;
-        currentStatus.syncLossCounter++;            
+        currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;            
         toothSystemCount = 1; // first tooth after gap is always 1
         toothCurrentCount = 1; // Reset as we've lost sync
       }
@@ -5305,7 +5305,7 @@ static void triggerPri_Renix(void)
 
     if( toothSystemCount == 12  || toothLastToothTime == 0) // toothLastToothTime used to ensure we set the value so the code that handles the fuel pump in speeduino.ini has a value to use once the engine is running.
     {
-      toothCurrentCount++;
+      toothCurrentCount = toothCurrentCount + 1U;
 
       if( (configPage2.nCylinders == 6 && toothCurrentCount == 7) ||    // 6 Pretend teeth on the 66 tooth wheel, if get to severn rotate round back to first tooth
           (configPage2.nCylinders == 4 && toothCurrentCount == 5 ) )    // 4 Pretend teeth on the 44 tooth wheel, if get to five rotate round back to first tooth
@@ -5313,7 +5313,7 @@ static void triggerPri_Renix(void)
         toothOneMinusOneTime = toothOneTime;
         toothOneTime = curTime;
         decoderStatus.syncStatus = SyncStatus::Full;
-        currentStatus.startRevolutions++; //Counter               
+        currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter               
         revolutionOne = !revolutionOne;
         toothCurrentCount = 1;  
       }
@@ -5452,17 +5452,17 @@ static void triggerPri_RoverMEMS(void)
       if ( curGap > targetGap) // we've found a gap
       {
         roverMEMSTeethSeen = roverMEMSTeethSeen << 2; // add the space for the gap and the tooth we've just seen so shift 2 bits
-        roverMEMSTeethSeen++; // add the tooth seen to the variable
-        toothCurrentCount++; // Increment the tooth counter on the wheel (used to spot a revolution and trigger igition timing)
+        roverMEMSTeethSeen = roverMEMSTeethSeen + 1U; // add the tooth seen to the variable
+        toothCurrentCount = toothCurrentCount + 1U; // Increment the tooth counter on the wheel (used to spot a revolution and trigger igition timing)
 
         // the missing tooth gap messing up timing as it appears in different parts of the cycle. Don't update setFilter as it would be wrong with the gap
-        toothCurrentCount++;
+        toothCurrentCount = toothCurrentCount + 1U;
       }
       else //Regular (non-missing) tooth so update things
       {    
         roverMEMSTeethSeen = roverMEMSTeethSeen << 1; // make a space, shift the bits 1 place to the left
-        roverMEMSTeethSeen++; // add the tooth seen
-        toothCurrentCount++; //Increment the tooth counter on the wheel (used to spot a revolution)
+        roverMEMSTeethSeen = roverMEMSTeethSeen + 1U; // add the tooth seen
+        toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter on the wheel (used to spot a revolution)
         setFilter(curGap);
       }
 
@@ -5545,7 +5545,7 @@ static void triggerPri_RoverMEMS(void)
         else if(toothCurrentCount > triggerActualTeeth+1) // no patterns match after a rotation when we only need 32 teeth to match, we've lost sync
         {
           decoderStatus.syncStatus = SyncStatus::None;
-          currentStatus.syncLossCounter++;              
+          currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;              
         }
       }
     }
@@ -5593,7 +5593,7 @@ static void triggerRoverMEMSCommon(void)
   }
   else { decoderStatus.syncStatus = SyncStatus::Partial; } //If nothing is using sequential, we  set half sync bit
 
-  currentStatus.startRevolutions++;  
+  currentStatus.startRevolutions = currentStatus.startRevolutions + 1U;  
 }
 
 static void triggerSec_RoverMEMS(void) 
@@ -5611,7 +5611,7 @@ static void triggerSec_RoverMEMS(void)
   
   if ( curGap2 >= triggerSecFilterTime )
   {
-    secondaryToothCount++;
+    secondaryToothCount = secondaryToothCount + 1U;
     toothLastSecToothTime = curTime2;
     
 
@@ -5651,7 +5651,7 @@ static void triggerSec_RoverMEMS(void)
           revolutionOne = false;
           if(toothCurrentCount < 19)
           {
-            toothCurrentCount += 18;
+            toothCurrentCount = toothCurrentCount + 18;
           }
         }
         else if (secondaryToothCount == 4)
@@ -5660,7 +5660,7 @@ static void triggerSec_RoverMEMS(void)
           revolutionOne = true;
           if(toothCurrentCount > 17)
           {
-            toothCurrentCount -= 18;
+            toothCurrentCount = toothCurrentCount - 18;
           }
         }
         else if (secondaryToothCount == 3)
@@ -5669,7 +5669,7 @@ static void triggerSec_RoverMEMS(void)
           revolutionOne = true;
           if(toothCurrentCount < 19)
           {
-            toothCurrentCount += 18;
+            toothCurrentCount = toothCurrentCount + 18;
           }
         }
         secondaryToothCount = 1; // as we've had a gap we need to reset to this being the first tooth after the gap
@@ -5755,7 +5755,7 @@ static void triggerSetEndTeeth_RoverMEMS(void)
 decoder_t  __attribute__((optimize("Os"))) triggerSetup_RoverMEMS(void)
 {
   decoderFeatures = decoder_features_t();
-  for(toothOneTime = 0; toothOneTime < 10; toothOneTime++)   // repurpose variable temporarily to help clear ToothAngles.
+  for(toothOneTime = 0; toothOneTime < 10; toothOneTime = toothOneTime + 1U)   // repurpose variable temporarily to help clear ToothAngles.
     { toothAngles[toothOneTime] = 0; }// Repurpose ToothAngles to store data needed for this implementation.
  
   triggerFilterTime = (MICROS_PER_SEC / (MAX_RPM / 60U * 36U)); //Trigger filter time is the shortest possible time (in uS) that there can be between crank teeth (ie at max RPM). Any pulses that occur faster than this time will be discarded as noise
@@ -5799,7 +5799,7 @@ static void triggerPri_SuzukiK6A(void)
   curGap = curTime - toothLastToothTime;
   if ( (curGap >= triggerFilterTime) || (currentStatus.startRevolutions == 0U) )
   {    
-    toothCurrentCount++;
+    toothCurrentCount = toothCurrentCount + 1U;
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
     toothLastMinusOneToothTime = toothLastToothTime;
@@ -5833,7 +5833,7 @@ static void triggerPri_SuzukiK6A(void)
     {
       // Lost sync
       decoderStatus.syncStatus = SyncStatus::None; 
-      currentStatus.syncLossCounter++;
+      currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
       triggerFilterTime = 0;
       toothCurrentCount=0;
     } else {
@@ -5855,7 +5855,7 @@ static void triggerPri_SuzukiK6A(void)
         if (curGap > curGap2)
         { 
           decoderStatus.syncStatus = SyncStatus::None; 
-          currentStatus.syncLossCounter++;
+          currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
           triggerFilterTime = 0;
           toothCurrentCount=2;
         }          
@@ -5870,7 +5870,7 @@ static void triggerPri_SuzukiK6A(void)
         if (curGap < curGap2)
         { 
           decoderStatus.syncStatus = SyncStatus::None; 
-          currentStatus.syncLossCounter++;
+          currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
           triggerFilterTime = 0;
           toothCurrentCount=1;
         }
@@ -6071,7 +6071,9 @@ decoder_t  __attribute__((optimize("Os"))) triggerSetup_SuzukiK6A(void)
   configPage4.TrigSpeed = CAM_SPEED;
   triggerActualTeeth = 7;
   toothCurrentCount = 1;
-  curGap = curGap2 = curGap3 = 0;
+  curGap3 = 0;
+  curGap2 = 0;
+  curGap = 0;
 
   if(currentStatus.initialisationComplete == false) { toothLastToothTime = micros(); } //Set a startup value here to avoid filter errors when starting. This MUST have the initial check to prevent the fuel pump just staying on all the time
   else { toothLastToothTime = 0; }
@@ -6142,19 +6144,19 @@ static void triggerPri_FordTFI(void)
     if(decoderStatus.syncStatus==SyncStatus::Full) { setFilter(curGap); } //Recalc the new filter value
     else { triggerFilterTime = 0; } //If we don't yet have sync, ensure that the filter won't prevent future valid pulses from being ignored
     
-    toothCurrentCount++; //Increment the tooth counter
+    toothCurrentCount = toothCurrentCount + 1U; //Increment the tooth counter
     
     if(toothCurrentCount > triggerActualTeeth)//Check if we're back to the beginning of a revolution
     {
       if ( (decoderStatus.syncStatus==SyncStatus::Full)  && ( (lastSyncRevolution) + 3  < currentStatus.startRevolutions)) // Revolution count when signature tooth was detected, Allow up to 4 cam revolution without sync signal detected
       {
         decoderStatus.syncStatus = SyncStatus::None;
-        currentStatus.syncLossCounter++;
+        currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
       }
       toothCurrentCount = 1; //Reset the counter
       toothOneMinusOneTime = toothOneTime;
       toothOneTime = curTime;
-      currentStatus.startRevolutions++; //Counter
+      currentStatus.startRevolutions = currentStatus.startRevolutions + 1U; //Counter
     }
 
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
@@ -6218,7 +6220,7 @@ static void triggerSec_FordTFI(void)
       {
         if ( (toothCurrentCount != 2) && (currentStatus.startRevolutions > 2)) 
         { 
-          currentStatus.syncLossCounter++;
+          currentStatus.syncLossCounter = currentStatus.syncLossCounter + 1U;
         } //Indicates likely sync loss.
         if (configPage4.useResync == 1) 
         { 

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -68,7 +68,10 @@ These functions cover the PWM and stepper idle control
 Idle Control
 Currently limited to on/off control and open loop PWM and stepper drive
 */
-integerPID idlePID(&currentStatus.longRPM, &idle_pid_target_value, &idle_cl_target_rpm, configPage6.idleKP, configPage6.idleKI, configPage6.idleKD, DIRECT); //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
+// Gains are reapplied at runtime by SetTunings() (see currentIdleControl) before the PID is
+// ever used, so we initialise them to 0 here to avoid reading from configPage6 at static-init
+// time (cross-TU init order is unspecified).
+integerPID idlePID(&currentStatus.longRPM, &idle_pid_target_value, &idle_cl_target_rpm, 0, 0, 0, DIRECT);
 
 //Any common functions associated with starting the Idle
 //Typically this is enabling the PWM interrupt

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2474,7 +2474,7 @@ void setPinMapping(byte boardID)
   if ( (configPage10.wmiIndicatorPin != 0) && (configPage10.wmiIndicatorPin < BOARD_MAX_IO_PINS) ) { pinWMIIndicator = pinTranslate(configPage10.wmiIndicatorPin); }
   if ( (configPage10.wmiEnabledPin != 0) && (configPage10.wmiEnabledPin < BOARD_MAX_IO_PINS) ) { pinWMIEnabled = pinTranslate(configPage10.wmiEnabledPin); }
   if ( (configPage10.vvt2Pin != 0) && (configPage10.vvt2Pin < BOARD_MAX_IO_PINS) ) { pinVVT_2 = pinTranslate(configPage10.vvt2Pin); }
-  if ( (configPage13.onboard_log_trigger_Epin != 0 ) && (configPage13.onboard_log_trigger_Epin != 0) && (configPage13.onboard_log_tr5_Epin_pin < BOARD_MAX_IO_PINS) ) { pinSDEnable = pinTranslate(configPage13.onboard_log_tr5_Epin_pin); }
+  if ( (configPage13.onboard_log_trigger_Epin != 0 ) && (configPage13.onboard_log_tr5_Epin_pin != 0) && (configPage13.onboard_log_tr5_Epin_pin < BOARD_MAX_IO_PINS) ) { pinSDEnable = pinTranslate(configPage13.onboard_log_tr5_Epin_pin); }
   
 
   //Currently there's no default pin for Idle Up

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -971,7 +971,7 @@ void flexPulse(void)
   {
     uint16_t tempPW = clamp(micros() - flexStartTime, 0UL, (unsigned long)UINT16_MAX); //Calculate the pulse width
     flexPulseWidth = LOW_PASS_FILTER(tempPW, configPage4.FILTER_FLEX, flexPulseWidth);
-    ++flexCounter;
+    flexCounter = flexCounter + 1U; // C++20: ++ on volatile is deprecated
   }
   else
   {
@@ -1003,7 +1003,7 @@ void knockPulse(void)
 {
   if( (currentStatus.MAP < (configPage10.knock_maxMAP*2)) && (currentStatus.RPMdiv100 < configPage10.knock_maxRPM) )
   {
-    if(!currentStatus.knockRetardActive) { currentStatus.knockCount++; } //If knock is not currently active we count every pulse. If knock is already active then additional pulses will be counted in correctionKnockTiming()
+    if(!currentStatus.knockRetardActive) { currentStatus.knockCount = currentStatus.knockCount + 1U; } //If knock is not currently active we count every pulse. If knock is already active then additional pulses will be counted in correctionKnockTiming()
     currentStatus.knockPulseDetected = true;
   }
 }
@@ -1015,7 +1015,7 @@ void knockPulse(void)
 void vssPulse(void)
 {
   //TODO: Add basic filtering here
-  vssIndex++;
+  vssIndex = vssIndex + 1U; // C++20: ++ on volatile is deprecated
   if(vssIndex == VSS_SAMPLES) { vssIndex = 0U; }
 
   vssTimes[vssIndex] = micros();

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -178,7 +178,7 @@ static inline void setFuelSchedules(const statuses &current, const uint16_t (&in
  */
 BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
 {
-      if(mainLoopCount < UINT16_MAX) { mainLoopCount++; }
+      if(mainLoopCount < UINT16_MAX) { mainLoopCount = mainLoopCount + 1U; }
       LOOP_TIMER = TIMER_mask;
 
       //SERIAL Comms

--- a/speeduino/timers.cpp
+++ b/speeduino/timers.cpp
@@ -72,16 +72,18 @@ void tachoPulseLow(void)
 void oneMSInterval(void)
 {
   BIT_SET(TIMER_mask, BIT_TIMER_1KHZ);
-  ms_counter++;
+  // C++20 deprecates ++/-- and compound assignment on volatile, so use plain
+  // assignment. The semantics for these single-writer ISR counters are unchanged.
+  ms_counter = ms_counter + 1U;
 
   //Increment Loop Counters
-  loop5ms++;
-  loop20ms++;
-  loop33ms++;
-  loop66ms++;
-  loop100ms++;
-  loop250ms++;
-  loopSec++;
+  loop5ms = loop5ms + 1U;
+  loop20ms = loop20ms + 1U;
+  loop33ms = loop33ms + 1U;
+  loop66ms = loop66ms + 1U;
+  loop100ms = loop100ms + 1U;
+  loop250ms = loop250ms + 1U;
+  loopSec = loopSec + 1;
 
   applyOverDwellProtection(configPage4, currentStatus);
 
@@ -94,14 +96,14 @@ void oneMSInterval(void)
     else 
     {
       // Ramp the needle smoothly to the max over the SWEEP_RAMP time
-      if( ms_counter < TACHO_SWEEP_RAMP_MS ) { tachoSweepAccum += map(ms_counter, 0, TACHO_SWEEP_RAMP_MS, 0, tachoSweepIncr); }
-      else                                   { tachoSweepAccum += tachoSweepIncr;                                             }
-             
+      if( ms_counter < TACHO_SWEEP_RAMP_MS ) { tachoSweepAccum = tachoSweepAccum + (uint16_t)map(ms_counter, 0, TACHO_SWEEP_RAMP_MS, 0, tachoSweepIncr); }
+      else                                   { tachoSweepAccum = tachoSweepAccum + tachoSweepIncr;                                                       }
+
       // Each time it rolls over, it's time to pulse the Tach
-      if( tachoSweepAccum >= MS_PER_SEC ) 
-      {  
+      if( tachoSweepAccum >= MS_PER_SEC )
+      {
         tachoOutputFlag = READY;
-        tachoSweepAccum -= MS_PER_SEC;
+        tachoSweepAccum = tachoSweepAccum - MS_PER_SEC;
       }
     }
   }
@@ -198,15 +200,15 @@ void oneMSInterval(void)
     currentStatus.rpmDOT = (currentStatus.RPM - lastRPM_100ms) * 10; //This is the RPM per second that the engine has accelerated/decelerated in the last loop
     lastRPM_100ms = currentStatus.RPM; //Record the current RPM for next calc
 
-    if ( currentStatus.engineIsRunning ) { runSecsX10++; }
+    if ( currentStatus.engineIsRunning ) { runSecsX10 = runSecsX10 + 1U; }
     else { runSecsX10 = 0; }
 
-    if ( (currentStatus.injPrimed == false) && (seclx10 >= configPage2.primingDelay) && (currentStatus.RPM == 0) && (currentStatus.initialisationComplete == true) ) 
-    { 
-      beginInjectorPriming(); 
-      currentStatus.injPrimed = true; 
+    if ( (currentStatus.injPrimed == false) && (seclx10 >= configPage2.primingDelay) && (currentStatus.RPM == 0) && (currentStatus.initialisationComplete == true) )
+    {
+      beginInjectorPriming();
+      currentStatus.injPrimed = true;
     }
-    seclx10++;
+    seclx10 = seclx10 + 1U;
   }
 
   //4Hz loop
@@ -233,7 +235,7 @@ void oneMSInterval(void)
     if (currentStatus.engineIsRunning)
     { //NOTE - There is a potential for a ~1sec gap between engine crank starting and the runSec number being incremented. This may delay ASE!
       if (currentStatus.runSecs <= (UINT8_MAX-1U)) //Ensure we cap out at 255 and don't overflow. (which would reset ASE and cause problems with the closed loop fuelling (Which has to wait for the O2 to warmup))
-        { currentStatus.runSecs++; } //Increment our run counter by 1 second.
+        { currentStatus.runSecs = currentStatus.runSecs + 1U; } //Increment our run counter by 1 second.
     }
     //**************************************************************************************************************************************************
     //This records the number of main loops the system has completed in the last second
@@ -241,7 +243,7 @@ void oneMSInterval(void)
     mainLoopCount = 0;
     //**************************************************************************************************************************************************
     //increment secl (secl is simply a counter that increments every second and is used to track whether the system has unexpectedly reset
-    currentStatus.secl++;
+    currentStatus.secl = currentStatus.secl + 1U;
     //**************************************************************************************************************************************************
     //Check the fan output status
     if (configPage2.fanEnable >= 1)
@@ -325,9 +327,9 @@ void oneMSInterval(void)
         
         testInjectorPulseCount = 0;
       }
-      else { testInjectorPulseCount++; }
+      else { testInjectorPulseCount = testInjectorPulseCount + 1U; }
     }
-    
+
 
     //Check for pulsed ignition output test
     if( (HWTest_IGN_Pulsed > 0) )
@@ -345,9 +347,9 @@ void oneMSInterval(void)
 
         testIgnitionPulseCount = 0;
       }
-      else { testIgnitionPulseCount++; }
+      else { testIgnitionPulseCount = testIgnitionPulseCount + 1U; }
     }
-    
+
   }
 
 

--- a/test/test_general/main.cpp
+++ b/test/test_general/main.cpp
@@ -6,9 +6,17 @@ void runAllTests(void)
 {
     extern void testPinMapping(void);
     extern void testResetControl(void);
+    extern void testPolling(void);
+    extern void testTimers(void);
+    extern void testLogger(void);
+    extern void testTSCommandHandler(void);
 
     testPinMapping();
     testResetControl();
+    testPolling();
+    testTimers();
+    testLogger();
+    testTSCommandHandler();
 }
 
 TEST_HARNESS(runAllTests)

--- a/test/test_general/test_logger.cpp
+++ b/test/test_general/test_logger.cpp
@@ -1,0 +1,66 @@
+#include <unity.h>
+#include "logger.h"
+#include "../test_utils.h"
+
+// Mirror of the static fsIntIndex[] table inside is2ByteEntry().
+// MUST be kept in sync with logger.cpp.
+static constexpr uint8_t expected_2byte_keys[] = {
+  4, 14, 17, 22, 26, 28, 33, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62,
+  64, 66, 68, 70, 72, 76, 78, 80, 82, 86, 88, 90, 93, 95, 99, 104, 111,
+  121, 125, 130, 132, 134, 136
+};
+
+static bool isInExpected(uint8_t key)
+{
+  for (uint8_t i = 0U; i < (sizeof(expected_2byte_keys) / sizeof(expected_2byte_keys[0])); ++i)
+  {
+    if (expected_2byte_keys[i] == key) { return true; }
+  }
+  return false;
+}
+
+static void test_is2ByteEntry_known_2byte_keys(void)
+{
+  for (uint8_t i = 0U; i < (sizeof(expected_2byte_keys) / sizeof(expected_2byte_keys[0])); ++i)
+  {
+    TEST_ASSERT_TRUE_MESSAGE(is2ByteEntry(expected_2byte_keys[i]),
+                             "Expected key to be a 2-byte entry");
+  }
+}
+
+static void test_is2ByteEntry_exhaustive_complement(void)
+{
+  // Validate every byte 0..254 against the known-good list.
+  // (Skip 255 because it's outside the table's documented range.)
+  for (uint16_t k = 0U; k < 255U; ++k)
+  {
+    bool actual = is2ByteEntry((uint8_t)k);
+    bool expected = isInExpected((uint8_t)k);
+    TEST_ASSERT_EQUAL_MESSAGE(expected, actual,
+                              "is2ByteEntry mismatch for key");
+  }
+}
+
+static void test_is2ByteEntry_edges(void)
+{
+  // First entry in the table
+  TEST_ASSERT_TRUE(is2ByteEntry(4U));
+  // Last entry in the table
+  TEST_ASSERT_TRUE(is2ByteEntry(136U));
+  // Just below the lowest entry
+  TEST_ASSERT_FALSE(is2ByteEntry(0U));
+  TEST_ASSERT_FALSE(is2ByteEntry(3U));
+  // Just above the highest entry
+  TEST_ASSERT_FALSE(is2ByteEntry(137U));
+  TEST_ASSERT_FALSE(is2ByteEntry(200U));
+}
+
+void testLogger(void)
+{
+  SET_UNITY_FILENAME()
+  {
+    RUN_TEST(test_is2ByteEntry_known_2byte_keys);
+    RUN_TEST(test_is2ByteEntry_exhaustive_complement);
+    RUN_TEST(test_is2ByteEntry_edges);
+  }
+}

--- a/test/test_general/test_polling.cpp
+++ b/test/test_general/test_polling.cpp
@@ -1,0 +1,108 @@
+#include <unity.h>
+#include "polling.hpp"
+#include "static_for.hpp"
+#include "bit_manip.h"
+#include "../test_utils.h"
+
+static uint16_t polling_counter[3];
+
+static void incCounter0(void) { ++polling_counter[0]; }
+static void incCounter1(void) { ++polling_counter[1]; }
+static void incCounter2(void) { ++polling_counter[2]; }
+
+static void reset_counters(void)
+{
+  polling_counter[0] = 0U;
+  polling_counter[1] = 0U;
+  polling_counter[2] = 0U;
+}
+
+static void test_executePolledAction_bit_set(void)
+{
+  reset_counters();
+  polledAction_t action = { 2U, &incCounter0 };
+  byte loopTimer = 0U;
+  BIT_SET(loopTimer, 2U);
+  executePolledAction(action, loopTimer);
+  TEST_ASSERT_EQUAL_UINT16(1U, polling_counter[0]);
+}
+
+static void test_executePolledAction_bit_clear(void)
+{
+  reset_counters();
+  polledAction_t action = { 3U, &incCounter0 };
+  byte loopTimer = 0U;
+  BIT_SET(loopTimer, 5U);  // a different bit is set
+  executePolledAction(action, loopTimer);
+  TEST_ASSERT_EQUAL_UINT16(0U, polling_counter[0]);
+}
+
+static void test_executePolledArrayAction(void)
+{
+  reset_counters();
+  const polledAction_t actions[] = {
+    { 0U, &incCounter0 },
+    { 1U, &incCounter1 },
+    { 2U, &incCounter2 },
+  };
+  byte loopTimer = 0U;
+  BIT_SET(loopTimer, 0U);
+  BIT_SET(loopTimer, 2U);
+
+  executePolledArrayAction(0U, actions, loopTimer);
+  executePolledArrayAction(1U, actions, loopTimer);
+  executePolledArrayAction(2U, actions, loopTimer);
+
+  TEST_ASSERT_EQUAL_UINT16(1U, polling_counter[0]);
+  TEST_ASSERT_EQUAL_UINT16(0U, polling_counter[1]);
+  TEST_ASSERT_EQUAL_UINT16(1U, polling_counter[2]);
+}
+
+static void recordCall(uint8_t idx, uint8_t *log)
+{
+  log[idx] += 1U;
+}
+
+static void test_static_for_repeat_n(void)
+{
+  uint8_t log[10] = { 0U };
+  static_for<2U, 7U>::repeat_n(recordCall, log);
+  TEST_ASSERT_EQUAL_UINT8(0U, log[0]);
+  TEST_ASSERT_EQUAL_UINT8(0U, log[1]);
+  TEST_ASSERT_EQUAL_UINT8(1U, log[2]);
+  TEST_ASSERT_EQUAL_UINT8(1U, log[3]);
+  TEST_ASSERT_EQUAL_UINT8(1U, log[4]);
+  TEST_ASSERT_EQUAL_UINT8(1U, log[5]);
+  TEST_ASSERT_EQUAL_UINT8(1U, log[6]);
+  TEST_ASSERT_EQUAL_UINT8(0U, log[7]);
+}
+
+static void test_static_for_array_polling(void)
+{
+  reset_counters();
+  const polledAction_t actions[] = {
+    { 0U, &incCounter0 },
+    { 1U, &incCounter1 },
+    { 2U, &incCounter2 },
+  };
+  byte loopTimer = 0U;
+  BIT_SET(loopTimer, 1U);
+
+  static_for<0U, 3U>::repeat_n(executePolledArrayAction, actions, loopTimer);
+
+  TEST_ASSERT_EQUAL_UINT16(0U, polling_counter[0]);
+  TEST_ASSERT_EQUAL_UINT16(1U, polling_counter[1]);
+  TEST_ASSERT_EQUAL_UINT16(0U, polling_counter[2]);
+}
+
+void testPolling(void)
+{
+  SET_UNITY_FILENAME()
+  {
+    RUN_TEST(test_executePolledAction_bit_set);
+    RUN_TEST(test_executePolledAction_bit_clear);
+    RUN_TEST(test_executePolledArrayAction);
+    RUN_TEST(test_static_for_repeat_n);
+    RUN_TEST(test_static_for_array_polling);
+  }
+}

--- a/test/test_general/test_timers.cpp
+++ b/test/test_general/test_timers.cpp
@@ -1,19 +1,120 @@
 #include <unity.h>
 #include <Arduino.h>
+#include "globals.h"
 #include "timers.h"
+#include "sensors.h"
+#include "auxiliaries.h"
+#include "scheduledIO_direct_inj.h"
+#include "scheduledIO_direct_ign.h"
 #include "../test_utils.h"
 
-static void test_initialiseTimers_runs(void)
+extern volatile byte loop5ms;
+extern volatile byte loop20ms;
+extern volatile byte loop33ms;
+extern volatile byte loop66ms;
+extern volatile byte loop100ms;
+extern volatile byte loop250ms;
+extern volatile int loopSec;
+extern volatile uint16_t lastRPM_100ms;
+extern volatile uint8_t tachoEndTime;
+extern volatile uint16_t tachoSweepAccum;
+extern volatile uint8_t testInjectorPulseCount;
+extern volatile uint8_t testIgnitionPulseCount;
+
+static bool tm_io_initialised = false;
+
+static void ensure_tm_io_initialised(void)
 {
-  // No externally-visible state to verify; we just want the call to execute
-  // without crashing so the line coverage records execution.
+  if (tm_io_initialised) { return; }
+  // oneMSInterval() may call openInjectorN()/closeInjectorN()/beginCoilNCharge()/endCoilNCharge()
+  // when test mode is active. Those dereference the static port pointers inside fastOutputPin_t,
+  // which must be wired to real pins (any free pin numbers will do under ArduinoFake).
+  const uint8_t inj_pins[INJ_CHANNELS] = { 50U, 51U, 52U, 53U, 54U, 55U, 56U, 57U };
+  const uint8_t ign_pins[IGN_CHANNELS] = { 60U, 61U, 62U, 63U, 64U, 65U, 66U, 67U };
+  initInjDirectIO(inj_pins);
+  initIgnDirectIO(ign_pins);
+  initTacho(40U);
+  initialiseFan(41U);
+  initialiseFuelPump(configPage2, 42U);
+  tm_io_initialised = true;
+}
+
+static void reset_oneMSInterval_state(void)
+{
+  ensure_tm_io_initialised();
   initialiseTimers();
+  TIMER_mask = 0U;
+  ms_counter = 0UL;
+  lastRPM_100ms = 0U;
+  tachoOutputFlag = TACHO_INACTIVE;
+  tachoSweepAccum = 0U;
+  tachoSweepIncr = 0U;
+  tachoEndTime = 0U;
+  testInjectorPulseCount = 0U;
+  testIgnitionPulseCount = 0U;
+  HWTest_INJ_Pulsed = 0U;
+  HWTest_IGN_Pulsed = 0U;
+  mainLoopCount = 0U;
+  runSecsX10 = 0U;
+  seclx10 = 0U;
+  flexCounter = 0U;
+  flexPulseWidth = 0UL;
+
+  // Default the global config state to "do nothing" branches inside oneMSInterval().
+  configPage2.tachoDiv = 0U;
+  configPage2.tachoDuration = 6U;
+  configPage2.fanEnable = 0U;
+  configPage2.flexEnabled = false;
+  configPage2.fpPrime = 0U;
+  configPage2.primingDelay = 0U;
+  configPage4.useDwellLim = 0U;
+  configPage4.crankRPM = 40U;  // (* 10 = 400 RPM cranking)
+  configPage13.hwTestInjDuration = 1U;
+  configPage13.hwTestIgnDuration = 1U;
+
+  currentStatus.RPM = 0U;
+  currentStatus.runSecs = 0U;
+  currentStatus.secl = 0U;
+  currentStatus.loopsPerSecond = 0U;
+  currentStatus.rpmDOT = 0;
+  currentStatus.engineIsRunning = false;
+  currentStatus.engineIsCranking = false;
+  currentStatus.tachoSweepEnabled = false;
+  currentStatus.tachoAlt = false;
+  currentStatus.fpPrimed = true;     // Skip fuel pump priming branch
+  currentStatus.injPrimed = true;    // Skip injector priming branch
+  currentStatus.initialisationComplete = true;
+  currentStatus.isTestModeActive = false;
+}
+
+static void run_n_intervals(unsigned n)
+{
+  for (unsigned i = 0U; i < n; ++i) { oneMSInterval(); }
+}
+
+static void test_initialiseTimers_resets_counters(void)
+{
+  reset_oneMSInterval_state();
+  // Push counters to non-default
+  loop5ms = 99U; loop20ms = 99U; loop33ms = 99U; loop66ms = 99U;
+  loop100ms = 99U; loop250ms = 99U; loopSec = 999;
+  lastRPM_100ms = 555U;
+
+  initialiseTimers();
+  TEST_ASSERT_EQUAL_UINT8(0U, loop5ms);
+  TEST_ASSERT_EQUAL_UINT8(0U, loop20ms);
+  TEST_ASSERT_EQUAL_UINT8(0U, loop33ms);
+  TEST_ASSERT_EQUAL_UINT8(0U, loop66ms);
+  TEST_ASSERT_EQUAL_UINT8(0U, loop100ms);
+  TEST_ASSERT_EQUAL_UINT8(0U, loop250ms);
+  TEST_ASSERT_EQUAL_INT(0, loopSec);
+  TEST_ASSERT_EQUAL_UINT16(0U, lastRPM_100ms);
 }
 
 static void test_initTacho_setsInactiveFlag(void)
 {
   constexpr uint8_t pin = 30U;
-  tachoOutputFlag = ACTIVE;  // start non-default
+  tachoOutputFlag = ACTIVE;
   initTacho(pin);
   TEST_ASSERT_EQUAL(TACHO_INACTIVE, tachoOutputFlag);
 }
@@ -29,17 +130,453 @@ static void test_tachoPulseHighAndLow_togglePin(void)
   tachoPulseLow();
   TEST_ASSERT_EQUAL(LOW, digitalRead(pin));
 
-  // Toggle again to make sure the pin functions are idempotent
   tachoPulseHigh();
   TEST_ASSERT_EQUAL(HIGH, digitalRead(pin));
+}
+
+static void test_oneMSInterval_increments_counters_and_sets_1KHz(void)
+{
+  reset_oneMSInterval_state();
+  oneMSInterval();
+  TEST_ASSERT_EQUAL_UINT32(1UL, ms_counter);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_1KHZ));
+  TEST_ASSERT_EQUAL_UINT8(1U, loop5ms);
+  TEST_ASSERT_EQUAL_UINT8(1U, loop20ms);
+  TEST_ASSERT_EQUAL_UINT8(1U, loop33ms);
+  TEST_ASSERT_EQUAL_UINT8(1U, loop66ms);
+  TEST_ASSERT_EQUAL_UINT8(1U, loop100ms);
+  TEST_ASSERT_EQUAL_UINT8(1U, loop250ms);
+  TEST_ASSERT_EQUAL_INT(1, loopSec);
+}
+
+static void test_oneMSInterval_5ms_boundary_sets_200Hz(void)
+{
+  reset_oneMSInterval_state();
+  run_n_intervals(5);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_200HZ));
+  TEST_ASSERT_EQUAL_UINT8(0U, loop5ms);
+}
+
+static void test_oneMSInterval_20ms_boundary_sets_50Hz(void)
+{
+  reset_oneMSInterval_state();
+  run_n_intervals(20);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_50HZ));
+  TEST_ASSERT_EQUAL_UINT8(0U, loop20ms);
+}
+
+static void test_oneMSInterval_33ms_boundary_sets_30Hz(void)
+{
+  reset_oneMSInterval_state();
+  run_n_intervals(33);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_30HZ));
+  TEST_ASSERT_EQUAL_UINT8(0U, loop33ms);
+}
+
+static void test_oneMSInterval_66ms_boundary_sets_15Hz(void)
+{
+  reset_oneMSInterval_state();
+  run_n_intervals(66);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_15HZ));
+  TEST_ASSERT_EQUAL_UINT8(0U, loop66ms);
+}
+
+static void test_oneMSInterval_100ms_boundary_updates_rpmDOT(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.RPM = 1500U;
+  lastRPM_100ms = 1000U;
+
+  run_n_intervals(100);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_10HZ));
+  TEST_ASSERT_EQUAL_UINT8(0U, loop100ms);
+  TEST_ASSERT_EQUAL_INT(5000, currentStatus.rpmDOT);  // (1500-1000)*10
+  TEST_ASSERT_EQUAL_UINT16(1500U, lastRPM_100ms);
+}
+
+static void test_oneMSInterval_250ms_boundary_sets_4Hz(void)
+{
+  reset_oneMSInterval_state();
+  run_n_intervals(250);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_4HZ));
+  TEST_ASSERT_EQUAL_UINT8(0U, loop250ms);
+}
+
+static void test_oneMSInterval_1Hz_boundary(void)
+{
+  reset_oneMSInterval_state();
+  mainLoopCount = 7777U;
+  currentStatus.secl = 100U;
+
+  run_n_intervals(1000);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_1HZ));
+  TEST_ASSERT_EQUAL_INT(0, loopSec);
+  TEST_ASSERT_EQUAL_UINT8(101U, currentStatus.secl);
+  TEST_ASSERT_EQUAL_UINT16(7777U, currentStatus.loopsPerSecond);
+  TEST_ASSERT_EQUAL_UINT16(0U, mainLoopCount);
+  // crankRPM = configPage4.crankRPM * 10
+  TEST_ASSERT_EQUAL_UINT16(400U, currentStatus.crankRPM);
+}
+
+static void test_oneMSInterval_runSecs_increments_when_running(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.engineIsRunning = true;
+  currentStatus.runSecs = 10U;
+
+  run_n_intervals(1000);
+  TEST_ASSERT_EQUAL_UINT8(11U, currentStatus.runSecs);
+}
+
+static void test_oneMSInterval_runSecs_caps_at_255(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.engineIsRunning = true;
+  currentStatus.runSecs = 255U;
+
+  run_n_intervals(1000);
+  TEST_ASSERT_EQUAL_UINT8(255U, currentStatus.runSecs);
+}
+
+static void test_oneMSInterval_runSecsX10_running_at_10Hz(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.engineIsRunning = true;
+
+  run_n_intervals(100);
+  TEST_ASSERT_EQUAL_UINT32(1UL, runSecsX10);
+
+  run_n_intervals(100);
+  TEST_ASSERT_EQUAL_UINT32(2UL, runSecsX10);
+}
+
+static void test_oneMSInterval_runSecsX10_resets_when_not_running(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.engineIsRunning = true;
+  run_n_intervals(100);
+  TEST_ASSERT_EQUAL_UINT32(1UL, runSecsX10);
+
+  currentStatus.engineIsRunning = false;
+  run_n_intervals(100);
+  TEST_ASSERT_EQUAL_UINT32(0UL, runSecsX10);
+}
+
+static void test_oneMSInterval_tacho_ready_full_speed_to_active(void)
+{
+  reset_oneMSInterval_state();
+  configPage2.tachoDiv = 0U;       // Full speed
+  configPage2.tachoDuration = 5U;  // 5ms pulse
+  currentStatus.tachoAlt = false;
+  tachoOutputFlag = READY;
+
+  oneMSInterval();
+  TEST_ASSERT_EQUAL(ACTIVE, tachoOutputFlag);
+  // tachoEndTime = (uint8_t)ms_counter + tachoDuration ; ms_counter is 1 after oneMSInterval()
+  TEST_ASSERT_EQUAL_UINT8((uint8_t)(1U + 5U), tachoEndTime);
+  // Alt flag flipped
+  TEST_ASSERT_TRUE(currentStatus.tachoAlt);
+}
+
+static void test_oneMSInterval_tacho_ready_half_speed_skips(void)
+{
+  reset_oneMSInterval_state();
+  configPage2.tachoDiv = 1U;          // Half speed
+  currentStatus.tachoAlt = false;     // Not alternate this pulse
+  tachoOutputFlag = READY;
+
+  oneMSInterval();
+  // tachoAlt false + tachoDiv != 0 hits the else branch -> set TACHO_INACTIVE
+  TEST_ASSERT_EQUAL(TACHO_INACTIVE, tachoOutputFlag);
+  TEST_ASSERT_TRUE(currentStatus.tachoAlt);
+}
+
+static void test_oneMSInterval_tacho_active_to_inactive_at_endtime(void)
+{
+  reset_oneMSInterval_state();
+  // Drive ms_counter forward by 9 ticks first
+  run_n_intervals(9);
+  // Now ms_counter == 9. Schedule the tacho end at the next tick (ms_counter == 10).
+  tachoEndTime = (uint8_t)(ms_counter + 1U);
+  tachoOutputFlag = ACTIVE;
+
+  oneMSInterval();
+  TEST_ASSERT_EQUAL(TACHO_INACTIVE, tachoOutputFlag);
+}
+
+static void test_oneMSInterval_tacho_sweep_disables_when_running(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.tachoSweepEnabled = true;
+  currentStatus.engineIsRunning = true;
+
+  oneMSInterval();
+  TEST_ASSERT_FALSE(currentStatus.tachoSweepEnabled);
+}
+
+static void test_oneMSInterval_tacho_sweep_pulse_marks_ready(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.tachoSweepEnabled = true;
+  // Make accum overflow on the very first call: incr is added unconditionally during ramp.
+  // Pre-load accum so the first ramp-mapped add tips it past MS_PER_SEC (1000).
+  tachoSweepIncr = 1000U;
+  tachoSweepAccum = 0U;
+  ms_counter = 600UL;  // > TACHO_SWEEP_RAMP_MS (1000) is false -> use map() ramp branch
+
+  oneMSInterval();
+  // map(601, 0, 1000, 0, 1000) ~ 601, accum becomes 601 -> below MS_PER_SEC, not READY yet.
+  // Run more iterations until accum overflows; oneMSInterval also flips READY -> ACTIVE
+  // on the same call once ms_counter reaches TACHO_SWEEP_TIME_MS the sweep stops, so
+  // bound the loop conservatively.
+  bool sawPulse = (tachoOutputFlag == READY) || (tachoOutputFlag == ACTIVE);
+  for (unsigned i = 0U; i < 200U && !sawPulse; ++i)
+  {
+    oneMSInterval();
+    if ((tachoOutputFlag == READY) || (tachoOutputFlag == ACTIVE)) { sawPulse = true; }
+  }
+  TEST_ASSERT_TRUE(sawPulse);
+}
+
+static void test_oneMSInterval_test_mode_pulse_inj_emitted_at_30Hz(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.isTestModeActive = true;
+  currentStatus.RPM = 0U;
+  BIT_SET(HWTest_INJ_Pulsed, INJ1_CMD_BIT);
+  BIT_SET(HWTest_IGN_Pulsed, IGN1_CMD_BIT);
+  configPage13.hwTestInjDuration = 100U;  // Don't auto-close in this test
+  configPage13.hwTestIgnDuration = 100U;
+
+  // 33 ticks reaches the 30Hz boundary which fires the openInjectorN()/beginCoilNCharge().
+  // Just verify the call path runs without crashing — the line coverage is the goal.
+  run_n_intervals(33);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_30HZ));
+}
+
+static void test_oneMSInterval_test_mode_auto_close_inj(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.isTestModeActive = true;
+  currentStatus.RPM = 0U;
+  BIT_SET(HWTest_INJ_Pulsed, INJ1_CMD_BIT);
+  configPage13.hwTestInjDuration = 2U;
+
+  // Once testInjectorPulseCount reaches hwTestInjDuration the close path runs and
+  // testInjectorPulseCount resets to 0. Run > duration and verify the counter wraps.
+  run_n_intervals(5);
+  TEST_ASSERT_TRUE(testInjectorPulseCount <= configPage13.hwTestInjDuration);
+}
+
+static void test_oneMSInterval_test_mode_auto_end_ign(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.isTestModeActive = true;
+  currentStatus.RPM = 0U;
+  BIT_SET(HWTest_IGN_Pulsed, IGN1_CMD_BIT);
+  configPage13.hwTestIgnDuration = 2U;
+
+  run_n_intervals(5);
+  TEST_ASSERT_TRUE(testIgnitionPulseCount <= configPage13.hwTestIgnDuration);
+}
+
+static void test_oneMSInterval_flex_low_freq_yields_zero_pct(void)
+{
+  reset_oneMSInterval_state();
+  configPage2.flexEnabled = true;
+  configPage2.flexFreqLow = 50U;
+  configPage2.flexFreqHigh = 150U;
+  configPage4.FILTER_FLEX = 0U;        // No filter, immediate
+  flexCounter = 10U;                    // Below flexFreqLow
+  flexPulseWidth = 1000UL;
+  currentStatus.ethanolPct = 100U;
+
+  run_n_intervals(1000);
+  TEST_ASSERT_EQUAL_UINT8(0U, currentStatus.ethanolPct);
+  TEST_ASSERT_EQUAL_UINT32(0UL, flexCounter);
+}
+
+static void test_oneMSInterval_flex_in_band_yields_pct(void)
+{
+  reset_oneMSInterval_state();
+  configPage2.flexEnabled = true;
+  configPage2.flexFreqLow = 50U;
+  configPage2.flexFreqHigh = 150U;
+  configPage4.FILTER_FLEX = 0U;
+  flexCounter = 75U;                    // 25% ethanol
+  flexPulseWidth = 1000UL;
+  currentStatus.ethanolPct = 0U;
+
+  run_n_intervals(1000);
+  TEST_ASSERT_EQUAL_UINT8(25U, currentStatus.ethanolPct);
+}
+
+static void test_oneMSInterval_fpPrime_completes_when_rpm_zero(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.fpPrimed = false;
+  currentStatus.secl = 0U;
+  fpPrimeTime = 0U;
+  configPage2.fpPrime = 0U;            // Threshold reached immediately
+
+  run_n_intervals(1000);
+  TEST_ASSERT_TRUE(currentStatus.fpPrimed);
+}
+
+static void test_oneMSInterval_tacho_sweep_post_ramp_branch(void)
+{
+  reset_oneMSInterval_state();
+  // After the linear-ramp window, sweep adds tachoSweepIncr unconditionally.
+  // Drive ms_counter past TACHO_SWEEP_RAMP_MS but stop before TACHO_SWEEP_TIME_MS
+  // (which would auto-disable the sweep), then enable the sweep and step once.
+  ms_counter = (unsigned long)TACHO_SWEEP_RAMP_MS + 10UL;
+  currentStatus.tachoSweepEnabled = true;
+  tachoSweepIncr = 100U;
+  tachoSweepAccum = 0U;
+
+  oneMSInterval();
+  TEST_ASSERT_EQUAL_UINT16(100U, tachoSweepAccum);
+  TEST_ASSERT_TRUE(currentStatus.tachoSweepEnabled);
+}
+
+static void test_oneMSInterval_tacho_sweep_disables_on_timeout(void)
+{
+  reset_oneMSInterval_state();
+  ms_counter = (unsigned long)TACHO_SWEEP_TIME_MS - 1UL;
+  currentStatus.tachoSweepEnabled = true;
+
+  oneMSInterval();
+  // ms_counter incremented to TACHO_SWEEP_TIME_MS -> sweep disables.
+  TEST_ASSERT_FALSE(currentStatus.tachoSweepEnabled);
+}
+
+static void test_oneMSInterval_fanControl_runs_at_1Hz(void)
+{
+  reset_oneMSInterval_state();
+  configPage2.fanEnable = 1U;          // Regular on/off fan control path
+  configPage2.fanWhenOff = false;      // Engine-running gates fan
+  currentStatus.engineIsRunning = false;
+  currentStatus.coolant = 0;            // Way below any sane fan threshold
+  configPage6.fanSP = 200U;
+  configPage6.fanHyster = 5U;
+  currentStatus.fanOn = true;          // Will get cleared by fanOff()
+
+  run_n_intervals(1000);
+  TEST_ASSERT_FALSE(currentStatus.fanOn);
+}
+
+static void test_oneMSInterval_inj_priming_runs_when_rpm_zero(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.injPrimed = false;
+  currentStatus.initialisationComplete = true;
+  currentStatus.RPM = 0U;
+  currentStatus.maxInjOutputs = 0U;    // Skip actual fuel-schedule dispatch
+  configPage2.primingDelay = 0U;        // seclx10 >= 0 always
+
+  run_n_intervals(100);                 // Crosses 10Hz boundary, hits priming branch
+  TEST_ASSERT_TRUE(currentStatus.injPrimed);
+}
+
+static void test_oneMSInterval_flex_over_range_error_yields_zero_pct(void)
+{
+  reset_oneMSInterval_state();
+  configPage2.flexEnabled = true;
+  configPage2.flexFreqLow = 50U;
+  configPage2.flexFreqHigh = 150U;
+  configPage4.FILTER_FLEX = 0U;
+  flexCounter = 200U;                   // > flexFreqHigh+1 and >= flexFreqLow+19 -> error
+  flexPulseWidth = 1000UL;
+  currentStatus.ethanolPct = 50U;       // Should drop to 0 (error condition)
+
+  run_n_intervals(1000);
+  TEST_ASSERT_EQUAL_UINT8(0U, currentStatus.ethanolPct);
+  TEST_ASSERT_EQUAL_UINT32(0UL, flexCounter);
+}
+
+static void test_oneMSInterval_flex_off_by_one_correction(void)
+{
+  reset_oneMSInterval_state();
+  configPage2.flexEnabled = true;
+  configPage2.flexFreqLow = 50U;
+  configPage2.flexFreqHigh = 150U;
+  configPage4.FILTER_FLEX = 0U;
+  flexCounter = 51U;                    // tempEthPct = 1 -> off-by-one corrected to 0
+  flexPulseWidth = 1000UL;
+  currentStatus.ethanolPct = 75U;
+
+  run_n_intervals(1000);
+  TEST_ASSERT_EQUAL_UINT8(0U, currentStatus.ethanolPct);
+}
+
+static void test_oneMSInterval_flex_clamps_pulsewidth_low(void)
+{
+  reset_oneMSInterval_state();
+  configPage2.flexEnabled = true;
+  configPage2.flexFreqLow = 50U;
+  configPage2.flexFreqHigh = 150U;
+  configPage4.FILTER_FLEX = 0U;
+  flexCounter = 100U;                   // 50% ethanol
+  flexPulseWidth = 0UL;                  // Below 1000us -> clamp to 1000
+
+  run_n_intervals(1000);
+  // With pw clamped at 1000us: tempX100 = (4224*1000)/1024 - 8125 = 4125 - 8125 = -4000
+  // fuelTemp = -4000/100 = -40C
+  TEST_ASSERT_EQUAL_INT16(-40, currentStatus.fuelTemp);
+}
+
+static void test_oneMSInterval_test_mode_skipped_when_rpm_nonzero(void)
+{
+  reset_oneMSInterval_state();
+  currentStatus.isTestModeActive = true;
+  currentStatus.RPM = 1000U;             // Engine spinning -> the 30Hz test pulse
+  BIT_SET(HWTest_INJ_Pulsed, INJ1_CMD_BIT);
+  configPage13.hwTestInjDuration = 5U;
+
+  // Even with isTestModeActive, RPM != 0 means the 30Hz openInjector branch is
+  // skipped. The auto-close path however still runs because it's gated only on
+  // isTestModeActive.
+  run_n_intervals(33);
+  TEST_ASSERT_TRUE(BIT_CHECK(TIMER_mask, BIT_TIMER_30HZ));
 }
 
 void testTimers(void)
 {
   SET_UNITY_FILENAME()
   {
-    RUN_TEST(test_initialiseTimers_runs);
+    RUN_TEST(test_initialiseTimers_resets_counters);
     RUN_TEST(test_initTacho_setsInactiveFlag);
     RUN_TEST(test_tachoPulseHighAndLow_togglePin);
+    RUN_TEST(test_oneMSInterval_increments_counters_and_sets_1KHz);
+    RUN_TEST(test_oneMSInterval_5ms_boundary_sets_200Hz);
+    RUN_TEST(test_oneMSInterval_20ms_boundary_sets_50Hz);
+    RUN_TEST(test_oneMSInterval_33ms_boundary_sets_30Hz);
+    RUN_TEST(test_oneMSInterval_66ms_boundary_sets_15Hz);
+    RUN_TEST(test_oneMSInterval_100ms_boundary_updates_rpmDOT);
+    RUN_TEST(test_oneMSInterval_250ms_boundary_sets_4Hz);
+    RUN_TEST(test_oneMSInterval_1Hz_boundary);
+    RUN_TEST(test_oneMSInterval_runSecs_increments_when_running);
+    RUN_TEST(test_oneMSInterval_runSecs_caps_at_255);
+    RUN_TEST(test_oneMSInterval_runSecsX10_running_at_10Hz);
+    RUN_TEST(test_oneMSInterval_runSecsX10_resets_when_not_running);
+    RUN_TEST(test_oneMSInterval_tacho_ready_full_speed_to_active);
+    RUN_TEST(test_oneMSInterval_tacho_ready_half_speed_skips);
+    RUN_TEST(test_oneMSInterval_tacho_active_to_inactive_at_endtime);
+    RUN_TEST(test_oneMSInterval_tacho_sweep_disables_when_running);
+    RUN_TEST(test_oneMSInterval_tacho_sweep_pulse_marks_ready);
+    RUN_TEST(test_oneMSInterval_test_mode_pulse_inj_emitted_at_30Hz);
+    RUN_TEST(test_oneMSInterval_test_mode_auto_close_inj);
+    RUN_TEST(test_oneMSInterval_test_mode_auto_end_ign);
+    RUN_TEST(test_oneMSInterval_flex_low_freq_yields_zero_pct);
+    RUN_TEST(test_oneMSInterval_flex_in_band_yields_pct);
+    RUN_TEST(test_oneMSInterval_fpPrime_completes_when_rpm_zero);
+    RUN_TEST(test_oneMSInterval_tacho_sweep_post_ramp_branch);
+    RUN_TEST(test_oneMSInterval_tacho_sweep_disables_on_timeout);
+    RUN_TEST(test_oneMSInterval_fanControl_runs_at_1Hz);
+    RUN_TEST(test_oneMSInterval_inj_priming_runs_when_rpm_zero);
+    RUN_TEST(test_oneMSInterval_flex_over_range_error_yields_zero_pct);
+    RUN_TEST(test_oneMSInterval_flex_off_by_one_correction);
+    RUN_TEST(test_oneMSInterval_flex_clamps_pulsewidth_low);
+    RUN_TEST(test_oneMSInterval_test_mode_skipped_when_rpm_nonzero);
   }
 }

--- a/test/test_general/test_timers.cpp
+++ b/test/test_general/test_timers.cpp
@@ -1,0 +1,45 @@
+#include <unity.h>
+#include <Arduino.h>
+#include "timers.h"
+#include "../test_utils.h"
+
+static void test_initialiseTimers_runs(void)
+{
+  // No externally-visible state to verify; we just want the call to execute
+  // without crashing so the line coverage records execution.
+  initialiseTimers();
+}
+
+static void test_initTacho_setsInactiveFlag(void)
+{
+  constexpr uint8_t pin = 30U;
+  tachoOutputFlag = ACTIVE;  // start non-default
+  initTacho(pin);
+  TEST_ASSERT_EQUAL(TACHO_INACTIVE, tachoOutputFlag);
+}
+
+static void test_tachoPulseHighAndLow_togglePin(void)
+{
+  constexpr uint8_t pin = 31U;
+  initTacho(pin);
+
+  tachoPulseHigh();
+  TEST_ASSERT_EQUAL(HIGH, digitalRead(pin));
+
+  tachoPulseLow();
+  TEST_ASSERT_EQUAL(LOW, digitalRead(pin));
+
+  // Toggle again to make sure the pin functions are idempotent
+  tachoPulseHigh();
+  TEST_ASSERT_EQUAL(HIGH, digitalRead(pin));
+}
+
+void testTimers(void)
+{
+  SET_UNITY_FILENAME()
+  {
+    RUN_TEST(test_initialiseTimers_runs);
+    RUN_TEST(test_initTacho_setsInactiveFlag);
+    RUN_TEST(test_tachoPulseHighAndLow_togglePin);
+  }
+}

--- a/test/test_general/test_ts_command_handler.cpp
+++ b/test/test_general/test_ts_command_handler.cpp
@@ -1,0 +1,154 @@
+#include <unity.h>
+#include "globals.h"
+#include "TS_CommandButtonHandler.h"
+#include "scheduledIO_direct_inj.h"
+#include "scheduledIO_direct_ign.h"
+#include "../test_utils.h"
+
+static bool ts_io_initialised = false;
+
+static void ensure_io_initialised(void)
+{
+  if (ts_io_initialised) { return; }
+  // Cases like TS_CMD_TEST_DSBL or TS_CMD_INJ1_OFF call closeInjectorN()/endCoilN()
+  // unconditionally, which dereferences the static port pointers inside
+  // fastOutputPin_t. Those must be wired to real pins (any free pin numbers
+  // will do under ArduinoFake) before driving the handler.
+  const uint8_t inj_pins[INJ_CHANNELS] = { 50U, 51U, 52U, 53U, 54U, 55U, 56U, 57U };
+  const uint8_t ign_pins[IGN_CHANNELS] = { 60U, 61U, 62U, 63U, 64U, 65U, 66U, 67U };
+  initInjDirectIO(inj_pins);
+  initIgnDirectIO(ign_pins);
+  ts_io_initialised = true;
+}
+
+static void reset_test_mode_state(void)
+{
+  ensure_io_initialised();
+  currentStatus.RPM = 0U;
+  currentStatus.isTestModeActive = false;
+  HWTest_INJ_Pulsed = 0U;
+  HWTest_IGN_Pulsed = 0U;
+}
+
+static void test_handler_unknown_command_returns_false(void)
+{
+  reset_test_mode_state();
+  TEST_ASSERT_FALSE(TS_CommandButtonsHandler(0xFFFFU));
+}
+
+static void test_handler_test_enbl_sets_active(void)
+{
+  reset_test_mode_state();
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_TEST_ENBL));
+  TEST_ASSERT_TRUE(currentStatus.isTestModeActive);
+}
+
+static void test_handler_test_dsbl_clears_active_and_pulsed(void)
+{
+  reset_test_mode_state();
+  // First enable & flag pulsed bits, then disable
+  TS_CommandButtonsHandler(TS_CMD_TEST_ENBL);
+  HWTest_INJ_Pulsed = 0xFFU;
+  HWTest_IGN_Pulsed = 0xFFU;
+
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_TEST_DSBL));
+  TEST_ASSERT_FALSE(currentStatus.isTestModeActive);
+  TEST_ASSERT_EQUAL_UINT8(0U, HWTest_INJ_Pulsed);
+  TEST_ASSERT_EQUAL_UINT8(0U, HWTest_IGN_Pulsed);
+}
+
+static void test_handler_rejects_stop_required_when_engine_running(void)
+{
+  reset_test_mode_state();
+  currentStatus.RPM = 1000U;  // engine running
+  // INJ1_ON is in the stop-required range
+  TEST_ASSERT_FALSE(TS_CommandButtonsHandler(TS_CMD_INJ1_ON));
+  // Verify the command did not flip test mode on
+  TEST_ASSERT_FALSE(currentStatus.isTestModeActive);
+}
+
+static void test_handler_inj1_pulsed_sets_bit_when_active(void)
+{
+  reset_test_mode_state();
+  TS_CommandButtonsHandler(TS_CMD_TEST_ENBL);
+
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_INJ1_PULSED));
+  TEST_ASSERT_TRUE(BIT_CHECK(HWTest_INJ_Pulsed, INJ1_CMD_BIT));
+}
+
+static void test_handler_inj1_off_clears_pulsed_bit(void)
+{
+  reset_test_mode_state();
+  TS_CommandButtonsHandler(TS_CMD_TEST_ENBL);
+  TS_CommandButtonsHandler(TS_CMD_INJ1_PULSED);
+  TEST_ASSERT_TRUE(BIT_CHECK(HWTest_INJ_Pulsed, INJ1_CMD_BIT));
+
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_INJ1_OFF));
+  TEST_ASSERT_FALSE(BIT_CHECK(HWTest_INJ_Pulsed, INJ1_CMD_BIT));
+}
+
+static void test_handler_ign1_pulsed_sets_bit_when_active(void)
+{
+  reset_test_mode_state();
+  TS_CommandButtonsHandler(TS_CMD_TEST_ENBL);
+
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_IGN1_PULSED));
+  TEST_ASSERT_TRUE(BIT_CHECK(HWTest_IGN_Pulsed, IGN1_CMD_BIT));
+}
+
+static void test_handler_ign1_pulsed_inactive_no_bit_set(void)
+{
+  reset_test_mode_state();
+  // Test mode NOT active — pulsed should not set bit
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_IGN1_PULSED));
+  TEST_ASSERT_FALSE(BIT_CHECK(HWTest_IGN_Pulsed, IGN1_CMD_BIT));
+}
+
+static void test_handler_inj_on_inactive_does_not_open(void)
+{
+  reset_test_mode_state();
+  // Without test mode active, INJ_ON returns true but should not modify state
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_INJ1_ON));
+  // No state change to verify positively, but the case path is now covered
+}
+
+static void test_handler_vss_ratio1_with_vss(void)
+{
+  reset_test_mode_state();
+  currentStatus.vss = 50U;
+  currentStatus.RPM = 2000U;
+  configPage2.vssRatio1 = 0U;
+
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_VSS_RATIO1));
+  // Expected: (50 * 10000) / 2000 = 250
+  TEST_ASSERT_EQUAL_UINT16(250U, configPage2.vssRatio1);
+  TEST_ASSERT_TRUE(currentStatus.vssUiRefresh);
+}
+
+static void test_handler_vss_ratio1_no_vss_no_change(void)
+{
+  reset_test_mode_state();
+  currentStatus.vss = 0U;
+  configPage2.vssRatio1 = 999U;
+
+  TEST_ASSERT_TRUE(TS_CommandButtonsHandler(TS_CMD_VSS_RATIO1));
+  TEST_ASSERT_EQUAL_UINT16(999U, configPage2.vssRatio1);
+}
+
+void testTSCommandHandler(void)
+{
+  SET_UNITY_FILENAME()
+  {
+    RUN_TEST(test_handler_unknown_command_returns_false);
+    RUN_TEST(test_handler_test_enbl_sets_active);
+    RUN_TEST(test_handler_test_dsbl_clears_active_and_pulsed);
+    RUN_TEST(test_handler_rejects_stop_required_when_engine_running);
+    RUN_TEST(test_handler_inj1_pulsed_sets_bit_when_active);
+    RUN_TEST(test_handler_inj1_off_clears_pulsed_bit);
+    RUN_TEST(test_handler_ign1_pulsed_sets_bit_when_active);
+    RUN_TEST(test_handler_ign1_pulsed_inactive_no_bit_set);
+    RUN_TEST(test_handler_inj_on_inactive_does_not_open);
+    RUN_TEST(test_handler_vss_ratio1_with_vss);
+    RUN_TEST(test_handler_vss_ratio1_no_vss_no_change);
+  }
+}

--- a/test/test_init/main.cpp
+++ b/test/test_init/main.cpp
@@ -28,10 +28,12 @@ void runAllInitTests(void)
     extern void testInitialisation(void);
     extern void testFuelScheduleInit(void);
     extern void testIgnitionScheduleInit(void);
+    extern void testBoardPinMappings(void);
 
     testInitialisation();
     testFuelScheduleInit();
     testIgnitionScheduleInit();
+    testBoardPinMappings();
 }
 
 TEST_HARNESS(runAllInitTests)

--- a/test/test_init/test_board_pin_mappings.cpp
+++ b/test/test_init/test_board_pin_mappings.cpp
@@ -144,6 +144,42 @@ static void test_setPinMapping_default_triggerTeeth_preserved(void)
   TEST_ASSERT_EQUAL_UINT8(24U, configPage4.triggerTeeth);
 }
 
+// pinSDEnable is assigned only when the SD trigger mode is non-zero AND the
+// configured trigger pin is non-zero AND in range. This reaches a branch that
+// previously had a copy-paste bug (the same field was checked twice) — the
+// bug let pinSDEnable be assigned when tr5_Epin_pin was 0.
+static void test_setPinMapping_sdEnable_assigned_when_trigger_and_pin_valid(void)
+{
+  setTuneToEmpty();
+  pinSDEnable = 0U;
+  configPage13.onboard_log_trigger_Epin = 1U;       // any non-zero mode
+  configPage13.onboard_log_tr5_Epin_pin = 5U;       // valid digital pin
+  setPinMapping(3U);
+  TEST_ASSERT_EQUAL_UINT8(5U, pinSDEnable);
+}
+
+static void test_setPinMapping_sdEnable_skipped_when_pin_zero(void)
+{
+  // Regression guard: with the old duplicated && operand this test would fail
+  // because pinSDEnable would be assigned 0 via pinTranslate(0).
+  setTuneToEmpty();
+  pinSDEnable = 99U;                                // sentinel
+  configPage13.onboard_log_trigger_Epin = 1U;
+  configPage13.onboard_log_tr5_Epin_pin = 0U;       // zero pin -> skip
+  setPinMapping(3U);
+  TEST_ASSERT_EQUAL_UINT8(99U, pinSDEnable);
+}
+
+static void test_setPinMapping_sdEnable_skipped_when_trigger_zero(void)
+{
+  setTuneToEmpty();
+  pinSDEnable = 99U;
+  configPage13.onboard_log_trigger_Epin = 0U;       // disabled
+  configPage13.onboard_log_tr5_Epin_pin = 5U;
+  setPinMapping(3U);
+  TEST_ASSERT_EQUAL_UINT8(99U, pinSDEnable);
+}
+
 static void test_setPinMapping_resets_output_controls_to_direct(void)
 {
   // setPinMapping() unconditionally resets injector & ignition output control
@@ -177,6 +213,9 @@ void testBoardPinMappings(void)
     RUN_TEST_P(test_setPinMapping_board45);
     RUN_TEST_P(test_setPinMapping_default_triggerTeeth_guard);
     RUN_TEST_P(test_setPinMapping_default_triggerTeeth_preserved);
+    RUN_TEST_P(test_setPinMapping_sdEnable_assigned_when_trigger_and_pin_valid);
+    RUN_TEST_P(test_setPinMapping_sdEnable_skipped_when_pin_zero);
+    RUN_TEST_P(test_setPinMapping_sdEnable_skipped_when_trigger_zero);
     RUN_TEST_P(test_setPinMapping_resets_output_controls_to_direct);
   }
 }

--- a/test/test_init/test_board_pin_mappings.cpp
+++ b/test/test_init/test_board_pin_mappings.cpp
@@ -1,0 +1,182 @@
+#include <unity.h>
+#include "globals.h"
+#include "init.h"
+#include "pages.h"
+#include "../test_utils.h"
+
+void prepareForInitialiseAll(uint8_t boardId);
+
+// Each native-compatible case in setPinMapping() assigns the core injector,
+// coil, trigger and fuel-pump pins. For coverage purposes we only need to
+// dispatch the switch and verify the case body actually ran (i.e. left the
+// pin globals in a non-default state). We deliberately keep the assertions
+// loose because the goal is exercising the case branches across as many
+// board layouts as possible — the existing initialiseAll() tests already
+// pin down the exact wiring for the V0.3, V0.4 and MX5 boards.
+
+static void assert_core_pins_assigned(const char *label)
+{
+  // pinInjector1 / pinCoil1 are always set inside every native-compatible
+  // case in setPinMapping(). If we land in a default/empty case they stay
+  // zero, which is also what setTuneToEmpty() leaves them at.
+  TEST_ASSERT_NOT_EQUAL_MESSAGE(0U, pinInjector1, label);
+  TEST_ASSERT_NOT_EQUAL_MESSAGE(0U, pinCoil1, label);
+}
+
+static void apply_board(uint8_t boardId)
+{
+  setTuneToEmpty();
+  configPage2.pinMapping = boardId;
+  setPinMapping(boardId);
+}
+
+static void test_setPinMapping_board1_v02(void)
+{
+  apply_board(1U);
+  assert_core_pins_assigned("Board 1 (V0.2)");
+}
+
+static void test_setPinMapping_board2_v03(void)
+{
+  apply_board(2U);
+  assert_core_pins_assigned("Board 2 (V0.3)");
+}
+
+static void test_setPinMapping_board3_v04(void)
+{
+  apply_board(3U);
+  assert_core_pins_assigned("Board 3 (V0.4)");
+  // Spot-check a known-good wiring: pinTachOut on V0.4 is pin 49.
+  TEST_ASSERT_EQUAL_UINT8(49U, pinTachOut);
+}
+
+static void test_setPinMapping_board6_mx5_pnp(void)
+{
+  apply_board(6U);
+  assert_core_pins_assigned("Board 6 (MX5 2001-05 PNP)");
+  // Specific pin assignments listed in init.cpp for case 6.
+  TEST_ASSERT_EQUAL_UINT8(44U, pinInjector1);
+  TEST_ASSERT_EQUAL_UINT8(42U, pinCoil1);
+}
+
+static void test_setPinMapping_board8(void)
+{
+  apply_board(8U);
+  assert_core_pins_assigned("Board 8");
+}
+
+static void test_setPinMapping_board9_mx5_8995(void)
+{
+  apply_board(9U);
+  assert_core_pins_assigned("Board 9 (MX5 89-95)");
+}
+
+static void test_setPinMapping_board10(void)
+{
+  apply_board(10U);
+  assert_core_pins_assigned("Board 10");
+}
+
+static void test_setPinMapping_board14_levin(void)
+{
+  apply_board(14U);
+  assert_core_pins_assigned("Board 14 (Levin)");
+}
+
+static void test_setPinMapping_board20(void)
+{
+  apply_board(20U);
+  assert_core_pins_assigned("Board 20");
+}
+
+static void test_setPinMapping_board30(void)
+{
+  apply_board(30U);
+  assert_core_pins_assigned("Board 30");
+}
+
+static void test_setPinMapping_board31_bmw_pnp(void)
+{
+  apply_board(31U);
+  assert_core_pins_assigned("Board 31 (BMW PnP)");
+}
+
+static void test_setPinMapping_board40_ua4c(void)
+{
+  apply_board(40U);
+  assert_core_pins_assigned("Board 40 (UA4C)");
+}
+
+static void test_setPinMapping_board41(void)
+{
+  apply_board(41U);
+  assert_core_pins_assigned("Board 41");
+}
+
+static void test_setPinMapping_board42_blitzbox(void)
+{
+  apply_board(42U);
+  assert_core_pins_assigned("Board 42 (Blitzbox BL49sp)");
+}
+
+static void test_setPinMapping_board45(void)
+{
+  apply_board(45U);
+  assert_core_pins_assigned("Board 45");
+}
+
+static void test_setPinMapping_default_triggerTeeth_guard(void)
+{
+  // setPinMapping() bumps configPage4.triggerTeeth to 4 if it was 0 to avoid
+  // a downstream divide-by-zero. Verify the guard fires.
+  setTuneToEmpty();
+  configPage4.triggerTeeth = 0U;
+  setPinMapping(3U);
+  TEST_ASSERT_EQUAL_UINT8(4U, configPage4.triggerTeeth);
+}
+
+static void test_setPinMapping_default_triggerTeeth_preserved(void)
+{
+  // If triggerTeeth is already non-zero, the guard should not change it.
+  setTuneToEmpty();
+  configPage4.triggerTeeth = 24U;
+  setPinMapping(3U);
+  TEST_ASSERT_EQUAL_UINT8(24U, configPage4.triggerTeeth);
+}
+
+static void test_setPinMapping_resets_output_controls_to_direct(void)
+{
+  // setPinMapping() unconditionally resets injector & ignition output control
+  // back to OUTPUT_CONTROL_DIRECT before applying the per-board overrides.
+  setTuneToEmpty();
+  injectorOutputControl = 0xFFU;
+  ignitionOutputControl = 0xFFU;
+  setPinMapping(3U);  // V0.4 is direct-drive
+  TEST_ASSERT_EQUAL_UINT8(OUTPUT_CONTROL_DIRECT, injectorOutputControl);
+  TEST_ASSERT_EQUAL_UINT8(OUTPUT_CONTROL_DIRECT, ignitionOutputControl);
+}
+
+void testBoardPinMappings(void)
+{
+  SET_UNITY_FILENAME()
+  {
+    RUN_TEST_P(test_setPinMapping_board1_v02);
+    RUN_TEST_P(test_setPinMapping_board2_v03);
+    RUN_TEST_P(test_setPinMapping_board3_v04);
+    RUN_TEST_P(test_setPinMapping_board6_mx5_pnp);
+    RUN_TEST_P(test_setPinMapping_board8);
+    RUN_TEST_P(test_setPinMapping_board9_mx5_8995);
+    RUN_TEST_P(test_setPinMapping_board10);
+    RUN_TEST_P(test_setPinMapping_board14_levin);
+    RUN_TEST_P(test_setPinMapping_board20);
+    RUN_TEST_P(test_setPinMapping_board30);
+    RUN_TEST_P(test_setPinMapping_board31_bmw_pnp);
+    RUN_TEST_P(test_setPinMapping_board40_ua4c);
+    RUN_TEST_P(test_setPinMapping_board41);
+    RUN_TEST_P(test_setPinMapping_board42_blitzbox);
+    RUN_TEST_P(test_setPinMapping_board45);
+    RUN_TEST_P(test_setPinMapping_default_triggerTeeth_guard);
+    RUN_TEST_P(test_setPinMapping_default_triggerTeeth_preserved);
+    RUN_TEST_P(test_setPinMapping_resets_output_controls_to_direct);
+  }
+}

--- a/test/test_math/main.cpp
+++ b/test/test_math/main.cpp
@@ -11,6 +11,7 @@ void runAllMathTests(void)
     extern void test_fast_map(void);
     extern void testUnitConversions(void);
     extern void testOther(void);
+    extern void testRandom(void);
 
     testCrankMaths();
     testPercent();
@@ -19,6 +20,7 @@ void runAllMathTests(void)
     test_fast_map();
     testUnitConversions();
     testOther();
+    testRandom();
 }
 
 TEST_HARNESS(runAllMathTests)

--- a/test/test_math/test_random.cpp
+++ b/test/test_math/test_random.cpp
@@ -1,0 +1,40 @@
+#include <unity.h>
+#include "maths.h"
+#include "../test_utils.h"
+
+static void test_random1to100_range(void)
+{
+  for (uint16_t i = 0U; i < 5000U; ++i)
+  {
+    uint8_t v = random1to100();
+    TEST_ASSERT_TRUE(v >= 1U);
+    TEST_ASSERT_TRUE(v <= 100U);
+  }
+}
+
+static void test_random1to100_distribution(void)
+{
+  // Over many calls every bucket [1..100] should be hit. This also exercises
+  // the do/while rejection branch (a >= 100U) inside random1to100().
+  bool seen[101] = { false };
+  uint16_t distinct = 0U;
+  for (uint32_t i = 0U; i < 200000UL && distinct < 100U; ++i)
+  {
+    uint8_t v = random1to100();
+    if ((v >= 1U) && (v <= 100U) && !seen[v])
+    {
+      seen[v] = true;
+      ++distinct;
+    }
+  }
+  TEST_ASSERT_GREATER_OR_EQUAL_UINT16(95U, distinct);
+}
+
+void testRandom(void)
+{
+  SET_UNITY_FILENAME()
+  {
+    RUN_TEST(test_random1to100_range);
+    RUN_TEST(test_random1to100_distribution);
+  }
+}


### PR DESCRIPTION
## Summary
Two reliability-focused commits, both surfaced by SonarCloud:

- **`5874311c` Fix SonarCloud-flagged reliability bugs**
  - **Real bugs:** copy-paste in `setPinMapping` SD-enable branch (`init.cpp:2477`), `uint8_t << 24` undefined behaviour in SD-byte assembly (`comms.cpp:1042/1050`), union type-punning replaced with `memcpy` in `readSerialIntegralTimeout` (`comms.cpp:187`).
  - **Static-init-order fixes (cpp:S7119):** PID constructors at file scope (`auxiliaries.cpp` boost/vvt/vvt2, `idle.cpp`, `corrections.cpp` ego) now construct with zero gains — `SetTunings()` is called from `init...` paths at runtime so the captured config-page references stay correct.
  - **Sonar false-positive shifts (cpp:S3949):** added explicit `(uint32_t)` casts on already-correct shift expressions in `comms.cpp:138/807` and `comms_legacy.cpp:564/1181/1219`.
  - **Identical if/else (cpp:S3923):** unchained two collapsed `if/else` blocks in `decoders.cpp:1642/4296`.
  - Added regression tests for `setPinMapping` SD-enable behaviour (3 cases: pin valid, pin zero, trigger zero) in `test_board_pin_mappings.cpp`.

- **`7664791b` Replace deprecated ++/-- and compound assignment on volatile variables**
  - C++20 deprecates `++`, `--`, `+=`, `-=` on volatile-qualified types (cpp:S6191). Replaced 103 sites across `decoders.cpp` (78), `timers.cpp` (17), `sensors.cpp` (3), `corrections.cpp` (2), `comms.cpp` (2), `speeduino.ino` (1) with explicit `x = x + 1U` form. No behavioural change.

## Stacking note
This branch is currently based on PR #1475 (test coverage). The diff against master will look larger until that PR merges; once it does, this PR will auto-shrink to just the two reliability commits above.

## Test plan
- [x] `pio test -e native_code_coverage` — 1252 pass, 18 skipped, 2 known `test_schedules` timing flakes (pre-existing, unrelated)
- [x] New `test_board_pin_mappings` cases for the SD-enable bug fix all pass
- [ ] Visual confirm in SonarCloud post-scan that the targeted real-bug rules drop to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)