### PR TITLE
Comms: parse complete secondary CAN success and failure replies

### DIFF
--- a/speeduino/comms_secondary.cpp
+++ b/speeduino/comms_secondary.cpp
@@ -25,6 +25,7 @@ sendcancommand is called when a command is to be sent either to serial3
 #include "logger.h"
 #include "page_crc.h"
 #include "board_definition.h"
+#include "unit_testing.h"
 
 uint8_t currentSecondaryCommand;
 SECONDARY_SERIAL_T* pSecondarySerial;
@@ -39,24 +40,26 @@ static constexpr uint8_t CAN_FRAME_DATA_BYTES = 8U;
 #endif
 
 // Handle a 'G' reply from the CAN interface: <success><channel><8 data bytes>.
-// Assumes the caller has confirmed enough bytes are available to read.
-static void processSecondaryCanReply(void)
+// Leave incomplete replies buffered, including a partial two-byte failure reply.
+TESTABLE_INLINE_STATIC bool processSecondaryCanReply(Stream &port)
 {
-  const uint8_t cmdSuccessful = secondarySerial.read();      // 0 == fail, 1 == good
-  const uint8_t destcaninchannel = secondarySerial.read();   // the input channel that requested the data value
+  if (port.available() < 2) { return false; }
+  if ((port.peek() != 0) && (port.available() < (CAN_FRAME_DATA_BYTES + 2))) { return false; }
+  const uint8_t cmdSuccessful = port.read();      // 0 == fail, 1 == good
+  const uint8_t destcaninchannel = port.read();   // the input channel that requested the data value
 
   // Nothing further is sent for a failed request.
-  if (cmdSuccessful == 0U) { return; }
+  if (cmdSuccessful == 0U) { return true; }
 
   uint8_t Gdata[CAN_FRAME_DATA_BYTES + 1U] = { 0U };
   for (uint8_t Gx = 0U; Gx < CAN_FRAME_DATA_BYTES; Gx++)
   {
-    Gdata[Gx] = secondarySerial.read();
+    Gdata[Gx] = port.read();
   }
 
   // Ignore out-of-range channels: destcaninchannel indexes both
   // caninput_source_start_byte[] and canin[].
-  if (destcaninchannel >= _countof(currentStatus.canin)) { return; }
+  if (destcaninchannel >= _countof(currentStatus.canin)) { return true; }
 
   // Mask to a valid data-byte index (0..CAN_FRAME_DATA_BYTES-1)
   const uint8_t startByte = configPage9.caninput_source_start_byte[destcaninchannel] & (CAN_FRAME_DATA_BYTES - 1U);
@@ -67,6 +70,7 @@ static void processSecondaryCanReply(void)
     Ghigh = Gdata[startByte + 1U];
   }
   currentStatus.canin[destcaninchannel] = ((uint16_t)Ghigh << 8) | Gdata[startByte];
+  return true;
 }
 
 void secondserial_Command(void)
@@ -106,10 +110,9 @@ void secondserial_Command(void)
 
     case 'G': // this is the reply command sent by the Can interface
       serialSecondaryStatusFlag = SERIAL_COMMAND_INPROGRESS_LEGACY;
-      if (secondarySerial.available() >= 9)
+      if (processSecondaryCanReply(secondarySerial))
       {
         serialSecondaryStatusFlag = SERIAL_INACTIVE;
-        processSecondaryCanReply();
       }
       break;
 

