### PR TITLE
Make flood clear a latched fuel cut with ATDC ignition retard

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2179,7 +2179,7 @@ menuDialog = main
   dwellErrCorrect   = "A basic closed loop adjustment will be made to the dwell time to account for variations due to accel/decel. This is generally only needed on lower resolution trigger arrangements"
 
   crankRPM          = "The cranking RPM threshold. When RPM is lower than this value (and above 0) the system will be considered to be cranking"
-  tpsflood          = "Keep throttle over this value to disable the priming pulse and cranking fuel. Used to prevent flood or clear already flooded engine, and to build oil pressure by cranking without fuel. Once triggered the fuel cut latches (the engine cannot start even if it spins past the cranking RPM) until the throttle is held below 1% for 3 seconds or the ECU is restarted. Set to 0 to disable flood clear entirely."
+  tpsflood          = "Keep throttle over this value to disable the priming pulse and cranking fuel. Used to prevent flood or clear already flooded engine, and to build oil pressure by cranking without fuel. Once triggered the fuel cut latches (the engine cannot start even if it spins past the cranking RPM) until the throttle is held below 1% for 3 seconds or the ECU is restarted. Whilst the cut is latched the ignition is retarded to 5 degrees ATDC so residual fuel keeps being burned off without producing torque. Set to 0 to disable flood clear entirely."
 
   fanInv            = ""
   fanHyster         = "The number of degrees of hysteresis to be used in controlling the fan. Recommended values are between 2 and 5"

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2179,7 +2179,7 @@ menuDialog = main
   dwellErrCorrect   = "A basic closed loop adjustment will be made to the dwell time to account for variations due to accel/decel. This is generally only needed on lower resolution trigger arrangements"
 
   crankRPM          = "The cranking RPM threshold. When RPM is lower than this value (and above 0) the system will be considered to be cranking"
-  tpsflood          = "Keep throttle over this value to disable the priming pulse and cranking fuel. Used to prevent flood or clear already flooded engine"
+  tpsflood          = "Keep throttle over this value to disable the priming pulse and cranking fuel. Used to prevent flood or clear already flooded engine, and to build oil pressure by cranking without fuel. Once triggered the fuel cut latches (the engine cannot start even if it spins past the cranking RPM) until the throttle is held below 1% for 3 seconds or the ECU is restarted. Set to 0 to disable flood clear entirely."
 
   fanInv            = ""
   fanHyster         = "The number of degrees of hysteresis to be used in controlling the fan. Recommended values are between 2 and 5"
@@ -5293,7 +5293,7 @@ cmdVSSratio6 =      "E\x99\x06"
    indicator = { mapaccaen          }, "MAP Accel",     "MAP Accel",          white,  black, green,    black
    indicator = { mapaccden          }, "MAP Decel",     "MAP Decel",          white,  black, green,    black
    indicator = { error              }, "No Errors",     "ERROR",              white,  black, green,    black
-   indicator = { (tps > tpsflood) && (rpm < crankRPM) }, "FLOOD OFF", "FLOOD CLEAR",      white, black, red,   black
+   indicator = { (tpsflood > 0) && (tps >= tpsflood) && (rpm < crankRPM) }, "FLOOD OFF", "FLOOD CLEAR",      white, black, red,   black
    indicator = { DFCOOn             }, "DFCO OFF",      "DFCO On",            white,  black, red,      black
    indicator = { launchHard         }, "Launch Hard",   "Launch Hard",        white,  black, green,    black
    indicator = { launchSoft         }, "Launch Soft",   "Launch Soft",        white,  black, green,    black

