### PR TITLE
Deduplicate idleLoad step-count heuristic in idle.cpp

### DIFF
--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -319,13 +319,13 @@ static inline void doStep(void)
 Clamps the target step count to the configured max steps (including any idle-up
 adder, to prevent over-opening), updates the reported idleLoad and performs a step.
 */
-static inline void updateIdleStepAndLoad(statuses &current, const config9 &page9)
+static inline void updateIdleStepAndLoad(statuses &current, const config9 &page9, StepperIdle &idleState)
 {
   //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
-  idleStepper.targetIdleStep = clamp((uint16_t)idleStepper.targetIdleStep, (uint16_t)0U, IAC_STEPS.toUser(page9.iacMaxSteps));
+  idleState.targetIdleStep = clamp((uint16_t)idleState.targetIdleStep, (uint16_t)0U, IAC_STEPS.toUser(page9.iacMaxSteps));
   
-  if (IAC_STEPS.toUser(page9.iacMaxSteps) > (uint16_t)UINT8_MAX ) { current.idleLoad = idleStepper.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
-  else { current.idleLoad = idleStepper.curIdleStep; }
+  if (IAC_STEPS.toUser(page9.iacMaxSteps) > (uint16_t)UINT8_MAX ) { current.idleLoad = idleState.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
+  else { current.idleLoad = idleState.curIdleStep; }
   
   doStep();
 }
@@ -607,7 +607,7 @@ void idleControl(void)
             iacCoolTime_uS = configPage9.iacCoolTime * 1000;
           }
         }
-        updateIdleStepAndLoad(currentStatus, configPage9);
+        updateIdleStepAndLoad(currentStatus, configPage9, idleStepper);
       }
       break;
 
@@ -680,7 +680,7 @@ void idleControl(void)
         
         if(currentStatus.idleUpActive == true) { idleStepper.targetIdleStep += configPage2.idleUpAdder; } //Add Idle Up amount if active
         
-        updateIdleStepAndLoad(currentStatus, configPage9);
+        updateIdleStepAndLoad(currentStatus, configPage9, idleStepper);
       }
       if (BIT_CHECK(currentStatus.LOOP_TIMER, BIT_TIMER_1HZ)) //Use timer flag instead idle count
       {

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -322,12 +322,11 @@ adder, to prevent over-opening), updates the reported idleLoad and performs a st
 static inline void updateIdleStepAndLoad(void)
 {
   //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
-  if (idleStepper.targetIdleStep > (configPage9.iacMaxSteps * 3) )
-  {
-    idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;
-  }
-  if( ((uint16_t)configPage9.iacMaxSteps * 3) > UINT8_MAX ) { currentStatus.idleLoad = idleStepper.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
+  idleStepper.targetIdleStep = clamp((uint16_t)idleStepper.targetIdleStep, (uint16_t)0U, IAC_STEPS.toUser(configPage9.iacMaxSteps));
+  
+  if (IAC_STEPS.toUser(configPage9.iacMaxSteps) > (uint16_t)UINT8_MAX ) { currentStatus.idleLoad = idleStepper.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
   else { currentStatus.idleLoad = idleStepper.curIdleStep; }
+  
   doStep();
 }
 

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -315,6 +315,15 @@ static inline void doStep(void)
   }
 }
 
+static inline uint8_t calculateIdleLoad(const config9 &page9, const StepperIdle &idleState)
+{
+  if (IAC_STEPS.toUser(page9.iacMaxSteps) > (uint16_t)UINT8_MAX ) 
+  { 
+    return idleState.curIdleStep / 2; 
+  }
+  return idleState.curIdleStep;
+}
+
 /*
 Clamps the target step count to the configured max steps (including any idle-up
 adder, to prevent over-opening), updates the reported idleLoad and performs a step.
@@ -323,10 +332,7 @@ static inline void updateIdleStepAndLoad(statuses &current, const config9 &page9
 {
   //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
   idleState.targetIdleStep = clamp((uint16_t)idleState.targetIdleStep, (uint16_t)0U, IAC_STEPS.toUser(page9.iacMaxSteps));
-  
-  if (IAC_STEPS.toUser(page9.iacMaxSteps) > (uint16_t)UINT8_MAX ) { current.idleLoad = idleState.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
-  else { current.idleLoad = idleState.curIdleStep; }
-  
+  current.idleLoad = calculateIdleLoad(page9, idleState);
   doStep();
 }
 

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -319,13 +319,13 @@ static inline void doStep(void)
 Clamps the target step count to the configured max steps (including any idle-up
 adder, to prevent over-opening), updates the reported idleLoad and performs a step.
 */