--- a/speeduino/comms_secondary.cpp
+++ b/speeduino/comms_secondary.cpp
@@ -43,8 +43,11 @@ static constexpr uint8_t CAN_FRAME_DATA_BYTES = 8U;
 // Leave incomplete replies buffered, including a partial two-byte failure reply.
 TESTABLE_INLINE_STATIC bool processSecondaryCanReply(Stream &port)
 {
-  if (port.available() < 2) { return false; }
-  if ((port.peek() != 0) && (port.available() < (CAN_FRAME_DATA_BYTES + 2))) { return false; }
+  // Evaluate readiness from one snapshot; later arrivals wait for the next call.
+  const int availableBytes = port.available();
+  if (availableBytes < 2) { return false; }
+  const bool successfulReply = port.peek() != 0;
+  if (successfulReply && (availableBytes < (CAN_FRAME_DATA_BYTES + 2))) { return false; }
   const uint8_t cmdSuccessful = port.read();      // 0 == fail, 1 == good
   const uint8_t destcaninchannel = port.read();   // the input channel that requested the data value
 

--- a/test/test_secondary_can/main.cpp
+++ b/test/test_secondary_can/main.cpp
@@ -1,0 +1,71 @@
+#include "../test_harness_device.h"
+#include "../test_harness_native.h"
+#include "../test_utils.h"
+#include "globals.h"
+
+extern bool processSecondaryCanReply(Stream &port);
+
+class reply_stream_t : public Stream
+{
+public:
+    uint8_t data[10] = {1, 0, 0, 0, 0, 0, 0, 0, 0x34, 0x12};
+    uint8_t cursor = 0;
+    uint8_t received = 0;
+    uint8_t emptyReads = 0;
+    int available(void) override { return received - cursor; }
+    int peek(void) override { return available() ? data[cursor] : -1; }
+    int read(void) override { if (available()) { return data[cursor++]; } ++emptyReads; return -1; }
+    void flush(void) override {}
+    size_t write(uint8_t) override { return 1; }
+};
+
+static void test_fragmented_success(void)
+{
+    reply_stream_t port;
+    configPage9.caninput_source_start_byte[0] = 6;
+    configPage9.caninput_source_num_bytes = 1;
+    currentStatus.canin[0] = 42;
+    for (uint8_t n = 0; n < 10; ++n)
+    {
+        port.received = n;
+        TEST_ASSERT_FALSE(processSecondaryCanReply(port));
+        TEST_ASSERT_EQUAL_UINT8(0, port.cursor);
+        TEST_ASSERT_EQUAL_UINT16(42, currentStatus.canin[0]);
+    }
+    port.received = 10;
+    TEST_ASSERT_TRUE(processSecondaryCanReply(port));
+    TEST_ASSERT_EQUAL_UINT16(0x1234, currentStatus.canin[0]);
+    TEST_ASSERT_EQUAL_UINT8(10, port.cursor);
+    TEST_ASSERT_EQUAL_UINT8(0, port.emptyReads);
+}
+
+static void test_short_failure(void)
+{
+    reply_stream_t port;
+    port.data[0] = 0;
+    port.received = 1;
+    TEST_ASSERT_FALSE(processSecondaryCanReply(port));
+    port.received = 2;
+    TEST_ASSERT_TRUE(processSecondaryCanReply(port));
+    TEST_ASSERT_EQUAL_UINT8(2, port.cursor);
+    TEST_ASSERT_EQUAL_UINT8(0, port.emptyReads);
+}
+
+static void test_invalid_channel_consumes_reply(void)
+{
+    reply_stream_t port;
+    port.data[1] = 255;
+    port.received = 10;
+    currentStatus.canin[0] = 42;
+    TEST_ASSERT_TRUE(processSecondaryCanReply(port));
+    TEST_ASSERT_EQUAL_UINT8(10, port.cursor);
+    TEST_ASSERT_EQUAL_UINT16(42, currentStatus.canin[0]);
+}
+
+void runAllTests(void)
+{
+    RUN_TEST_P(test_fragmented_success);
+    RUN_TEST_P(test_short_failure);
+    RUN_TEST_P(test_invalid_channel_consumes_reply);
+}
+TEST_HARNESS(runAllTests)

--- a/test/test_secondary_can/main.cpp
+++ b/test/test_secondary_can/main.cpp
@@ -2,13 +2,22 @@
 #include "../test_harness_native.h"
 #include "../test_utils.h"
 #include "globals.h"
+#include "comms.h"
+#include "comms_legacy.h"
+#include "comms_secondary.h"
 
 extern bool processSecondaryCanReply(Stream &port);
 
-class reply_stream_t : public Stream
+#if defined(NATIVE_BOARD)
+using reply_stream_base_t = SECONDARY_SERIAL_T;
+#else
+using reply_stream_base_t = Stream;
+#endif
+
+class reply_stream_t : public reply_stream_base_t
 {
 public:
-    uint8_t data[10] = {1, 0, 0, 0, 0, 0, 0, 0, 0x34, 0x12};
+    uint8_t data[22] = {1, 0, 0, 0, 0, 0, 0, 0, 0x34, 0x12};
     uint8_t cursor = 0;
     uint8_t received = 0;
     uint8_t emptyReads = 0;
@@ -62,10 +71,71 @@ static void test_invalid_channel_consumes_reply(void)
     TEST_ASSERT_EQUAL_UINT16(42, currentStatus.canin[0]);
 }
 
+static void test_single_byte_and_last_byte(void)
+{
+    for (uint8_t twoBytes = 0; twoBytes < 2; ++twoBytes)
+    {
+        reply_stream_t port;
+        port.received = 10;
+        configPage9.caninput_source_num_bytes = twoBytes;
+        configPage9.caninput_source_start_byte[0] = 7;
+        TEST_ASSERT_TRUE(processSecondaryCanReply(port));
+        TEST_ASSERT_EQUAL_UINT16(0x12, currentStatus.canin[0]);
+        TEST_ASSERT_EQUAL_UINT8(0, port.emptyReads);
+    }
+}
+
+#if defined(NATIVE_BOARD)
+static void pump_secondary(reply_stream_t &port)
+{
+    SECONDARY_SERIAL_T *previousPort = pSecondarySerial;
+    const uint8_t previousProtocol = configPage9.secondarySerialProtocol;
+    pSecondarySerial = &port;
+    configPage9.secondarySerialProtocol = SECONDARY_SERIAL_PROTO_CAN;
+    secondserial_Command();
+    pSecondarySerial = previousPort;
+    configPage9.secondarySerialProtocol = previousProtocol;
+}
+
+static void test_dispatch_fragmented_and_consecutive_replies(void)
+{
+    reply_stream_t port;
+    for (uint8_t i = 10; i > 0; --i) { port.data[i] = port.data[i - 1]; }
+    port.data[0] = 'G';
+    port.data[11] = 'G'; port.data[12] = 0; port.data[13] = 0;
+    configPage9.caninput_source_num_bytes = 1;
+    configPage9.caninput_source_start_byte[0] = 6;
+    currentStatus.canin[0] = 42;
+    serialSecondaryStatusFlag = SERIAL_INACTIVE;
+    for (uint8_t n = 1; n < 11; ++n)
+    {
+        port.received = n;
+        pump_secondary(port);
+        TEST_ASSERT_EQUAL(SERIAL_COMMAND_INPROGRESS_LEGACY, serialSecondaryStatusFlag);
+        TEST_ASSERT_EQUAL_UINT8(1, port.cursor);
+        TEST_ASSERT_EQUAL_UINT16(42, currentStatus.canin[0]);
+    }
+    port.received = 11;
+    pump_secondary(port);
+    TEST_ASSERT_EQUAL(SERIAL_INACTIVE, serialSecondaryStatusFlag);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, currentStatus.canin[0]);
+    port.received = 14;
+    pump_secondary(port);
+    TEST_ASSERT_EQUAL(SERIAL_INACTIVE, serialSecondaryStatusFlag);
+    TEST_ASSERT_EQUAL_UINT8(14, port.cursor);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, currentStatus.canin[0]);
+    TEST_ASSERT_EQUAL_UINT8(0, port.emptyReads);
+}
+#endif
+
 void runAllTests(void)
 {
     RUN_TEST_P(test_fragmented_success);
     RUN_TEST_P(test_short_failure);
     RUN_TEST_P(test_invalid_channel_consumes_reply);
+    RUN_TEST_P(test_single_byte_and_last_byte);
+#if defined(NATIVE_BOARD)
+    RUN_TEST_P(test_dispatch_fragmented_and_consecutive_replies);
+#endif
 }
 TEST_HARNESS(runAllTests)


