### PR TITLE
Fix baro plausibility check truncating uint16_t MAP reading to uint8_t

### DIFF
--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -634,7 +634,7 @@ static inline void readIAT(void)
 * with record highs close to 108.5 kPa.
 * The lowest possible baro reading is based on an altitude of 3500m above sea level.
 */
-static inline bool isValidBaro(uint8_t baro) 
+static inline bool isValidBaro(uint16_t baro)
 {
   static constexpr uint16_t BARO_MIN = 65U;
   static constexpr uint16_t BARO_MAX = 108U;

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -634,7 +634,7 @@ static inline void readIAT(void)
 * with record highs close to 108.5 kPa.
 * The lowest possible baro reading is based on an altitude of 3500m above sea level.
 */
-static inline bool isValidBaro(uint16_t baro)
+TESTABLE_INLINE_STATIC bool isValidBaro(uint16_t baro)
 {
   static constexpr uint16_t BARO_MIN = 65U;
   static constexpr uint16_t BARO_MAX = 108U;

--- a/test/test_sensors/main.cpp
+++ b/test/test_sensors/main.cpp
@@ -6,9 +6,11 @@ void runAllSensorTests(void)
 {
     extern void test_fastMap10Bit(void);
     extern void test_map_sampling(void);
+    extern void test_baro(void);
 
     test_fastMap10Bit();
     test_map_sampling();
+    test_baro();
 }
 
 TEST_HARNESS(runAllSensorTests)

--- a/test/test_sensors/test_baro.cpp
+++ b/test/test_sensors/test_baro.cpp
@@ -1,0 +1,41 @@
+#include "../test_utils.h"
+#include "globals.h"
+
+extern bool isValidBaro(uint16_t baro);
+
+static void test_isValidBaro_inRange(void)
+{
+  // Values inside the physical plausibility window [65, 108] kPa are valid.
+  TEST_ASSERT_TRUE(isValidBaro(65U));
+  TEST_ASSERT_TRUE(isValidBaro(100U));
+  TEST_ASSERT_TRUE(isValidBaro(108U));
+}
+
+static void test_isValidBaro_outOfRange(void)
+{
+  // Just outside the window on either side is rejected.
+  TEST_ASSERT_FALSE(isValidBaro(64U));
+  TEST_ASSERT_FALSE(isValidBaro(109U));
+  TEST_ASSERT_FALSE(isValidBaro(0U));
+}
+
+static void test_isValidBaro_noTruncationAbove255(void)
+{
+  // A MAP-derived reading can exceed 255 kPa on boosted / high-mapMax setups.
+  // The parameter must be wide enough that such a reading is rejected rather
+  // than truncated modulo 256 into the valid window (e.g. 356 & 0xFF == 100,
+  // which would previously have passed as a valid baro reading).
+  TEST_ASSERT_FALSE(isValidBaro(356U));
+  TEST_ASSERT_FALSE(isValidBaro(300U));
+  TEST_ASSERT_FALSE(isValidBaro(65535U));
+}
+
+void test_baro(void)
+{
+  SET_UNITY_FILENAME()
+  {
+    RUN_TEST(test_isValidBaro_inRange);
+    RUN_TEST(test_isValidBaro_outOfRange);
+    RUN_TEST(test_isValidBaro_noTruncationAbove255);
+  }
+}


### PR DESCRIPTION
## Summary
`isValidBaro()` took a `uint8_t` parameter, but `setBaroFromMAP()` passes it a `uint16_t` MAP-derived reading that can legitimately exceed 255 on boost-capable configurations (`configPage2.mapMax` is user-configurable well above 255 kPa). The implicit narrowing conversion truncated the value modulo 256 before the 65-108 kPa plausibility range check ever saw the real value, letting some out-of-range readings pass as valid baro.

Widened the parameter to `uint16_t`; the function's own `BARO_MIN`/`BARO_MAX` constants were already `uint16_t`, so no other change is needed. The one other call site (`initialiseMAPBaro`) already passes a `uint8_t` value loaded from EEPROM, so its behavior is unaffected.

Fixes #1563

## Test plan
- [ ] CI build/test suite
- Checked `test/test_sensors/` — no existing test exercises `isValidBaro`/`setBaroFromMAP` with a value >255, so this shouldn't change any current test result.