-static inline void updateIdleStepAndLoad(void)
+static inline void updateIdleStepAndLoad(statuses &current, const config9 &page9)
 {
   //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
-  idleStepper.targetIdleStep = clamp((uint16_t)idleStepper.targetIdleStep, (uint16_t)0U, IAC_STEPS.toUser(configPage9.iacMaxSteps));
+  idleStepper.targetIdleStep = clamp((uint16_t)idleStepper.targetIdleStep, (uint16_t)0U, IAC_STEPS.toUser(page9.iacMaxSteps));
   
-  if (IAC_STEPS.toUser(configPage9.iacMaxSteps) > (uint16_t)UINT8_MAX ) { currentStatus.idleLoad = idleStepper.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
-  else { currentStatus.idleLoad = idleStepper.curIdleStep; }
+  if (IAC_STEPS.toUser(page9.iacMaxSteps) > (uint16_t)UINT8_MAX ) { current.idleLoad = idleStepper.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
+  else { current.idleLoad = idleStepper.curIdleStep; }
   
   doStep();
 }
@@ -607,7 +607,7 @@ void idleControl(void)
             iacCoolTime_uS = configPage9.iacCoolTime * 1000;
           }
         }
-        updateIdleStepAndLoad();
+        updateIdleStepAndLoad(currentStatus, configPage9);
       }
       break;
 
@@ -680,7 +680,7 @@ void idleControl(void)
         
         if(currentStatus.idleUpActive == true) { idleStepper.targetIdleStep += configPage2.idleUpAdder; } //Add Idle Up amount if active
         
