### PR TITLE
Docs: document fuel scheduler page10 parameter

### DIFF
--- a/speeduino/scheduler_fuel_controller.h
+++ b/speeduino/scheduler_fuel_controller.h
@@ -49,6 +49,7 @@ uint16_t setFuelChannelSchedules(const statuses &current);
  * @param page2 Tune settings
  * @param page4 Tune settings
  * @param page6 Tune settings
+ * @param page10 Tune settings
  * @param current Current system state
  */
 void applyPwToInjectorChannels(const pulseWidths &pulse_widths, const config2 &page2, const config4 &page4, const config6 &page6, const config10 &page10, statuses &current);


### PR DESCRIPTION
Doxygen on master stops because applyPwToInjectorChannels documents every configuration argument except page10. Add the missing parameter description alongside the other tune pages. This is a one-line documentation change with no executable or tune-layout changes.

Fixes #1628

### Validation
- Matched the documented arguments against the function declaration.
- git diff --check passed.
- Full isolated documentation generation using Doxygen 1.9.8 exited successfully (0); only unsupported newer Doxyfile setting warnings were emitted.
- Doxygen 1.12 was also attempted but stopped at the existing sensors_map_structs.h conditional-section diagnostic. Exact results therefore depend on the Doxygen version.
- No firmware RAM/flash impact.

### Commit structure
- Docs: document fuel scheduler page10 parameter