--- a/speeduino/config_pages.h
+++ b/speeduino/config_pages.h
@@ -392,7 +392,7 @@ struct config4 : public config_page_t {
   byte triggerTeeth;  ///< The full count of teeth on the trigger wheel if there were no gaps
   byte triggerMissingTeeth; ///< The size of the tooth gap (ie number of missing teeth)
   byte crankRPM;      ///< RPM below which the engine is considered to be cranking
-  byte floodClear;    ///< TPS (raw adc count? % ?) value that triggers flood clear mode (No fuel whilst cranking, See @ref correctionFloodClear())
+  byte floodClear;    ///< TPS value (in 0.5% units, 0-200) at or above which flood clear latches whilst cranking: no fuel until the throttle is held below 1% for 3s or the ECU restarts. 0 = disabled. See @ref correctionFloodClear()
   byte SoftRevLim;    ///< Soft rev limit (RPM/100)
   byte SoftLimRetard; ///< Amount soft limit (ignition) retard (degrees)
   byte SoftLimMax;    ///< Time the soft limit can run (units 0.1S)

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -518,6 +518,7 @@ initialiseCorrections() (that runs on every stall detection).
 */
 static constexpr uint8_t FLOOD_CLEAR_RELEASE_TPS = 2U; //1% in 0.5% TPS units
 static constexpr uint16_t FLOOD_CLEAR_RELEASE_TIME_MS = 3000U;
+static constexpr int8_t FLOOD_CLEAR_IGN_ANGLE = -5; //5 degrees ATDC, see correctionFloodClearIgnition()
 TESTABLE_STATIC bool floodClearLatched = false;
 static uint32_t floodClearTpsHighMs; //Last time the TPS was at or above FLOOD_CLEAR_RELEASE_TPS
 
@@ -915,6 +916,21 @@ TESTABLE_INLINE_STATIC int8_t correctionCLTadvance(int8_t advance)
     cachedValue = IGNITION_ADVANCE_SMALL.toUser(table2D_getValue(&CLTAdvanceTable, temperatureAddOffset(currentStatus.coolant)));
   }
   return advance + cachedValue;
+}
+
+/** Ignition retard whilst the flood clear fuel cut is latched.
+ * With no fuel injected, the only combustion possible is from residual mixture in the cylinders.
+ * Firing slightly after TDC means any such burn happens with the piston already descending: it
+ * cannot kick back against the starter and produces almost no torque, so the engine cannot
+ * accelerate on residual fuel, whilst the plugs keep firing to dry themselves and the late burn
+ * helps vaporise and expel the excess fuel.
+ * Must be called last as an absolute override (note: has no effect when the decoder-level
+ * cranking timing lock (ignCranklock) is enabled, as that bypasses the advance value entirely).
+ */
+TESTABLE_INLINE_STATIC int8_t correctionFloodClearIgnition(int8_t advance)
+{
+  if (floodClearLatched) { advance = FLOOD_CLEAR_IGN_ANGLE; }
+  return advance;
 }
 
 /** Correct ignition timing to configured fixed value to use during craning.
@@ -1390,6 +1406,7 @@ int8_t correctionsIgn(int8_t base_advance)
   //Fixed timing check must go last
   advance = correctionFixedTiming(advance);
   advance = correctionCrankingFixedTiming(advance); //This overrides the regular fixed timing, must come last
+  advance = correctionFloodClearIgnition(advance); //Flood clear retard overrides even the fixed timings, must come after them
 
   return advance;
 }

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -508,17 +508,59 @@ TESTABLE_INLINE_STATIC uint16_t correctionAccel(void)
 
 // ============================= Flood Clear =============================
 
-static inline bool isFloodClearActive(const statuses &current, const config4 &page4) {
-  return current.rotationStatus==EngineRotationStatus::Cranking
+/*
+Flood clear is safety-critical (it is also used to build oil pressure by cranking without fuel),
+so once triggered it LATCHES: the fuel cut is held even if the engine momentarily spins past the
+cranking RPM threshold on residual fuel. The latch is only released once the throttle has been held
+below FLOOD_CLEAR_RELEASE_TPS for longer than FLOOD_CLEAR_RELEASE_TIME_MS, or the ECU is restarted.
+The latch must survive between crank attempts, so it is deliberately NOT reset in
+initialiseCorrections() (that runs on every stall detection).
+*/
+static constexpr uint8_t FLOOD_CLEAR_RELEASE_TPS = 2U; //1% in 0.5% TPS units
+static constexpr uint16_t FLOOD_CLEAR_RELEASE_TIME_MS = 3000U;
+TESTABLE_STATIC bool floodClearLatched = false;
+static uint32_t floodClearTpsHighMs; //Last time the TPS was at or above FLOOD_CLEAR_RELEASE_TPS
+
+static inline bool isFloodClearEnabled(const config4 &page4) {
+  //A threshold of 0 would match any TPS reading and permanently cut all cranking fuel, so treat 0 as disabled
+  return page4.floodClear > 0U;
+}
+
+static inline bool isFloodClearTriggered(const statuses &current, const config4 &page4) {
+  return isFloodClearEnabled(page4)
+      && current.rotationStatus==EngineRotationStatus::Cranking
       && (current.TPS >= page4.floodClear);
 }
 
