### PR TITLE
Comms: handle an empty composite log without an out-of-bounds read

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -1176,7 +1176,7 @@ void sendCompositeLog(void)
     //If the buffer is not yet full but TS has timed out, pad the rest of the buffer with 0s
     while(toothHistoryIndex < _countof(toothHistory))
     {
-      toothHistory[toothHistoryIndex] = toothHistory[toothHistoryIndex-1U]; //Composite logger needs a realistic time value to display correctly. Copy the last value
+      toothHistory[toothHistoryIndex] = toothHistoryIndex == 0U ? 0U : toothHistory[toothHistoryIndex-1U]; //Composite logger needs a realistic time value to display correctly. Copy the last value
       compositeLogHistory[toothHistoryIndex] = 0U;
       toothHistoryIndex++;
     }

--- a/test/test_composite_log/main.cpp
+++ b/test/test_composite_log/main.cpp
@@ -1,0 +1,53 @@
+#include "../test_harness_device.h"
+#include "../test_harness_native.h"
+#include "../test_utils.h"
+#include "globals.h"
+#include "comms.h"
+#include "comms_legacy.h"
+
+extern void sendCompositeLog(void);
+
+class log_test_stream_t : public Stream
+{
+public:
+    uint16_t written = 0;
+    int available(void) override { return 0; }
+    int availableForWrite(void) override { return 1024; }
+    int read(void) override { return -1; }
+    int peek(void) override { return -1; }
+    void flush(void) override {}
+    size_t write(uint8_t) override { ++written; return 1; }
+};
+
+static void assert_padded_log(uint16_t samples, uint32_t timestamp)
+{
+    log_test_stream_t stream;
+    Stream *oldSerial = pPrimarySerial;
+    pPrimarySerial = &stream;
+    currentStatus.isToothLog1Full = false;
+    toothHistoryIndex = samples;
+    logItemsTransmitted = 0;
+    toothHistory[0] = timestamp;
+    compositeLogHistory[0] = 1;
+    sendCompositeLog();
+    pPrimarySerial = oldSerial;
+
+    const uint32_t expected = samples == 0 ? 0 : timestamp;
+    for (uint16_t i = samples; i < TOOTH_LOG_SIZE; ++i)
+    {
+        TEST_ASSERT_EQUAL_UINT32(expected, toothHistory[i]);
+        TEST_ASSERT_EQUAL_UINT8(0, compositeLogHistory[i]);
+    }
+    TEST_ASSERT_EQUAL_UINT16(2U + 1U + (TOOTH_LOG_SIZE * 5U) + 4U, stream.written);
+    TEST_ASSERT_EQUAL_UINT16(0, toothHistoryIndex);
+}
+
+static void test_empty_log(void) { assert_padded_log(0, 12345); }
+static void test_one_sample(void) { assert_padded_log(1, 12345); }
+
+void runAllTests(void)
+{
+    RUN_TEST_P(test_empty_log);
+    RUN_TEST_P(test_one_sample);
+}
+TEST_HARNESS(runAllTests)


### PR DESCRIPTION
Requesting a composite log before the first trigger sample pads toothHistory by reading index -1. Seed the first missing timestamp with zero; subsequent padding continues to repeat the previous timestamp. Add tests that invoke the actual serial transfer with zero or one captured sample and check the padded data and response length.

Fixes #1621

### Validation
- The empty-log regression crashes/errors when run against the old padding expression.
- Both transfer tests pass with this fix in native 4x4.
- Mega2560 build passes; RAM 6352 bytes (unchanged), flash 187394 bytes versus 187692 on cc9eb445 (-298 bytes) with the local toolchain.
- No engine or physical TunerStudio session was used; zero is the defined timestamp for an empty capture.

### Commit structure
- Tests: exercise empty and single-sample composite log transfers
- Comms: seed an empty composite log before repeating timestamps
