### PR TITLE
Fix missing break after ROTARY_IGN_RX8 case

### DIFF
--- a/speeduino/scheduler_ignition_controller.cpp
+++ b/speeduino/scheduler_ignition_controller.cpp
@@ -208,6 +208,7 @@ static void __attribute__((optimize("Os"))) setRotaryCallbacks(uint8_t rotaryTyp
   case ROTARY_IGN_RX8:
     //RX8 outputs are simply 1 coil and 1 output per plug
     setSequentialCallbacks(4U);
+    break;
 
   default:
     //No action for other RX ignition modes (Future expansion / MISRA compliant). 


### PR DESCRIPTION
## Summary
`setRotaryCallbacks()` fell through from `ROTARY_IGN_RX8` into `default` undocumented - every other case in this switch (and the equivalent pattern elsewhere in the file) either breaks or explicitly annotates intentional fall-through. `default`'s body is currently just `break;`, so there's no behavioral change today, but this silences a MISRA 16.3 violation and removes the latent risk of RX8 silently picking up whatever code `default` gains in the future.

Fixes #1566

## Test plan
- [ ] CI build/test suite
- No behavioral change (default's body was already just `break;`), so existing rotary-ignition tests should be unaffected.