-/** Simple check to see whether we are cranking with the TPS above the flood clear threshold.
-@return 100 (not cranking and thus no need for flood-clear) or 0 (Engine cranking and TPS above @ref config4.floodClear limit).
+bool isFloodClearActive(void) {
+  return floodClearLatched;
+}
+
+TESTABLE_INLINE_STATIC void updateFloodClear(uint32_t nowMs)
+{
+  if (isFloodClearTriggered(currentStatus, configPage4)) { floodClearLatched = true; }
+
+  if (currentStatus.TPS >= FLOOD_CLEAR_RELEASE_TPS) { floodClearTpsHighMs = nowMs; }
+  else if ((nowMs - floodClearTpsHighMs) > FLOOD_CLEAR_RELEASE_TIME_MS) { floodClearLatched = false; }
+}
+
+/** Latch or release the flood clear state. Called at the TPS read rate from the main loop,
+including while the engine is not rotating, so the release timer keeps running once cranking stops. */
+void updateFloodClear(void)
+{
+  updateFloodClear(millis());
+}
+
+/** Cut all fuel whilst the flood clear latch is set.
+Latched by cranking with the TPS at or above the @ref config4.floodClear threshold; released by
+updateFloodClear() once the throttle has been held closed for long enough.
+@return 100 (latch not set) or 0 (Flood clear latched: no fuel).
 */
 TESTABLE_INLINE_STATIC uint8_t correctionFloodClear(void)
 {
-  return isFloodClearActive(currentStatus, configPage4) ? 0U : NO_FUEL_CORRECTION;
+  //The trigger is also evaluated here so the cut starts on the same loop that the cranking state & TPS first match
+  if (isFloodClearTriggered(currentStatus, configPage4)) { floodClearLatched = true; }
+  return floodClearLatched ? 0U : NO_FUEL_CORRECTION;
 }
 
 /** Battery Voltage correction.

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -7,6 +7,11 @@ All functions in the gamma file return
 
 void initialiseCorrections(void);
 uint16_t correctionsFuel(void);
+
+/** @brief Whether the flood clear fuel cut is currently latched. Only released by updateFloodClear() or an ECU restart */
+bool isFloodClearActive(void);
+/** @brief Latch or release the flood clear state. Must be called at the TPS read rate, even when the engine is not rotating */
+void updateFloodClear(void);
 uint8_t calculateAfrTarget(table3d16RpmLoad &afrLookUpTable, const statuses &current, const config2 &page2, const config6 &page6);
 
 int8_t correctionsIgn(int8_t advance);

--- a/speeduino/scheduler_fuel_controller.cpp
+++ b/speeduino/scheduler_fuel_controller.cpp
@@ -1,6 +1,7 @@
 #include "scheduler_fuel_controller.h"
 #include "scheduledIO_inj.h"
 #include "units.h"
+#include "corrections.h"
 
 FuelSchedule fuelSchedule1(FUEL1_COUNTER, FUEL1_COMPARE); //cppcheck-suppress misra-c2012-8.4
 FuelSchedule fuelSchedule2(FUEL2_COUNTER, FUEL2_COMPARE); //cppcheck-suppress misra-c2012-8.4