-        updateIdleStepAndLoad();
+        updateIdleStepAndLoad(currentStatus, configPage9);
       }
       if (BIT_CHECK(currentStatus.LOOP_TIMER, BIT_TIMER_1HZ)) //Use timer flag instead idle count
       {

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -316,6 +316,22 @@ static inline void doStep(void)
 }
 
 /*
+Clamps the target step count to the configured max steps (including any idle-up
+adder, to prevent over-opening), updates the reported idleLoad and performs a step.
+*/
+static inline void updateIdleStepAndLoad(void)
+{
+  //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
+  if (idleStepper.targetIdleStep > (configPage9.iacMaxSteps * 3) )
+  {
+    idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;
+  }
+  if( ((uint16_t)configPage9.iacMaxSteps * 3) > UINT8_MAX ) { currentStatus.idleLoad = idleStepper.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
+  else { currentStatus.idleLoad = idleStepper.curIdleStep; }
+  doStep();
+}
+
+/*
 Checks whether the stepper has been homed yet. If it hasn't, will handle the next step
 Returns:
 True: If the system has been homed. No other action is taken
@@ -592,14 +608,7 @@ void idleControl(void)
             iacCoolTime_uS = configPage9.iacCoolTime * 1000;
           }
         }
-        //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
-        if (idleStepper.targetIdleStep > (configPage9.iacMaxSteps * 3) )
-        {
-          idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;
-        }
-        if( ((uint16_t)configPage9.iacMaxSteps * 3) > UINT8_MAX ) { currentStatus.idleLoad = idleStepper.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
-        else { currentStatus.idleLoad = idleStepper.curIdleStep; }
-        doStep();
+        updateIdleStepAndLoad();
       }
       break;
 
@@ -672,14 +681,7 @@ void idleControl(void)
         
         if(currentStatus.idleUpActive == true) { idleStepper.targetIdleStep += configPage2.idleUpAdder; } //Add Idle Up amount if active
         
-        //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
-        if (idleStepper.targetIdleStep > (configPage9.iacMaxSteps * 3) )
-        {
-          idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;
-        }
-        if( ( (uint16_t)configPage9.iacMaxSteps * 3) > UINT8_MAX ) { currentStatus.idleLoad = idleStepper.curIdleStep / 2; }//Current step count (Divided by 2 for byte)
-        else { currentStatus.idleLoad = idleStepper.curIdleStep; }
-        doStep();
+        updateIdleStepAndLoad();
       }
       if (BIT_CHECK(currentStatus.LOOP_TIMER, BIT_TIMER_1HZ)) //Use timer flag instead idle count
       {

--- a/speeduino/units.h
+++ b/speeduino/units.h
@@ -143,6 +143,9 @@ static constexpr conversionFactor<int8_t, uint8_t> FUEL_TRIM = { .scale=1U, .tra
 /** @brief Frequency range from 0 to 512 */
 static constexpr conversionFactor<uint16_t, uint8_t> FREQUENCY = { .scale=2U, .translate=0U };
 
+/** @brief IAC steps */
+static constexpr conversionFactor<uint16_t, uint8_t> IAC_STEPS = { .scale=3U, .translate=0U };
+
 ///@}
 
 /**

--- a/test/test_idle/main.cpp
+++ b/test/test_idle/main.cpp
@@ -6,9 +6,11 @@ void runAllTests(void)
 {
     extern void testInitialiseIdle(void);
     extern void testDisableIdle(void);
+    extern void testIdleControl(void);
 
     testInitialiseIdle();
     testDisableIdle();
+    testIdleControl();
 }
 
 TEST_HARNESS(runAllTests)

--- a/test/test_idle/test_idlecontrol.cpp
+++ b/test/test_idle/test_idlecontrol.cpp
@@ -9,16 +9,28 @@
 // read curIdleStep directly; instead we assert on currentStatus.idleLoad, which
 // the helper writes. A sentinel value is stored first to prove the helper ran.
 //
-// With forced homing curIdleStep starts at 0, so idleLoad is expected to be 0
-// in both max-steps regimes; the two tests exist to cover both sides of the
-// "does (iacMaxSteps * 3) exceed a byte?" branch inside the helper.
+// The cranking-table lookup is loaded with a large step count so the computed
+// target exceeds the configured max: that exercises the helper's clamp branch,
+// and the two maxSteps regimes cover both sides of its "does (iacMaxSteps * 3)
+// exceed a byte?" resolution branch. With forced homing curIdleStep starts at 0,
+// so idleLoad reads back as 0 (it is latched from curIdleStep before doStep()).
 
-static void prepare_stepper_homed(uint8_t maxSteps)
+static void prepare_stepper_homed(uint8_t algorithm, uint8_t maxSteps)
 {
-  prepare_idle(IAC_ALGORITHM_STEP_OL);
+  prepare_idle(algorithm);
   configPage6.iacStepHome = 0U;   // completedHomeSteps(0) < 0 is false -> already homed
   configPage9.iacMaxSteps = maxSteps;
   configPage6.iacStepHyster = 0U;
+
+  // Load the cranking step table so the lookup returns a large value. The target
+  // (returned value * 3) then exceeds iacMaxSteps * 3 for both regimes below,
+  // so the helper's clamp branch actually fires.
+  for (uint8_t i = 0U; i < 4U; i++)
+  {
+    configPage6.iacCrankBins[i] = i;     // all below the lookup key -> clamp to last value
+    configPage6.iacCrankSteps[i] = 120U; // 120 * 3 = 360 target
+  }
+
   // Not "Running" -> the cranking branch sets the target directly, with no
   // loop-timer gate, so the helper is reached deterministically on this call.
   currentStatus.rotationStatus = EngineRotationStatus::Cranking;
@@ -26,19 +38,31 @@ static void prepare_stepper_homed(uint8_t maxSteps)
   initialiseIdle(true);           // forcehoming: curIdleStep = 0, status = SOFF
 }
 
-static void test_idleControl_step_ol_load_directResolution(void)
+static void test_idleControl_step_ol_clamp_directResolution(void)
 {
-  // iacMaxSteps * 3 == 60, which fits in a byte -> idleLoad = curIdleStep.
-  prepare_stepper_homed(20U);
+  // Open-loop stepper. iacMaxSteps * 3 == 60: target 360 is clamped down to 60,
+  // and 60 fits in a byte -> idleLoad = curIdleStep.
+  prepare_stepper_homed(IAC_ALGORITHM_STEP_OL, 20U);
   currentStatus.idleLoad = 0xFFU; // sentinel: must be overwritten by the helper
   idleControl();
   TEST_ASSERT_EQUAL(0U, currentStatus.idleLoad);
 }
 
-static void test_idleControl_step_ol_load_halfResolution(void)
+static void test_idleControl_step_ol_clamp_halfResolution(void)
 {
-  // iacMaxSteps * 3 == 300, which exceeds a byte -> idleLoad = curIdleStep / 2.
-  prepare_stepper_homed(100U);
+  // Open-loop stepper. iacMaxSteps * 3 == 300: target 360 is clamped down to
+  // 300, which exceeds a byte -> idleLoad = curIdleStep / 2.
+  prepare_stepper_homed(IAC_ALGORITHM_STEP_OL, 100U);
+  currentStatus.idleLoad = 0xFFU; // sentinel: must be overwritten by the helper
+  idleControl();
+  TEST_ASSERT_EQUAL(0U, currentStatus.idleLoad);
+}
+
+static void test_idleControl_step_cl_reachesHelper(void)
+{
+  // Closed-loop stepper reaches the same helper from the other (previously
+  // duplicated) call site, via its cranking sub-path.
+  prepare_stepper_homed(IAC_ALGORITHM_STEP_CL, 20U);
   currentStatus.idleLoad = 0xFFU; // sentinel: must be overwritten by the helper
   idleControl();
   TEST_ASSERT_EQUAL(0U, currentStatus.idleLoad);
@@ -48,7 +72,8 @@ void testIdleControl(void)
 {
   SET_UNITY_FILENAME()
   {
-    RUN_TEST(test_idleControl_step_ol_load_directResolution);
-    RUN_TEST(test_idleControl_step_ol_load_halfResolution);
+    RUN_TEST(test_idleControl_step_ol_clamp_directResolution);
+    RUN_TEST(test_idleControl_step_ol_clamp_halfResolution);
+    RUN_TEST(test_idleControl_step_cl_reachesHelper);
   }
 }

--- a/test/test_idle/test_idlecontrol.cpp
+++ b/test/test_idle/test_idlecontrol.cpp
@@ -1,0 +1,54 @@
+#include "../test_utils.h"
+#include "idle.h"
+#include "prepare_idle.h"
+#include "units.h"
+
+// These tests drive idleControl() through the open-loop stepper path far
+// enough to execute updateIdleStepAndLoad() (the helper extracted from the two
+// previously-duplicated idle branches). idleStepper is file-static, so we can't
+// read curIdleStep directly; instead we assert on currentStatus.idleLoad, which
+// the helper writes. A sentinel value is stored first to prove the helper ran.
+//
+// With forced homing curIdleStep starts at 0, so idleLoad is expected to be 0
+// in both max-steps regimes; the two tests exist to cover both sides of the
+// "does (iacMaxSteps * 3) exceed a byte?" branch inside the helper.
+
+static void prepare_stepper_homed(uint8_t maxSteps)
+{
+  prepare_idle(IAC_ALGORITHM_STEP_OL);
+  configPage6.iacStepHome = 0U;   // completedHomeSteps(0) < 0 is false -> already homed
+  configPage9.iacMaxSteps = maxSteps;
+  configPage6.iacStepHyster = 0U;
+  // Not "Running" -> the cranking branch sets the target directly, with no
+  // loop-timer gate, so the helper is reached deterministically on this call.
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  currentStatus.coolant = 80;
+  initialiseIdle(true);           // forcehoming: curIdleStep = 0, status = SOFF
+}
+
+static void test_idleControl_step_ol_load_directResolution(void)
+{
+  // iacMaxSteps * 3 == 60, which fits in a byte -> idleLoad = curIdleStep.
+  prepare_stepper_homed(20U);
+  currentStatus.idleLoad = 0xFFU; // sentinel: must be overwritten by the helper
+  idleControl();
+  TEST_ASSERT_EQUAL(0U, currentStatus.idleLoad);
+}
+
+static void test_idleControl_step_ol_load_halfResolution(void)
+{
+  // iacMaxSteps * 3 == 300, which exceeds a byte -> idleLoad = curIdleStep / 2.
+  prepare_stepper_homed(100U);
+  currentStatus.idleLoad = 0xFFU; // sentinel: must be overwritten by the helper
+  idleControl();
+  TEST_ASSERT_EQUAL(0U, currentStatus.idleLoad);
+}
+
+void testIdleControl(void)
+{
+  SET_UNITY_FILENAME()
+  {
+    RUN_TEST(test_idleControl_step_ol_load_directResolution);
+    RUN_TEST(test_idleControl_step_ol_load_halfResolution);
+  }
+}


### PR DESCRIPTION
## Summary
The "clamp targetIdleStep to max steps, then update idleLoad (halving it if it won't fit in a byte at full resolution), then step" block was duplicated verbatim in both the open-loop and PID (open/closed-loop) idle branches. Extracted into `updateIdleStepAndLoad()` so any future change to the heuristic only needs to be made once. Purely a refactor - behavior is unchanged.

Fixes #1564

## Test plan
- [ ] CI build/test suite
- Diffed both call sites against the original duplicated blocks to confirm the extracted helper is byte-for-byte equivalent in behavior.
