### PR TITLE
Pins: reserve the fan output when PWM control is enabled

### DIFF
--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -57,7 +57,7 @@ bool pinIsOutput(byte pin)
       || pinNumbers.coilPins.isPinUsed(pin);
   //Functions?
   if ((pin == pinNumbers.pinFuelPump)
-  || ((pin == pinNumbers.pinFan) && (configPage2.fanEnable == 1))
+  || ((pin == pinNumbers.pinFan) && ((configPage2.fanEnable == 1) || (configPage2.fanEnable == 2)))
   || ((pin == pinNumbers.pinVVT_1) && (configPage6.vvtEnabled > 0))
   || ((pin == pinNumbers.pinVVT_2) && (configPage10.wmiEnabled > 0))
   || ((pin == pinNumbers.pinVVT_2) && (configPage10.vvt2Enabled > 0))

--- a/test/test_programmableio/test_programmableIOControl.cpp
+++ b/test/test_programmableio/test_programmableIOControl.cpp
@@ -219,6 +219,27 @@ static void test_initialiseProgrammableIO_clears_conflicting_pin(void)
     TEST_ASSERT_EQUAL_UINT8(0, context.page13.outputPin[3]);
 }
 
+static void test_initialiseProgrammableIO_fan_modes(void)
+{
+    const uint8_t oldFanPin = pinNumbers.pinFan;
+    const uint8_t oldFanMode = configPage2.fanEnable;
+    pinNumbers.pinFan = 11;
+    configPage2.fanEnable = 0;
+    TEST_ASSERT_FALSE(pinIsUsed(pinNumbers.pinFan));
+
+    for (uint8_t mode = 0; mode <= 2; ++mode)
+    {
+        programmableIOTestContext_t context;
+        configPage2.fanEnable = mode;
+        context.page13.outputPin[0] = pinNumbers.pinFan;
+        initialiseProgrammableIO(context.page13);
+        TEST_ASSERT_EQUAL(mode == 0, state.channels[0].isPinValid());
+        TEST_ASSERT_EQUAL_UINT8(mode == 0 ? pinNumbers.pinFan : 0, context.page13.outputPin[0]);
+    }
+    pinNumbers.pinFan = oldFanPin;
+    configPage2.fanEnable = oldFanMode;
+}
+
 static void test_checkProgrammableIO_disabled_pin(void)
 {
     programmableIOTestContext_t context;
@@ -860,6 +881,7 @@ void testProgrammableIOControl(void)
         RUN_TEST_P(test_initialiseProgrammableIO_physical_pins);
         RUN_TEST_P(test_initialiseProgrammableIO_used_physical_pin);
         RUN_TEST_P(test_initialiseProgrammableIO_clears_conflicting_pin);
+        RUN_TEST_P(test_initialiseProgrammableIO_fan_modes);
         RUN_TEST_P(test_checkProgrammableIO_disabled_pin);
         RUN_TEST_P(test_checkProgrammableIO_skips_invalid_pins);
         RUN_TEST_P(test_checkProgrammableIO_all_cascade_rules);


### PR DESCRIPTION
pinIsOutput only recognized on/off fan mode, so an otherwise free PWM fan pin could also be accepted by programmable I/O. Treat PWM mode as an active owner using the existing pin validation path. The programmable rule is then cleared as for other occupied pins, retaining the one-function-per-pin policy.

Adds a regression covering disabled, on/off and PWM modes. This is independent of the broader pin-priority design in #1604.

Fixes #1622

### Validation
- Before: the new mode test failed (expected invalid pin, got valid); 49/50 passed.
- After: 50/50 programmable-I/O tests pass in native 4x4.
- Mega2560 firmware builds: RAM 6352 bytes (unchanged); flash 187690 bytes versus 187692 at cc9eb445 (-2 bytes) with the same local toolchain.
- Native tests exercise the PWM mode; physical ARM PWM output and full board matrix remain for CI/hardware validation.

### Commit structure
- Tests: cover programmable-output conflicts in both fan modes
- Pins: reserve the fan output in PWM mode as well as on-off mode