@@ -474,7 +475,11 @@ TESTABLE_CONSTEXPR table2D_u8_u8_4 PrimingPulseTable(&configPage2.primeBins, &co
 void __attribute__((optimize("Os"))) beginInjectorPriming(const statuses &current, const config4 &page4)
 {
   uint16_t primingValue = (uint16_t)table2D_getValue(&PrimingPulseTable, temperatureAddOffset(current.coolant));
-  if( (primingValue > 0U) && (current.TPS <= page4.floodClear) )
+  //No priming whilst the flood clear latch is set, or when the TPS is at or above the flood clear
+  //threshold (a threshold of 0 disables flood clear). The TPS comparison uses >= so that at exactly
+  //the threshold flood clear wins, matching correctionFloodClear()
+  bool floodClearBlocksPriming = isFloodClearActive() || ((page4.floodClear > 0U) && (current.TPS >= page4.floodClear));
+  if( (primingValue > 0U) && (floodClearBlocksPriming == false) )
   {
     constexpr uint32_t PRIMING_DELAY = 100U; // 100us
     // The prime pulse value is in ms*2, so need to multiply by 500 to get to µS

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -99,12 +99,19 @@ static inline uint16_t readAnalogPin(uint8_t pin)
 
 #if defined(ANALOG_ISR)
 static volatile uint16_t AnChannel[16];
+//16 bit reads are not atomic on 8 bit AVR, so guard against the ADC ISR updating the value mid-read
+static inline uint16_t readAnChannelAtomic(uint8_t pin) {
+  noInterrupts();
+  uint16_t value = AnChannel[pin-A0];
+  interrupts();
+  return value;
+}
 static inline uint16_t readAnalogSensor(uint8_t pin) {
-  return AnChannel[pin-A0];
+  return readAnChannelAtomic(pin);
 }
 static inline uint16_t readMAPSensor(uint8_t pin) {
 #if defined(ANALOG_ISR_MAP)
-  return AnChannel[pin-A0];
+  return readAnChannelAtomic(pin);
 #else
   return readAnalogPin(pin);
 #endif
@@ -189,8 +196,10 @@ void initialiseADC(void)
      BIT_CLEAR(ADCSRA,ADPS1);
      BIT_CLEAR(ADCSRA,ADPS0);
   #endif
-#elif defined(ARDUINO_ARCH_STM32) //STM32GENERIC core and ST STM32duino core, change analog read to 12 bit
+#elif defined(ARDUINO_ARCH_STM32) //STM32GENERIC core and ST STM32duino core can default to 12 bit, reduce to the 10 bit range the rest of the code expects
   analogReadResolution(10); //use 10bits for analog reading on STM32 boards
+#elif defined(CORE_TEENSY)
+  analogReadResolution(10); //Teensy cores default to 10 bit, but set it explicitly so a core default change cannot silently rescale every analog sensor
 #endif
 
   //The following checks the aux inputs and initialises pins if required
@@ -606,7 +615,14 @@ static inline void readTPS(void)
 }
 
 
-void initialiseTPS(void) { 
+void initialiseTPS(void) {
+#if defined(ANALOG_ISR)
+  //Interrupts are disabled for most of initialiseAll(), so the free-running ADC ISR may not have
+  //refreshed every channel yet. Re-enable it and allow one full 16 channel conversion cycle
+  //(~1.7ms at the 125KHz ADC clock) so the TPS reading below is real rather than stale/zero.
+  BIT_SET(ADCSRA,ADIE);
+  delay(3);
+#endif
   readTPS((uint8_t)fastMap10Bit(readAnalogSensor(pinTPS), 0U, 255U)); // Need to read tps to detect flood clear state
 }
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -233,6 +233,10 @@ BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
     //-----------------------------------------------------------------------------------------------------
     readPolledSensors(currentStatus.LOOP_TIMER);
 
+    //The flood clear latch/release must be evaluated even when the engine is not rotating, so the
+    //release timer keeps running once a crank attempt ends
+    if(BIT_CHECK(currentStatus.LOOP_TIMER, TPS_READ_TIMER_BIT)) { updateFloodClear(); }
+
     if(BIT_CHECK(currentStatus.LOOP_TIMER, BIT_TIMER_50HZ)) //50 hertz
     {
       #if defined(NATIVE_CAN_AVAILABLE)
@@ -418,7 +422,10 @@ BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
     if ((currentStatus.decoder.getStatus().syncStatus!=SyncStatus::None) && (currentStatus.RPM > 0))
     {
         //Check whether running or cranking
-        if(currentStatus.RPM > currentStatus.crankRPM) //Crank RPM in the config is stored as a x10. currentStatus.crankRPM is set in timers.ino and represents the true value
+        //Whilst flood clear is latched the engine must not be allowed to enter the running state:
+        //residual fuel can spin it past the cranking threshold, but fuel stays cut until the
+        //throttle has been held closed long enough to release the latch
+        if( (currentStatus.RPM > currentStatus.crankRPM) && (isFloodClearActive() == false) ) //Crank RPM in the config is stored as a x10. currentStatus.crankRPM is set in timers.ino and represents the true value
         {
           bool crankToRun = currentStatus.rotationStatus==EngineRotationStatus::Cranking;
           currentStatus.rotationStatus = EngineRotationStatus::Running;

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -289,29 +289,124 @@ static void test_corrections_ASE(void)
 }
 
 uint8_t correctionFloodClear(void);
+void updateFloodClear(uint32_t nowMs);
+extern bool floodClearLatched;
+
+static void reset_floodclear(void) {
+  floodClearLatched = false;
+}
 
 static void test_corrections_floodclear_no_crank_inactive(void) {
+  reset_floodclear();
   currentStatus.rotationStatus = EngineRotationStatus::Running;
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear + 10;
 
   TEST_ASSERT_EQUAL(100U, correctionFloodClear() );
+  TEST_ASSERT_FALSE(floodClearLatched);
 }
 
 static void test_corrections_floodclear_crank_below_threshold_inactive(void) {
+  reset_floodclear();
   currentStatus.rotationStatus = EngineRotationStatus::Cranking;
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear - 10;
 
   TEST_ASSERT_EQUAL(100U, correctionFloodClear() );
+  TEST_ASSERT_FALSE(floodClearLatched);
 }
 
 static void test_corrections_floodclear_crank_above_threshold_active(void) {
+  reset_floodclear();
   currentStatus.rotationStatus = EngineRotationStatus::Cranking;
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear + 10;
 
   TEST_ASSERT_EQUAL(0U, correctionFloodClear() );
+  TEST_ASSERT_TRUE(floodClearLatched);
+  reset_floodclear();
+}
+
+static void test_corrections_floodclear_crank_at_threshold_active(void) {
+  //At exactly the threshold the fuel cut must win (matches the priming suppression boundary)
+  reset_floodclear();
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  configPage4.floodClear = 90;
+  currentStatus.TPS = configPage4.floodClear;
+
+  TEST_ASSERT_EQUAL(0U, correctionFloodClear() );
+  reset_floodclear();
+}
+
+static void test_corrections_floodclear_zero_threshold_disabled(void) {
+  //A threshold of 0 must disable the feature entirely, not cut all cranking fuel
+  reset_floodclear();
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  configPage4.floodClear = 0;
+  currentStatus.TPS = 200; //WOT
+
+  TEST_ASSERT_EQUAL(100U, correctionFloodClear() );
+  TEST_ASSERT_FALSE(floodClearLatched);
+}
+
+static void test_corrections_floodclear_latch_holds_past_crank_rpm(void) {
+  //Once latched, the fuel cut must persist even if the engine spins past the cranking
+  //threshold (Running) or the crank attempt ends (Stopped)
+  reset_floodclear();
+  configPage4.floodClear = 90;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  currentStatus.TPS = 180;
+  TEST_ASSERT_EQUAL(0U, correctionFloodClear() );
+
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
+  TEST_ASSERT_EQUAL(0U, correctionFloodClear() );
+
+  currentStatus.rotationStatus = EngineRotationStatus::Stopped;
+  TEST_ASSERT_EQUAL(0U, correctionFloodClear() );
+  reset_floodclear();
+}
+
+static void test_corrections_floodclear_release_requires_low_tps_time(void) {
+  reset_floodclear();
+  configPage4.floodClear = 90;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  currentStatus.TPS = 180;
+  updateFloodClear(1000); //Latches & records the TPS-high time
+  TEST_ASSERT_TRUE(floodClearLatched);
+
+  currentStatus.rotationStatus = EngineRotationStatus::Stopped;
+  currentStatus.TPS = 1; //0.5%: below the 1% release threshold
+  updateFloodClear(2000);
+  TEST_ASSERT_TRUE(floodClearLatched); //Only 1s below the threshold
+  updateFloodClear(4000);
+  TEST_ASSERT_TRUE(floodClearLatched); //Exactly 3s: not yet released
+  updateFloodClear(4001);
+  TEST_ASSERT_FALSE(floodClearLatched); //>3s below 1%: released
+  TEST_ASSERT_EQUAL(100U, correctionFloodClear() );
+}
+
+static void test_corrections_floodclear_release_timer_resets_on_throttle(void) {
+  reset_floodclear();
+  configPage4.floodClear = 90;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  currentStatus.TPS = 180;
+  updateFloodClear(1000);
+  TEST_ASSERT_TRUE(floodClearLatched);
+
+  currentStatus.rotationStatus = EngineRotationStatus::Stopped;
+  currentStatus.TPS = 1;
+  updateFloodClear(2000);
+  TEST_ASSERT_TRUE(floodClearLatched);
+
+  currentStatus.TPS = 50; //Throttle blip above 1% restarts the 3s requirement
+  updateFloodClear(3000);
+  TEST_ASSERT_TRUE(floodClearLatched);
+
+  currentStatus.TPS = 0;
+  updateFloodClear(5900); //2.9s since the blip
+  TEST_ASSERT_TRUE(floodClearLatched);
+  updateFloodClear(6001); //>3s since the blip
+  TEST_ASSERT_FALSE(floodClearLatched);
 }
 
 static void test_corrections_floodclear(void)
@@ -319,6 +414,11 @@ static void test_corrections_floodclear(void)
   RUN_TEST_P(test_corrections_floodclear_no_crank_inactive);
   RUN_TEST_P(test_corrections_floodclear_crank_below_threshold_inactive);
   RUN_TEST_P(test_corrections_floodclear_crank_above_threshold_active);
+  RUN_TEST_P(test_corrections_floodclear_crank_at_threshold_active);
+  RUN_TEST_P(test_corrections_floodclear_zero_threshold_disabled);
+  RUN_TEST_P(test_corrections_floodclear_latch_holds_past_crank_rpm);
+  RUN_TEST_P(test_corrections_floodclear_release_requires_low_tps_time);
+  RUN_TEST_P(test_corrections_floodclear_release_timer_resets_on_throttle);
 }
 
 uint8_t correctionAFRClosedLoop(void);
@@ -1612,6 +1712,7 @@ static void test_corrections_correctionsFuel_ae_modes(void) {
   WUETable.cache.cacheTime = currentStatus.secl - 1;
 
   configPage4.floodClear = 100;
+  floodClearLatched = false;
 
   configPage6.egoType = 0;
   configPage6.egoAlgorithm = EGO_ALGORITHM_SIMPLE;
@@ -1662,6 +1763,7 @@ static void test_corrections_correctionsFuel_ae_modes(void) {
 
 static void test_corrections_correctionsFuel_clip_limit(void) {
   initialiseCorrections();
+  floodClearLatched = false;
 
   populate_2dtable(&injectorVCorrectionTable, (uint8_t)255, (uint8_t)100);
   populate_2dtable(&baroFuelTable, (uint8_t)255, (uint8_t)100);

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -409,6 +409,26 @@ static void test_corrections_floodclear_release_timer_resets_on_throttle(void) {
   TEST_ASSERT_FALSE(floodClearLatched);
 }
 
+int8_t correctionFloodClearIgnition(int8_t advance);
+
+static void test_corrections_floodclear_ignition_retard(void) {
+  reset_floodclear();
+  //Pass-through when not latched
+  TEST_ASSERT_EQUAL(10, correctionFloodClearIgnition(10));
+  TEST_ASSERT_EQUAL(-20, correctionFloodClearIgnition(-20));
+
+  //Latch flood clear
+  configPage4.floodClear = 90;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  currentStatus.TPS = 180;
+  TEST_ASSERT_EQUAL(0U, correctionFloodClear() );
+
+  //Absolute override to 5 degrees ATDC whilst latched
+  TEST_ASSERT_EQUAL(-5, correctionFloodClearIgnition(10));
+  TEST_ASSERT_EQUAL(-5, correctionFloodClearIgnition(-20));
+  reset_floodclear();
+}
+
 static void test_corrections_floodclear(void)
 {
   RUN_TEST_P(test_corrections_floodclear_no_crank_inactive);
@@ -419,6 +439,7 @@ static void test_corrections_floodclear(void)
   RUN_TEST_P(test_corrections_floodclear_latch_holds_past_crank_rpm);
   RUN_TEST_P(test_corrections_floodclear_release_requires_low_tps_time);
   RUN_TEST_P(test_corrections_floodclear_release_timer_resets_on_throttle);
+  RUN_TEST_P(test_corrections_floodclear_ignition_retard);
 }
 
 uint8_t correctionAFRClosedLoop(void);

--- a/test/test_schedules/test_fuel_controller.cpp
+++ b/test/test_schedules/test_fuel_controller.cpp
@@ -166,6 +166,8 @@ static void assert_isPriming(FuelSchedule &schedule, bool priming)
   }
 }
 
+extern bool floodClearLatched;
+
 static void test_beginInjectorPriming_floodclear(void)
 {
   stopFuelSchedulers();
@@ -190,6 +192,68 @@ static void test_beginInjectorPriming_floodclear(void)
     RUNIF_INJCHANNEL7( { assert_isPriming(fuelSchedule7, false); }, {});
     RUNIF_INJCHANNEL8( { assert_isPriming(fuelSchedule8, false); }, {});
   }
+}
+
+static void test_beginInjectorPriming_floodclear_at_threshold(void)
+{
+  //TPS exactly at the threshold: flood clear must win & suppress priming (matches correctionFloodClear())
+  constexpr int16_t COOLANT_TEMP = 200;
+  stopFuelSchedulers();
+  populate_2dtable(&PrimingPulseTable, PRIMING_PULSE_WIDTH, temperatureAddOffset(COOLANT_TEMP));
+
+  statuses current = {};
+  config4 page4 = {};
+  page4.floodClear = 90;
+  current.TPS = page4.floodClear;
+  current.coolant = COOLANT_TEMP;
+  current.numPrimaryInjOutputs = 1;
+  set_all_schedules_off();
+
+  beginInjectorPriming(current, page4);
+
+  RUNIF_INJCHANNEL1( { assert_isPriming(fuelSchedule1, false); }, {});
+}
+
+static void test_beginInjectorPriming_floodclear_latched(void)
+{
+  //Whilst the flood clear latch is set, priming must be suppressed even with the throttle closed
+  constexpr int16_t COOLANT_TEMP = 200;
+  stopFuelSchedulers();
+  populate_2dtable(&PrimingPulseTable, PRIMING_PULSE_WIDTH, temperatureAddOffset(COOLANT_TEMP));
+
+  statuses current = {};
+  config4 page4 = {};
+  page4.floodClear = 90;
+  current.TPS = 0;
+  current.coolant = COOLANT_TEMP;
+  current.numPrimaryInjOutputs = 1;
+  set_all_schedules_off();
+
+  floodClearLatched = true;
+  beginInjectorPriming(current, page4);
+  floodClearLatched = false;
+
+  RUNIF_INJCHANNEL1( { assert_isPriming(fuelSchedule1, false); }, {});
+}
+
+static void test_beginInjectorPriming_floodclear_disabled(void)
+{
+  //A flood clear threshold of 0 disables the feature: priming must happen even at WOT
+  constexpr int16_t COOLANT_TEMP = 200;
+  stopFuelSchedulers();
+  populate_2dtable(&PrimingPulseTable, PRIMING_PULSE_WIDTH, temperatureAddOffset(COOLANT_TEMP));
+
+  statuses current = {};
+  config4 page4 = {};
+  page4.floodClear = 0;
+  current.TPS = 200; //WOT
+  current.coolant = COOLANT_TEMP;
+  current.numPrimaryInjOutputs = 1;
+  set_all_schedules_off();
+
+  beginInjectorPriming(current, page4);
+
+  RUNIF_INJCHANNEL1( { assert_isPriming(fuelSchedule1, true); }, {});
 }
 
 static void test_beginInjectorPriming(void)
@@ -305,6 +369,9 @@ void test_fuel_controller(void)
     RUN_TEST_P(test_setFuelChannelSchedule_ignores_zero_timeout);
     RUN_TEST_P(test_lookupInjectorAngle_clamp_max_inj);
     RUN_TEST_P(test_beginInjectorPriming_floodclear);
+    RUN_TEST_P(test_beginInjectorPriming_floodclear_at_threshold);
+    RUN_TEST_P(test_beginInjectorPriming_floodclear_latched);
+    RUN_TEST_P(test_beginInjectorPriming_floodclear_disabled);
     RUN_TEST_P(test_beginInjectorPriming);
     RUN_TEST_P(test_setFuelChannelSchedules_returnsInjectionAngle);
     RUN_TEST_P(test_changeToFullSequentialInjection);


### PR DESCRIPTION
## Problem

Fixes #1054.

Flood clear currently deactivates the instant RPM exceeds the cranking threshold. A combustion kick on residual fuel can spike the decoder RPM past `crankRPM` (the crank/run hysteresis is only 15 RPM), flipping the ECU into the running state and resuming full-load fuel with the throttle held wide open — re-flooding the engine the driver is trying to clear, running it on one or two unflooded cylinders, and diluting the oil. It also makes flood clear unusable for its second common purpose: building oil pressure by cranking without fuel.

## Change 1: latch the fuel cut

Once triggered (cranking with TPS at or above the threshold), flood clear now **latches**:

- Fuel stays hard-cut (pulsewidths forced to zero) even if the engine spins past `crankRPM` on residual fuel, and the crank→run transition is blocked while latched, so the engine cannot enter the running state.
- The latch is released only once the TPS has been held below 1% for more than 3 seconds, or by an ECU restart. The release timer runs at the TPS read rate even while the engine is stopped, and the latch intentionally survives stall detection. This is slightly stricter than the "release throttle below the flood clear value" proposed in #1054, so that a partially-lifted throttle can't resume fuel mid-crank unexpectedly.

## Change 2: retard ignition to 5° ATDC while latched

With no fuel injected, the only combustion possible is from residual mixture. Firing it before TDC produces torque against or with the starter — enough to kick back or momentarily spin the engine on the fuel being purged. While the latch is set, ignition advance is overridden to a fixed **5° ATDC** (within the existing supported cranking angle range of −10..80): any residual burn happens with the piston already descending (no kickback, almost no torque) while the plugs keep firing to dry themselves and the late burn helps vaporise the excess fuel. The angle is deliberately not later than −5° so mixture doesn't burn into an open exhaust valve at cranking speed. Note: no effect when `ignCranklock` is enabled, as the decoder bypasses the advance value.

## Related fixes

- Priming and the fuel cut disagreed at `TPS == floodClear` (priming used `<=`, the cut used `>=`); flood clear now wins at equality in both places, and priming is also suppressed while the latch is set.
- `floodClear = 0` used to match any TPS reading, permanently cutting all cranking fuel (an undiagnosable no-start); 0 now disables the feature.
- `ANALOG_ISR` (AVR): `AnChannel` reads are now atomic (16-bit reads can tear on 8-bit AVR), and `initialiseTPS()` re-enables the ADC interrupt and waits one full conversion cycle so the boot-time TPS reading used for the flood clear/priming decision cannot be stale.
- Teensy now sets `analogReadResolution(10)` explicitly instead of relying on the core default; corrected a misleading "12 bit" comment in the STM32 branch.
- TunerStudio ini: the FLOOD CLEAR indicator now matches firmware semantics and the tooltip documents the latch, the retard and the 0 = disabled case.

## Testing

- 13 new/updated unit tests covering: trigger/no-trigger, exact-threshold boundary, threshold-0 disabled, latch holding through Running/Stopped states, release timing (3.0 s not enough, >3 s releases), release-timer reset on a throttle blip, priming suppression (at-threshold / while-latched / when-disabled), and the ignition override.
- Full suite passes on simavr (1278 tests): `pio test -e megaatmega2560_sim_unittest`
- Firmware builds clean for `megaatmega2560`, `black_F407VE` and `teensy41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)