### PR TITLE
Tests: initialize A/C fixtures and cover both fan polarities

### DIFF
--- a/test/test_accontrol/shared.cpp
+++ b/test/test_accontrol/shared.cpp
@@ -38,13 +38,15 @@ constexpr uint8_t TEST_ACFAN_PIN = 14;
 
 test_context setup_ac_tune(void)
 {
-    test_context context;
+    test_context context = {};
     context.pins.pinAirConComp = TEST_ACCOMP_PIN;
     context.pins.pinAirConRequest = TEST_ACREQUEST_PIN;
     context.pins.pinAirConFan = TEST_ACFAN_PIN;
 
     context.page15.airConEnable = true;
     context.page15.airConCompPol = false;
+    context.page15.airConReqPol = false;
+    context.page15.airConFanPol = false;
     context.page15.airConFanEnabled = true;
     context.page15.airConAfterStartDelay = 17;
     context.page15.airConClTempCut = TEMPERATURE.toRaw(100);

--- a/test/test_accontrol/test_airconcontrol.cpp
+++ b/test/test_accontrol/test_airconcontrol.cpp
@@ -228,15 +228,28 @@ static void test_ac_request_pin_inverted(void)
     TEST_ASSERT_TRUE(context.current.acStatus.turningOn);
 }
 
-static void test_fanon_when_acon(void)
+static void assert_fanon_when_acon(bool inverted)
 {
     auto context = setup_ac_tune();
+    context.page15.airConFanPol = inverted;
     context.initialise();
+    TEST_ASSERT_FALSE(context.current.acStatus.fanOn);
+    TEST_ASSERT_EQUAL(inverted, airConState.fanPin._pin.isPinHigh());
 
     setup_acon_status(context);
     context.control();
     TEST_ASSERT_TRUE(context.current.acStatus.fanOn);
-    TEST_ASSERT_TRUE(airConState.fanPin._pin.isPinHigh());
+    TEST_ASSERT_EQUAL(!inverted, airConState.fanPin._pin.isPinHigh());
+}
+
+static void test_fanon_when_acon(void)
+{
+    assert_fanon_when_acon(false);
+}
+
+static void test_fanon_when_acon_inverted(void)
+{
+    assert_fanon_when_acon(true);
 }
 
 void assert_ac_on(const test_context &context)
@@ -328,6 +341,7 @@ void testAcControl(void)
     RUN_TEST_P(test_ac_request_pin);
     RUN_TEST_P(test_ac_request_pin_inverted);
     RUN_TEST_P(test_fanon_when_acon);
+    RUN_TEST_P(test_fanon_when_acon_inverted);
     RUN_TEST_P(test_start_delay);
     RUN_TEST_P(test_airConOn);
     RUN_TEST_P(test_airConOn_inversepolarity);


### PR DESCRIPTION
The A/C fixture left configuration bits, including fan polarity, uninitialized. The 4x4 run could fail `test_fanon_when_acon` because the assertion assumed an active-high fan. Initialize the context and baseline polarities, then check both active-high and active-low fan transitions.

Production controller code and tune layout are unchanged.

Fixes #1626

### Validation
- Before: the original 4x4 A/C suite failed at test_airconcontrol.cpp:239.
- After: 27/27 A/C tests pass locally in native_code_coverage with INJ_CHANNELS=4 and IGN_CHANNELS=4 (Windows GCC, -Wa,-mbig-obj).
- Firmware RAM/flash impact: none; test-only changes. The 8x8 configuration is left to CI.

### Commit structure
- Tests: initialize the A/C tune fixture deterministically
- Tests: cover normal and inverted A/C fan activation
