### PR TITLE
Avoid implementation-defined narrowing in correctionLaunch()

### DIFF
--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -568,6 +568,9 @@ This simple check applies the extra fuel if we're currently launching
 */
 TESTABLE_INLINE_STATIC uint8_t correctionLaunch(void)
 {
+  // Accumulate in int16_t: NO_FUEL_CORRECTION (100) + lnchFuelAdd (tune range
+  // -40..+80) can reach 180, which overflows int8_t. The result is always within
+  // [60, 180], so the final narrowing to uint8_t is safe.
   int16_t correction = (int16_t)NO_FUEL_CORRECTION;
   if (currentStatus.launchingHard || currentStatus.launchingSoft) {
     correction = correction + configPage6.lnchFuelAdd;

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -568,10 +568,10 @@ This simple check applies the extra fuel if we're currently launching
 */
 TESTABLE_INLINE_STATIC uint8_t correctionLaunch(void)
 {
-  int8_t correction = (int8_t)NO_FUEL_CORRECTION;
+  int16_t correction = (int16_t)NO_FUEL_CORRECTION;
   if (currentStatus.launchingHard || currentStatus.launchingSoft) {
     correction = correction + configPage6.lnchFuelAdd;
-  } 
+  }
   return (uint8_t)correction;
 }
 

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -746,6 +746,26 @@ static void test_corrections_launch_removeFuel(void) {
   TEST_ASSERT_EQUAL(75U, correctionLaunch() );
 }
 
+static void test_corrections_launch_maxAdd(void) {
+  //lnchFuelAdd max is +80 (see speeduino.ini). 100 + 80 = 180, which exceeds
+  //int8_t range - the accumulator must be wide enough to hold it without relying
+  //on implementation-defined narrowing.
+  currentStatus.launchingHard = true;
+  currentStatus.launchingSoft = false;
+  configPage6.lnchFuelAdd = 80;
+
+  TEST_ASSERT_EQUAL(180U, correctionLaunch() );
+}
+
+static void test_corrections_launch_minAdd(void) {
+  //lnchFuelAdd min is -40 (see speeduino.ini). 100 - 40 = 60.
+  currentStatus.launchingHard = false;
+  currentStatus.launchingSoft = true;
+  configPage6.lnchFuelAdd = -40;
+
+  TEST_ASSERT_EQUAL(60U, correctionLaunch() );
+}
+
 static void test_corrections_launch(void)
 {
   RUN_TEST_P(test_corrections_launch_inactive);
@@ -753,6 +773,8 @@ static void test_corrections_launch(void)
   RUN_TEST_P(test_corrections_launch_soft);
   RUN_TEST_P(test_corrections_launch_both);
   RUN_TEST_P(test_corrections_launch_removeFuel);
+  RUN_TEST_P(test_corrections_launch_maxAdd);
+  RUN_TEST_P(test_corrections_launch_minAdd);
 }
 
 extern bool correctionDFCO(void);


### PR DESCRIPTION
## Summary
`correctionLaunch()` accumulated `NO_FUEL_CORRECTION` (100) + `lnchFuelAdd` (tune-editable -40..+80) in an `int8_t`, which can hold a computed value of 180 only via an implementation-defined conversion on assignment (well-defined as two's-complement wraparound on this project's GCC-based toolchains, but not something the standard guarantees generally). Widened the accumulator to `int16_t` so the value is correct by construction rather than by relying on a specific narrowing-conversion behavior; the final `(uint8_t)` cast is now a plain, always-safe conversion since the result is always in `[60,180]`.

Fixes #1571

## Test plan
- [ ] CI build/test suite
- Checked `test/test_fuel/test_corrections.cpp` - existing tests use `lnchFuelAdd` of +/-25 (never near the +/-40/+80 extremes that trigger the original narrowing), and produce identical results (100, 125, 75) under this change.
