### PR TITLE
Fix 5 cylinder single channel spark mode and remove duplicate unit test invocation.

### DIFF
--- a/.github/workflows/pr-memory-deltas.yml
+++ b/.github/workflows/pr-memory-deltas.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build PR Envs
       run: |
         source PIO/bin/activate
-        platformio run -d ${{ env.PR_FOLDER }} ${{ steps.build_command_line.outputs.CMD_PIO_ENVS }} &> ${{ env.PR_LOG_FILE }}
+        platformio run -d ${{ env.PR_FOLDER }} ${{ steps.build_command_line.outputs.CMD_PIO_ENVS }} 2>&1 | tee ${{ env.PR_LOG_FILE }}
     
     - name: Checkout Base Branch
       uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
     - name: Build Base Envs
       run: |
         source PIO/bin/activate
-        platformio run -d ${{ env.BASE_FOLDER }} ${{ steps.build_command_line.outputs.CMD_PIO_ENVS }} &> ${{ env.BASE_LOG_FILE }}
+        platformio run -d ${{ env.BASE_FOLDER }} ${{ steps.build_command_line.outputs.CMD_PIO_ENVS }} 2>&1 | tee ${{ env.BASE_LOG_FILE }}
 
     - name: Generate artifacts
       run: |

--- a/speeduino/scheduler_ignition_controller.cpp
+++ b/speeduino/scheduler_ignition_controller.cpp
@@ -389,7 +389,7 @@ static void __attribute__((optimize("Os"))) initScheduleAngles(statuses &current
 #endif
       current.maxIgnOutputs= 5; //Only 4 actual outputs, so that's all that can be cut
 
-      if(page4.sparkMode == IGN_MODE_SEQUENTIAL)
+      if( ( (page4.sparkMode == IGN_MODE_SEQUENTIAL) || (page4.sparkMode == IGN_MODE_SINGLE) ) && (page2.strokes == FOUR_STROKE) )
       {
 #if IGN_CHANNELS >= 2
         ignitionSchedule2.channelDegrees = 144;

--- a/test/test_schedules/test_igniton_schedule_controller.cpp
+++ b/test/test_schedules/test_igniton_schedule_controller.cpp
@@ -561,6 +561,38 @@ static void test_initialize_rotary_rx8_callbacks(void)
     RUNIF_IGNCHANNEL8( { assert_callbacks(ignitionSchedule8, nullCallback, nullCallback); }, {});
 }
 
+static void test_initialiseIgnitionSchedules_5cyl_singlechannel(void)
+{
+    statuses current = {};
+    config2 page2 = {};
+    config4 page4 = {};
+    config10 page10 = {};
+    pinNumbers_t pins = {};
+
+    page2.nCylinders = 5U;
+    page2.strokes = FOUR_STROKE;
+    page4.sparkMode = IGN_MODE_SINGLE;
+
+    initialiseIgnitionSchedules(current, page2, page4, page10, pins);
+
+    TEST_ASSERT_EQUAL_UINT16(720U, CRANK_ANGLE_MAX_IGN);
+    TEST_ASSERT_EQUAL_UINT8(5U, current.maxIgnOutputs);
+
+    TEST_ASSERT_EQUAL_UINT16(0U, ignitionSchedule1.channelDegrees);
+#if IGN_CHANNELS >= 2
+    TEST_ASSERT_EQUAL_UINT16(144U, ignitionSchedule2.channelDegrees);
+#endif
+#if IGN_CHANNELS >= 3
+    TEST_ASSERT_EQUAL_UINT16(288U, ignitionSchedule3.channelDegrees);
+#endif
+#if IGN_CHANNELS >= 4
+    TEST_ASSERT_EQUAL_UINT16(432U, ignitionSchedule4.channelDegrees);
+#endif
+#if IGN_CHANNELS >= 5
+    TEST_ASSERT_EQUAL_UINT16(576U, ignitionSchedule5.channelDegrees);
+#endif
+}
+
 void test_ignition_schedule_controller(void)
 {
   SET_UNITY_FILENAME() {
@@ -588,27 +620,6 @@ void test_ignition_schedule_controller(void)
     RUN_TEST_P(test_initialize_rotary_fc_callbacks);
     RUN_TEST_P(test_initialize_rotary_fd_callbacks);
     RUN_TEST_P(test_initialize_rotary_rx8_callbacks);
-    RUN_TEST_P(test_calculateIgnitionAngles_nonrotary);
-    RUN_TEST_P(test_calculateIgnitionAngles_rotary);
-    RUN_TEST_P(test_calculateIgnitionAngles_rotary_non_4_output_uses_non_rotary);
-    RUN_TEST_P(test_calculateIgnitionAngles_sync_state_transitions);
-    RUN_TEST_P(test_setIgnitionChannels_mask_enables_and_disables_channels);
-    RUN_TEST_P(test_changeIgnitionToFullSequential);
-    RUN_TEST_P(test_changeIgnitionToFullSequential_running_schedule);
-    RUN_TEST_P(test_changeIgnitionToHalfSync);
-    RUN_TEST_P(test_changeIgnitionToHalfSync_runningschedule);
-    RUN_TEST_P(test_isAnyIgnScheduleRunning);
-    RUN_TEST_P(test_initialize_singlechannel_callbacks);
-    RUN_TEST_P(test_initialize_wastedCOP1_callbacks);
-    RUN_TEST_P(test_initialize_wastedCOP2_callbacks);
-    RUN_TEST_P(test_initialize_wastedCOP3_callbacks);
-    RUN_TEST_P(test_initialize_wastedCOP4_callbacks);
-    RUN_TEST_P(test_initialize_wastedCOP5_callbacks);
-    RUN_TEST_P(test_initialize_wastedCOP6_callbacks);
-    RUN_TEST_P(test_initialize_wastedCOP8_callbacks);
-    RUN_TEST_P(test_initialize_sequential_callbacks);
-    RUN_TEST_P(test_initialize_rotary_fc_callbacks);
-    RUN_TEST_P(test_initialize_rotary_fd_callbacks);
-    RUN_TEST_P(test_initialize_rotary_rx8_callbacks);
+    RUN_TEST_P(test_initialiseIgnitionSchedules_5cyl_singlechannel);
   }
 }

--- a/test/test_schedules/test_igniton_schedule_controller.cpp
+++ b/test/test_schedules/test_igniton_schedule_controller.cpp
@@ -17,8 +17,10 @@ struct ignition_test_context_t
 {
     config2 page2 = {};
     config4 page4 = {};
+    config10 page10 = {};
     config13 page13 = {};
     statuses current = {};
+    pinNumbers_t pins = {};
 
     ignition_test_context_t() {
         // Set basic engine config defaults
@@ -63,6 +65,18 @@ static void assert_ignition_angles(const ignition_test_context_t &context)
     RUNIF_IGNCHANNEL6( { if (context.current.maxIgnOutputs>=6) { TEST_ASSERT_GREATER_THAN(0U, ignitionSchedule6.chargeAngle + ignitionSchedule6.dischargeAngle); }}, {});
     RUNIF_IGNCHANNEL7( { if (context.current.maxIgnOutputs>=7) { TEST_ASSERT_GREATER_THAN(0U, ignitionSchedule7.chargeAngle + ignitionSchedule7.dischargeAngle); }}, {});
     RUNIF_IGNCHANNEL8( { if (context.current.maxIgnOutputs>=8) { TEST_ASSERT_GREATER_THAN(0U, ignitionSchedule8.chargeAngle + ignitionSchedule8.dischargeAngle); }}, {});
+}
+
+static void assert_channel_angles(const ignition_test_context_t &context, const uint16_t (&angles)[8])
+{
+    RUNIF_IGNCHANNEL1( { if (context.current.maxIgnOutputs>=1) { TEST_ASSERT_EQUAL_UINT16(angles[0], ignitionSchedule1.channelDegrees); }}, {});
+    RUNIF_IGNCHANNEL2( { if (context.current.maxIgnOutputs>=2) { TEST_ASSERT_EQUAL_UINT16(angles[1], ignitionSchedule2.channelDegrees); }}, {});
+    RUNIF_IGNCHANNEL3( { if (context.current.maxIgnOutputs>=3) { TEST_ASSERT_EQUAL_UINT16(angles[2], ignitionSchedule3.channelDegrees); }}, {});
+    RUNIF_IGNCHANNEL4( { if (context.current.maxIgnOutputs>=4) { TEST_ASSERT_EQUAL_UINT16(angles[3], ignitionSchedule4.channelDegrees); }}, {});
+    RUNIF_IGNCHANNEL5( { if (context.current.maxIgnOutputs>=5) { TEST_ASSERT_EQUAL_UINT16(angles[4], ignitionSchedule5.channelDegrees); }}, {});
+    RUNIF_IGNCHANNEL6( { if (context.current.maxIgnOutputs>=6) { TEST_ASSERT_EQUAL_UINT16(angles[5], ignitionSchedule6.channelDegrees); }}, {});
+    RUNIF_IGNCHANNEL7( { if (context.current.maxIgnOutputs>=7) { TEST_ASSERT_EQUAL_UINT16(angles[6], ignitionSchedule7.channelDegrees); }}, {});
+    RUNIF_IGNCHANNEL8( { if (context.current.maxIgnOutputs>=8) { TEST_ASSERT_EQUAL_UINT16(angles[7], ignitionSchedule8.channelDegrees); }}, {});
 }
 
 static void test_calculateIgnitionAngles_nonrotary(void)
@@ -563,34 +577,18 @@ static void test_initialize_rotary_rx8_callbacks(void)
 
 static void test_initialiseIgnitionSchedules_5cyl_singlechannel(void)
 {
-    statuses current = {};
-    config2 page2 = {};
-    config4 page4 = {};
-    config10 page10 = {};
-    pinNumbers_t pins = {};
+    ignition_test_context_t context;
 
-    page2.nCylinders = 5U;
-    page2.strokes = FOUR_STROKE;
-    page4.sparkMode = IGN_MODE_SINGLE;
+    context.page2.nCylinders = 5U;
+    context.page2.strokes = FOUR_STROKE;
+    context.page4.sparkMode = IGN_MODE_SINGLE;
 
-    initialiseIgnitionSchedules(current, page2, page4, page10, pins);
+    initialiseIgnitionSchedules(context.current, context.page2, context.page4, context.page10, context.pins);
 
     TEST_ASSERT_EQUAL_UINT16(720U, CRANK_ANGLE_MAX_IGN);
-    TEST_ASSERT_EQUAL_UINT8(5U, current.maxIgnOutputs);
-
-    TEST_ASSERT_EQUAL_UINT16(0U, ignitionSchedule1.channelDegrees);
-#if IGN_CHANNELS >= 2
-    TEST_ASSERT_EQUAL_UINT16(144U, ignitionSchedule2.channelDegrees);
-#endif
-#if IGN_CHANNELS >= 3
-    TEST_ASSERT_EQUAL_UINT16(288U, ignitionSchedule3.channelDegrees);
-#endif
-#if IGN_CHANNELS >= 4
-    TEST_ASSERT_EQUAL_UINT16(432U, ignitionSchedule4.channelDegrees);
-#endif
-#if IGN_CHANNELS >= 5
-    TEST_ASSERT_EQUAL_UINT16(576U, ignitionSchedule5.channelDegrees);
-#endif
+    TEST_ASSERT_EQUAL_UINT8(5U, context.current.maxIgnOutputs);
+    constexpr uint16_t angles[] = { 0, 144, 288, 432, 576, 0, 0, 0};
+    assert_channel_angles(context, angles);
 }
 
 void test_ignition_schedule_controller(void)


### PR DESCRIPTION
On a car with a distributor and 5 cylinders Speeduino will currently trigger an erroneous 2nd pulse on each tooth event:
<img width="1536" height="758" alt="5 cyl trigger" src="https://github.com/user-attachments/assets/b4d6e45f-ec32-425a-ae6c-52b4bd1b0642" />
Yellow is the trigger pulse, where we can see 2 distinct green lines which are the ignition 1 output.

The 5 cylinder single channel spark mode is the only one that has this bug, as the 3 channel mode has been fixed with the same fix applied here. 

Also fixed unit tests that were invoked twice for `test/test_schedules/test_igniton_schedule_controller.cpp` and create a check for this in the unit tests.

Fixes #1615 