### PR TITLE
Clear a Programmable Output pin that conflicts with another function (surfaces the conflict in TS)

### DIFF
--- a/speeduino/src/controllers/progammableIO/programmableIOControl.cpp
+++ b/speeduino/src/controllers/progammableIO/programmableIOControl.cpp
@@ -14,10 +14,17 @@ using namespace programmableIOControl_details;
 
 TESTABLE_STATIC state_t state; // The current state of the programmable I/O system, including the status of each channel and its timers
 
-void __attribute__((optimize("Os"))) initialiseProgrammableIO(const config13& page13)
+void __attribute__((optimize("Os"))) initialiseProgrammableIO(config13& page13)
 {
   for (uint8_t y = 0; y < _countof(state_t::channels); ++y)
   {
+    // A physical output pin can only be driven by one function. If this rule's pin is
+    // already claimed elsewhere, clear it in the tune (disabling the rule) rather than
+    // letting the rule silently never run. Clearing the pin changes the page CRC, so
+    // TunerStudio detects the conflict and surfaces it to the user. Virtual/cascade
+    // pins (>=128) and already-disabled slots (0) are left untouched.
+    const uint8_t outputPin = page13.outputPin[y];
+    if ((outputPin > 0U) && (outputPin < 128U) && pinIsUsed(outputPin)) { page13.outputPin[y] = 0U; }
     state.channels[y].initialize(page13, y);
   }
 }

--- a/speeduino/src/controllers/progammableIO/programmableIOControl.h
+++ b/speeduino/src/controllers/progammableIO/programmableIOControl.h
@@ -6,7 +6,7 @@
 /** @brief Initialise the programmable I/O system.
  * @param page13 The tune
  */
-void initialiseProgrammableIO(const config13& page13);
+void initialiseProgrammableIO(config13& page13);
 
 /** @brief Control function for the programmable I/O system.
  * Should be called regularly (e.g. in main loop) to check the rules and update outputs accordingly.

--- a/test/test_programmableio/test_programmableIOControl.cpp
+++ b/test/test_programmableio/test_programmableIOControl.cpp
@@ -198,6 +198,28 @@ static void test_initialiseProgrammableIO_used_physical_pin(void)
     TEST_ASSERT_TRUE(processing_channel_t(context.page13, state.channels[1]).isPinValid);  // Should be valid
 }
 
+static void test_initialiseProgrammableIO_clears_conflicting_pin(void)
+{
+    programmableIOTestContext_t context;
+
+    pinNumbers.pinCLT = 10;               // pin 10 is claimed by the CLT sensor
+
+    context.page13.outputPin[0] = 10;     // conflicts with the CLT pin
+    context.page13.outputPin[1] = 11;     // free physical pin
+    context.page13.outputPin[2] = 130;    // virtual/cascade rule (>=128)
+    context.page13.outputPin[3] = 0;      // already disabled
+
+    initialiseProgrammableIO(context.page13);
+
+    // The conflicting physical pin is cleared in the tune (so the page CRC changes and
+    // TunerStudio surfaces the conflict) instead of the rule silently never running.
+    TEST_ASSERT_EQUAL_UINT8(0, context.page13.outputPin[0]);
+    // A free pin, a virtual rule and an already-disabled slot are left untouched.
+    TEST_ASSERT_EQUAL_UINT8(11, context.page13.outputPin[1]);
+    TEST_ASSERT_EQUAL_UINT8(130, context.page13.outputPin[2]);
+    TEST_ASSERT_EQUAL_UINT8(0, context.page13.outputPin[3]);
+}
+
 static void test_checkProgrammableIO_disabled_pin(void)
 {
     programmableIOTestContext_t context;
@@ -838,6 +860,7 @@ void testProgrammableIOControl(void)
         RUN_TEST_P(test_initialiseProgrammableIO_mixed_configuration);
         RUN_TEST_P(test_initialiseProgrammableIO_physical_pins);
         RUN_TEST_P(test_initialiseProgrammableIO_used_physical_pin);
+        RUN_TEST_P(test_initialiseProgrammableIO_clears_conflicting_pin);
         RUN_TEST_P(test_checkProgrammableIO_disabled_pin);
         RUN_TEST_P(test_checkProgrammableIO_skips_invalid_pins);
         RUN_TEST_P(test_checkProgrammableIO_all_cascade_rules);


### PR DESCRIPTION
## Summary

Implements @adbancroft's suggested approach from #1599 for the "stand-alone A/C fan pin silently disables a Programmable Output on the same pin" footgun:

> Solution should be simple. The firmware:
> 1. detects the conflict (done)
> 2. Changes the tune. E.g. to NOT_A_PIN
> 3. TS will detect the change via a CRC check & then show the diff in its UI

`initialiseProgrammableIO` now clears a conflicting output pin in the tune:

```cpp
const uint8_t outputPin = page13.outputPin[y];
if ((outputPin > 0U) && (outputPin < 128U) && pinIsUsed(outputPin)) { page13.outputPin[y] = 0U; }
```

- **Runtime behaviour is unchanged** — a rule whose pin is already used still doesn't drive that pin. The only change is that the pin is now cleared to `0` in the live tune, which changes the page CRC so TunerStudio surfaces the conflict to the user instead of the rule silently never running.
- Only **physical, in-use** pins are cleared. Virtual/cascade pins (`>=128`) and already-disabled slots (`0`) are left untouched.

### Note on the "clear" value: `0`, not `NOT_A_PIN`

The comment in #1599 suggested `NOT_A_PIN` as an example. For the `config13.outputPin` field the correct disabled value is **`0`**, not `NOT_A_PIN` (255): `isValidOutputPin` treats any value `> 128` as a *virtual/cascade* pin (it bypasses the `pinIsUsed` check), so writing 255 would turn the rule into a virtual rule rather than disabling it. `0` is the field's documented "not programmed" value and what `isValidOutputPin(0)` already rejects.

The change is RAM-only (not auto-burned to EEPROM) — matching the described flow where TS detects the CRC difference and the user then fixes/burns their tune. This also avoids EEPROM wear on every boot.

The signature of `initialiseProgrammableIO` changes from `const config13&` to `config13&` (it now writes back to the tune); the only non-test caller is `init.cpp` which passes the non-const global `configPage13`.

Fixes #1599

## Test plan

- [ ] CI build/test suite
- Added `test_initialiseProgrammableIO_clears_conflicting_pin` in `test/test_programmableio/`: a rule on a pin claimed by the CLT sensor is cleared to `0`, while a free physical pin, a virtual/cascade pin (`130`) and an already-disabled slot are left untouched.
- The existing `test_initialiseProgrammableIO_used_physical_pin` still passes (clearing the pin to 0 keeps `isPinValid` false).
- Ran `test_programmableio` natively: 49/49 pass.
