### PR TITLE
CI: surface native test failures and fix timer lifetime races

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -92,3 +92,8 @@ jobs:
       with:
         path: |
           .pio/build/${{ env.PIO_ENV }}/${{ env.FILE_ROOT }}.*
+    - name: Check native test results
+      if: ${{ always() && (steps.tests_8x8.outcome == 'failure' || steps.tests_other.outcome == 'failure') }}
+      run: |
+        echo "::error::Native tests failed. See the test steps above; coverage reporting was allowed to complete."
+        exit 1

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -40,6 +40,7 @@ jobs:
         pip install platformio
        
     - name: Run Code Coverage Tests (8x8)
+      id: tests_8x8
       # We want the coverage to reflect the status of the
       # unit tests: so even if the tests fail or outright
       # crash, continue the rest of the workflow.
@@ -50,6 +51,7 @@ jobs:
         platformio test -e ${{ env.PIO_ENV }} ${{ vars.PIO_CMD_PARAMS }}
         
     - name: Run Code Coverage Tests (Other)
+      id: tests_other
       continue-on-error: true
       # Set NO_MULTI_CHANNEL=1 to skip this step and only run the 8x8 coverage tests.
       if: ${{ !vars.NO_MULTI_CHANNEL }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -39,6 +39,13 @@ jobs:
         source PIO/bin/activate
         pip install platformio
        
+    - name: Test native timer lifetime
+      run: |
+        g++ -std=c++14 -O1 -g -DNATIVE_BOARD -pthread -I lib/ArduinoFake \
+          .github/workflows/tests/test_software_timer.cpp lib/ArduinoFake/SoftwareTimer.cpp \
+          -o /tmp/test-software-timer
+        timeout 30s /tmp/test-software-timer
+
     - name: Run Code Coverage Tests (8x8)
       id: tests_8x8
       # We want the coverage to reflect the status of the

--- a/.github/workflows/tests/test_software_timer.cpp
+++ b/.github/workflows/tests/test_software_timer.cpp
@@ -1,0 +1,57 @@
+// Standalone native regression: no firmware or Arduino mocks are needed.
+#include "SoftwareTimer.h"
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <thread>
+
+int main()
+{
+    std::promise<void> entered;
+    std::promise<void> release;
+    auto releaseSignal = release.get_future();
+    auto enteredSignal = entered.get_future();
+    auto *timer = new software_timer_t();
+    timer->setCallback([&]() {
+        timer->disableTimer();
+        entered.set_value();
+        releaseSignal.wait();
+    });
+    timer->compare = 0;
+    timer->enableTimer();
+    if (enteredSignal.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
+    {
+        // Release a late callback before waiting for destruction.
+        release.set_value();
+        delete timer;
+        std::cerr << "Timer did not deliver a callback\n";
+        return 1;
+    }
+
+    std::promise<void> deleting;
+    auto deletingSignal = deleting.get_future();
+    auto destroyed = std::async(std::launch::async, [&]() {
+        deleting.set_value();
+        delete timer;
+    });
+    deletingSignal.wait();
+    const bool waited = destroyed.wait_for(std::chrono::milliseconds(50)) == std::future_status::timeout;
+    release.set_value();
+    destroyed.get();
+    if (!waited)
+    {
+        std::cerr << "Timer destruction did not wait for its in-flight callback\n";
+        return 1;
+    }
+
+    // Exercise registration and removal while the ticker iterates its callbacks.
+    for (unsigned i = 0; i < 20000; ++i)
+    {
+        software_timer_t temporary;
+        if (i % 10 == 0)
+        {
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        }
+    }
+    std::cout << "Timer lifetime and registration stress tests passed\n";
+}

--- a/lib/ArduinoFake/SoftwareTimer.cpp
+++ b/lib/ArduinoFake/SoftwareTimer.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <functional>
 #include <map>
+#include <mutex>
 #include "SoftwareTimer.h"
 
 namespace {
@@ -33,7 +34,7 @@ public:
 
     /** @brief External access to the current tick */
     software_timer_t::counter_t currentTick(void) const {
-        return tickCounter;
+        return tickCounter.load();
     }
 
     /** @brief Register a tick callback
@@ -42,6 +43,7 @@ public:
      * @return uint16_t Callback id that can be passed to unregisterCallback
      */
     uint16_t registerCallback(callback_t cb) {
+        std::lock_guard<std::mutex> lock(callbackMutex_);
         uint16_t id = nextId_;
         callbacks_[id] = std::move(cb);
         ++nextId_;
@@ -50,6 +52,8 @@ public:
 
     /** @brief Remove a previously registered callback */
     void unregisterCallback(uint16_t id) {
+        // Wait for an in-flight notification before destroying its timer.
+        std::lock_guard<std::mutex> lock(callbackMutex_);
         (void)callbacks_.erase(id);
     }    
 
@@ -78,6 +82,7 @@ public:
 private:
 
     void notifyNextTickEvent(void) {
+        std::lock_guard<std::mutex> lock(callbackMutex_);
         for (const auto &cb : callbacks_) {
             if (cb.second) {
                 cb.second(currentTick());
@@ -106,10 +111,11 @@ private:
         }
     }
 
+    std::mutex callbackMutex_;
     std::map<uint16_t, callback_t> callbacks_;
     uint16_t nextId_ = 0;
     std::thread tickThread;
-    software_timer_t::counter_t tickCounter = 1U;
+    std::atomic<software_timer_t::counter_t> tickCounter = {1U};
     std::atomic<bool> halt = {false};
 };
 


### PR DESCRIPTION
Coverage jobs previously continued after native test failures and still reported success. Retain the outcomes of both native configurations, publish coverage, then fail the job if either test run failed. An intentionally disabled optional run remains supported.

Also fix a native-only timer lifetime race exposed by the stricter check: the ticker traversed its callback map while the main thread registered or destroyed timers. Synchronize registration, removal and notification, wait for an in-flight callback before destroying its timer, and make the shared tick count atomic. This prevents callback-map invalidation and callbacks accessing a destroyed timer during suite shutdown.

Refs #1625

### Validation
- Reproduced a crash in the original native timer with repeated construction/destruction while ticking (Windows access violation); the patched version completed the same 200,000-iteration run.
- Added a standalone CI regression that checks destruction waits for an in-flight callback and stresses registration/removal. It passes locally; CI applies a 30-second timeout so a deadlock also fails.
- Previous CI run 34407306116 recorded SIGSEGV in launch-control (8x8) and ignition (4x4), after their assertions passed. These were process crashes, not PID assertion failures.
- All 65 targeted ignition and launch-control tests pass locally with MinGW large-object support.
- GitHub run 34489937040 passes: standalone timer lifetime regression; native 8x8 (2,121 passed, 9 skipped); native 4x4 (1,917 passed, 69 skipped).
- All PR checks are green for bad9522e, including firmware builds, AVR simulator, coverage, Codecov project/patch, size, INI validation, spelling and Sonar.
- actionlint and git diff --check pass.
- Native-only code and CI changes: no ECU firmware RAM/flash or tune-layout changes.

### Review structure
The workflow outcome check, timer synchronization, and timer regression coverage are separate commits. The branch already includes the independently merged A/C fixture fix (#1630).