### PR DESCRIPTION
The G reply handler waited for nine bytes but read ten on success, and also waited for nine bytes for a two-byte failure. Inspect the buffered success flag without consuming a partial reply, then process only a complete two-byte failure or ten-byte success. The serial state returns to inactive only after a reply is consumed. Invalid channel replies still consume their data without writing a channel.

The helper takes Stream by reference so the real parser can be exercised with fragmented input; no new persistent parser buffer/state is added.

Read the buffered length once, before peeking, and evaluate the readiness predicates from that snapshot. This avoids repeated virtual available() calls while preserving the nonblocking two-byte/ten-byte framing decisions.

Fixes #1620

### Validation
- 5 native 4x4 regression tests pass: every successful-reply fragmentation boundary, partial/complete failure replies, invalid channel consumption, single-byte/last-byte values, and actual secondserial_Command dispatch of fragmented and consecutive success/failure replies.
- No empty read or premature channel update in the fragmented success test.
- Final Mega2560 build passed after taking one availability snapshot: RAM 6352 bytes (unchanged); flash 187720 bytes versus 187692 at cc9eb445 (+28 bytes). The prior two-read version measured 187420 bytes; the changed compiler output costs 300 bytes relative to that version.
- Physical CAN-interface hardware was not used; existing encoding and invalid-start-byte behavior are retained.
- All 5 tests passed again in native_code_coverage (4x4). Local gcov confirmed that all logical branches of processSecondaryCanReply were exercised; the earlier partial-line report included unexecuted C++ exception edges from Stream calls. The readiness predicates now operate on captured values; no synthetic exception tests or reduced coverage thresholds were added.

### Commit structure
- Comms: wait for complete success or failure CAN replies
- Tests: cover fragmented CAN replies and invalid channels
- Tests: cover CAN reply dispatch state and consecutive messages
- Comms: evaluate CAN reply readiness from one buffered-length snapshot
