### PR TITLE
Comms: validate receive frames, command bodies and calibration bounds

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -488,6 +488,25 @@ static void processTemperatureCalibrationTableUpdate(uint16_t calibrationLength,
 // ====================================== End Internal Functions =============================
 
 
+static void processReceivedFrame(uint32_t incomingCrc)
+{
+  if ((serialPayloadLength == 0U) || (serialPayloadLength > _countof(serialPayload)))
+  {
+    sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
+  }
+  else if (incomingCrc == CRC32_serial.crc32(serialPayload, serialPayloadLength))
+  {
+    //CRC is correct. Process the command
+    processSerialCommand();
+    currentStatus.allowLegacyComms = false; //Lock out legacy commands until next power cycle
+  }
+  else {
+    //CRC Error. Need to send an error message
+    sendReturnCodeMsg(SERIAL_RC_CRC_ERR);
+    flushRXbuffer();
+  }
+}
+
 /** Processes the incoming data on the serial buffer based on the command sent.
 Can be either data for a new command or a continuation of data for command that is already in progress:
 
@@ -554,21 +573,7 @@ void serialReceive(void)
 
       if (!isRxTimeout()) // CRC read can timeout also!
       {
-        if ((serialPayloadLength == 0U) || (serialPayloadLength > _countof(serialPayload)))
-        {
-          sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
-        }
-        else if (incomingCrc == CRC32_serial.crc32(serialPayload, serialPayloadLength))
-        {
-          //CRC is correct. Process the command
-          processSerialCommand();
-          currentStatus.allowLegacyComms = false; //Lock out legacy commands until next power cycle
-        }
-        else {
-          //CRC Error. Need to send an error message
-          sendReturnCodeMsg(SERIAL_RC_CRC_ERR);
-          flushRXbuffer();
-        }
+        processReceivedFrame(incomingCrc);
       }
       // else timeout - code below will kick in.
     }
@@ -633,6 +638,23 @@ static uint8_t minimumCommandLength(byte command)
     default: return 1U;
   }
 }
+
+#ifdef COMMS_SD
+static uint8_t minimumSdWriteLength(uint8_t command, uint16_t arg1, uint16_t arg2)
+{
+  if (command == SD_RTC_PAGE)
+  {
+    return ((arg1 == SD_RTC_WRITE_ARG1) && (arg2 == SD_RTC_WRITE_ARG2)) ? 15U : 7U;
+  }
+  if (command != SD_READWRITE_PAGE) { return 7U; }
+  if ((arg1 == SD_WRITE_DO_ARG1) && (arg2 == SD_WRITE_DO_ARG2)) { return 8U; }
+  if ((arg1 == SD_WRITE_DIR_ARG1) && (arg2 == SD_WRITE_DIR_ARG2)) { return 9U; }
+  if ((arg1 == SD_WRITE_READ_SEC_ARG1) && (arg2 == SD_WRITE_READ_SEC_ARG2)) { return 11U; }
+  if ((arg1 == SD_ERASEFILE_ARG1) && (arg2 == SD_ERASEFILE_ARG2)) { return 11U; }
+  if ((arg1 == SD_WRITE_COMP_ARG1) && (arg2 == SD_WRITE_COMP_ARG2)) { return 15U; }
+  return 7U;
+}
+#endif
 
 void processSerialCommand(void)
 {
@@ -1022,11 +1044,15 @@ void processSerialCommand(void)
       uint8_t cmd = serialPayload[2];
       uint16_t SD_arg1 = word(serialPayload[3], serialPayload[4]);
       uint16_t SD_arg2 = word(serialPayload[5], serialPayload[6]);
+      if (serialPayloadLength < minimumSdWriteLength(cmd, SD_arg1, SD_arg2))
+      {
+        sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
+        break;
+      }
       if(cmd == SD_READWRITE_PAGE)
         { 
           if((SD_arg1 == SD_WRITE_DO_ARG1) && (SD_arg2 == SD_WRITE_DO_ARG2))
           {
-            if (serialPayloadLength < 8U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             /*
             SD DO command. Single byte of data where the commands are:
             0 Reset
@@ -1046,7 +1072,6 @@ void processSerialCommand(void)
           }
           else if((SD_arg1 == SD_WRITE_DIR_ARG1) && (SD_arg2 == SD_WRITE_DIR_ARG2))
           {
-            if (serialPayloadLength < 9U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Begin SD directory read. Value in payload represents the directory chunk to read
             //Directory chunks are each 16 files long
             SDcurrentDirChunk = word(serialPayload[7], serialPayload[8]);
@@ -1054,7 +1079,6 @@ void processSerialCommand(void)
           }
           else if((SD_arg1 == SD_WRITE_READ_SEC_ARG1) && (SD_arg2 == SD_WRITE_READ_SEC_ARG2))
           {
-            if (serialPayloadLength < 11U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Read sector Init? Unsure what this is meant to do however it is sent at the beginning of a Card Format request and requires an OK response
             //Provided the sector being requested is x0 x0 x0 x0, we treat this as a SD Card format request
             if( (serialPayload[7] == 0) && (serialPayload[8] == 0) && (serialPayload[9] == 0) && (serialPayload[10] == 0) )
@@ -1070,7 +1094,6 @@ void processSerialCommand(void)
           }
           else if((SD_arg1 == SD_ERASEFILE_ARG1) && (SD_arg2 == SD_ERASEFILE_ARG2))
           {
-            if (serialPayloadLength < 11U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Erase file command
             //We just need the 4 ASCII characters of the file name
             char log1 = serialPayload[7];
@@ -1109,7 +1132,6 @@ void processSerialCommand(void)
           }
           else if((SD_arg1 == SD_WRITE_COMP_ARG1) && (SD_arg2 == SD_WRITE_COMP_ARG2))
           {
-            if (serialPayloadLength < 15U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Prepare to read a 2024 byte chunk of data from the SD card
             uint8_t sector1 = serialPayload[7];
             uint8_t sector2 = serialPayload[8];
@@ -1137,7 +1159,6 @@ void processSerialCommand(void)
           //Used for setting RTC settings
           if((SD_arg1 == SD_RTC_WRITE_ARG1) && (SD_arg2 == SD_RTC_WRITE_ARG2))
           {
-            if (serialPayloadLength < 15U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Set the RTC date/time
             byte second = serialPayload[7];
             byte minute = serialPayload[8];

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -541,7 +541,10 @@ void serialReceive(void)
   {
     if (serialBytesRxTx < serialPayloadLength )
     {
-      serialPayload[serialBytesRxTx] = (byte)primarySerial.read();
+      const byte received = (byte)primarySerial.read();
+      // Drain an oversized frame without writing outside the payload buffer.
+      // Keeping its declared length preserves framing across receive calls.
+      if (serialPayloadLength <= _countof(serialPayload)) { serialPayload[serialBytesRxTx] = received; }
       ++serialBytesRxTx;
     }
     else
@@ -551,7 +554,11 @@ void serialReceive(void)
 
       if (!isRxTimeout()) // CRC read can timeout also!
       {
-        if (incomingCrc == CRC32_serial.crc32(serialPayload, serialPayloadLength))
+        if ((serialPayloadLength == 0U) || (serialPayloadLength > _countof(serialPayload)))
+        {
+          sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
+        }
+        else if (incomingCrc == CRC32_serial.crc32(serialPayload, serialPayloadLength))
         {
           //CRC is correct. Process the command
           processSerialCommand();

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -623,8 +623,24 @@ static void burnSinglePage(uint8_t page)
   }
 }
 
+// Minimum header size, including the command byte. Check before reading fields.
+static uint8_t minimumCommandLength(byte command)
+{
+  switch (command)
+  {
+    case 'b': case 'B': case 'd': case 'E': case 'k': return 3U;
+    case 'M': case 'p': case 'r': case 't': case 'w': return 7U;
+    default: return 1U;
+  }
+}
+
 void processSerialCommand(void)
 {
+  if ((serialPayloadLength == 0U) || (serialPayloadLength < minimumCommandLength(serialPayload[0])))
+  {
+    sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
+    return;
+  }
   switch (serialPayload[0])
   {
 
@@ -723,7 +739,9 @@ void processSerialCommand(void)
       //2 - offset
       //2 - Length
       //1 - 1st New value
-      if (updatePageValues(serialPayload[2], word(serialPayload[4], serialPayload[3]), &serialPayload[7], word(serialPayload[6], serialPayload[5])))
+      const uint16_t length = word(serialPayload[6], serialPayload[5]);
+      if ((length <= (serialPayloadLength - 7U)) &&
+          updatePageValues(serialPayload[2], word(serialPayload[4], serialPayload[3]), &serialPayload[7], length))
       {
         sendReturnCodeMsg(SERIAL_RC_OK);    
       }
@@ -995,6 +1013,7 @@ void processSerialCommand(void)
         { 
           if((SD_arg1 == SD_WRITE_DO_ARG1) && (SD_arg2 == SD_WRITE_DO_ARG2))
           {
+            if (serialPayloadLength < 8U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             /*
             SD DO command. Single byte of data where the commands are:
             0 Reset
@@ -1014,6 +1033,7 @@ void processSerialCommand(void)
           }
           else if((SD_arg1 == SD_WRITE_DIR_ARG1) && (SD_arg2 == SD_WRITE_DIR_ARG2))
           {
+            if (serialPayloadLength < 9U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Begin SD directory read. Value in payload represents the directory chunk to read
             //Directory chunks are each 16 files long
             SDcurrentDirChunk = word(serialPayload[7], serialPayload[8]);
@@ -1021,6 +1041,7 @@ void processSerialCommand(void)
           }
           else if((SD_arg1 == SD_WRITE_READ_SEC_ARG1) && (SD_arg2 == SD_WRITE_READ_SEC_ARG2))
           {
+            if (serialPayloadLength < 11U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Read sector Init? Unsure what this is meant to do however it is sent at the beginning of a Card Format request and requires an OK response
             //Provided the sector being requested is x0 x0 x0 x0, we treat this as a SD Card format request
             if( (serialPayload[7] == 0) && (serialPayload[8] == 0) && (serialPayload[9] == 0) && (serialPayload[10] == 0) )
@@ -1036,6 +1057,7 @@ void processSerialCommand(void)
           }
           else if((SD_arg1 == SD_ERASEFILE_ARG1) && (SD_arg2 == SD_ERASEFILE_ARG2))
           {
+            if (serialPayloadLength < 11U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Erase file command
             //We just need the 4 ASCII characters of the file name
             char log1 = serialPayload[7];
@@ -1074,6 +1096,7 @@ void processSerialCommand(void)
           }
           else if((SD_arg1 == SD_WRITE_COMP_ARG1) && (SD_arg2 == SD_WRITE_COMP_ARG2))
           {
+            if (serialPayloadLength < 15U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Prepare to read a 2024 byte chunk of data from the SD card
             uint8_t sector1 = serialPayload[7];
             uint8_t sector2 = serialPayload[8];
@@ -1101,6 +1124,7 @@ void processSerialCommand(void)
           //Used for setting RTC settings
           if((SD_arg1 == SD_RTC_WRITE_ARG1) && (SD_arg2 == SD_RTC_WRITE_ARG2))
           {
+            if (serialPayloadLength < 15U) { sendReturnCodeMsg(SERIAL_RC_RANGE_ERR); break; }
             //Set the RTC date/time
             byte second = serialPayload[7];
             byte minute = serialPayload[8];

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -964,8 +964,21 @@ void processSerialCommand(void)
       uint16_t offset = word(serialPayload[3], serialPayload[4]);
       uint16_t calibrationLength = word(serialPayload[5], serialPayload[6]); // Should be 256
 
+      // Validate source bytes before either calibration path can alter tables/storage.
+      if (calibrationLength > (serialPayloadLength - 7U))
+      {
+        sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
+        break;
+      }
       if(cmd == SensorCalibrationTable::O2Sensor)
       {
+        // TS sends a 1024-byte calibration domain in chunks. Widen before adding
+        // because uint16_t arithmetic wraps on AVR.
+        if ((calibrationLength == 0U) || (addWithoutOverflow(offset, calibrationLength) > 1024U))
+        {
+          sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
+          break;
+        }
         loadO2CalibrationChunk(offset, calibrationLength);
         sendReturnCodeMsg(SERIAL_RC_OK);
         primarySerial.flush(); //This is safe because engine is assumed to not be running during calibration

--- a/test/test_serial_receive/main.cpp
+++ b/test/test_serial_receive/main.cpp
@@ -1,0 +1,152 @@
+#include "../test_harness_device.h"
+#include "../test_harness_native.h"
+#include "../test_utils.h"
+#include "globals.h"
+#include "comms.h"
+#include "comms_legacy.h"
+#include "pages.h"
+#include "sensors.h"
+
+#if defined(NATIVE_BOARD)
+#include <vector>
+#include <FastCRC.h>
+
+class packet_stream_t : public Stream
+{
+public:
+    std::vector<uint8_t> input;
+    std::vector<uint8_t> output;
+    size_t cursor = 0;
+    size_t received = 0;
+    int available(void) override { return received - cursor; }
+    int availableForWrite(void) override { return 4096; }
+    int peek(void) override { return available() ? input[cursor] : -1; }
+    int read(void) override { return available() ? input[cursor++] : -1; }
+    void flush(void) override {}
+    size_t write(uint8_t value) override { output.push_back(value); return 1; }
+    void frame(std::vector<uint8_t> payload)
+    {
+        input.clear(); output.clear(); cursor = 0;
+        input.push_back(payload.size() >> 8);
+        input.push_back(payload.size());
+        input.insert(input.end(), payload.begin(), payload.end());
+        FastCRC32 crc;
+        uint8_t empty = 0;
+        uint32_t checksum = crc.crc32(payload.empty() ? &empty : payload.data(), payload.size());
+        for (int8_t shift = 24; shift >= 0; shift -= 8) { input.push_back(checksum >> shift); }
+        received = input.size();
+    }
+    void pump(void)
+    {
+        pPrimarySerial = this;
+        currentStatus.allowLegacyComms = false;
+        serialReceive();
+        pPrimarySerial = &Serial;
+    }
+    void expect(uint8_t code)
+    {
+        TEST_ASSERT_TRUE(output.size() >= 3);
+        TEST_ASSERT_EQUAL_UINT8(code, output[2]);
+        TEST_ASSERT_EQUAL(SERIAL_INACTIVE, serialStatusFlag);
+    }
+};
+
+static void test_empty_frame(void)
+{
+    packet_stream_t port;
+    port.frame({}); port.pump(); port.expect(0x84);
+}
+
+static void test_capacity_boundary(void)
+{
+    packet_stream_t port;
+    std::vector<uint8_t> payload(TS_SERIAL_BUFFER_SIZE, 0);
+    payload[0] = 'C';
+    port.frame(payload); port.pump(); port.expect(0);
+    payload.push_back(0);
+    port.frame(payload); port.pump(); port.expect(0x84);
+    port.frame({'C'}); port.pump(); port.expect(0);
+}
+
+static void test_fragmented_oversized_frame(void)
+{
+    packet_stream_t port;
+    port.frame(std::vector<uint8_t>(TS_SERIAL_BUFFER_SIZE + 1, 0xFF));
+    port.received = 66;
+    port.pump();
+    TEST_ASSERT_TRUE(port.output.empty());
+    TEST_ASSERT_EQUAL(SERIAL_RECEIVE_INPROGRESS, serialStatusFlag);
+    port.received = port.input.size();
+    port.pump(); port.expect(0x84);
+    port.frame({'C'}); port.pump(); port.expect(0);
+}
+
+static void test_short_command_headers(void)
+{
+    packet_stream_t port;
+    const char commands[] = {'b', 'B', 'd', 'E', 'k', 'M', 'p', 'r', 't', 'w'};
+    for (char command : commands)
+    {
+        port.frame({static_cast<uint8_t>(command)});
+        port.pump(); port.expect(0x84);
+    }
+}
+
+static void test_page_write_requires_received_bytes(void)
+{
+    packet_stream_t port;
+    const uint8_t previous = getPageValue(veSetPage, 0);
+    port.frame({'M', 0, veSetPage, 0, 0, 2, 0, 0x5A});
+    port.pump(); port.expect(0x84);
+    TEST_ASSERT_EQUAL_UINT8(previous, getPageValue(veSetPage, 0));
+    port.frame({'M', 0, veSetPage, 0, 0, 1, 0, 0x5A});
+    port.pump(); port.expect(0);
+    TEST_ASSERT_EQUAL_UINT8(0x5A, getPageValue(veSetPage, 0));
+    setPageValue(veSetPage, 0, previous);
+}
+
+static void test_calibration_bounds(void)
+{
+    packet_stream_t port;
+    const uint8_t previous = o2CalibrationTable.values[0];
+    port.frame({'t', 0, 2, 4, 0, 0, 1, 0x55}); // offset 1024, length 1
+    port.pump(); port.expect(0x84);
+    port.frame({'t', 0, 2, 3, 255, 0, 2, 0x55, 0x55}); // crosses 1024
+    port.pump(); port.expect(0x84);
+    port.frame({'t', 0, 2, 0, 0, 0, 32}); // absent body
+    port.pump(); port.expect(0x84);
+    port.frame({'t', 0, 0, 0, 0, 0, 64}); // truncated CLT calibration
+    port.pump(); port.expect(0x84);
+    TEST_ASSERT_EQUAL_UINT8(previous, o2CalibrationTable.values[0]);
+}
+
+static void test_valid_first_calibration_chunk(void)
+{
+    packet_stream_t port;
+    std::vector<uint8_t> payload(263, 0x55);
+    payload[0] = 't'; payload[1] = 0; payload[2] = 2;
+    payload[3] = 0; payload[4] = 0; payload[5] = 1; payload[6] = 0;
+    port.frame(payload); port.pump(); port.expect(0);
+    for (uint8_t i = 0; i < 8; ++i)
+    {
+        TEST_ASSERT_EQUAL_UINT8(0x55, o2CalibrationTable.values[i]);
+        TEST_ASSERT_EQUAL_UINT16(i * 32U, o2CalibrationTable.axis[i]);
+    }
+}
+#endif
+
+void runAllTests(void)
+{
+#if defined(NATIVE_BOARD)
+    RUN_TEST_P(test_empty_frame);
+    RUN_TEST_P(test_capacity_boundary);
+    RUN_TEST_P(test_fragmented_oversized_frame);
+    RUN_TEST_P(test_short_command_headers);
+    RUN_TEST_P(test_page_write_requires_received_bytes);
+    RUN_TEST_P(test_calibration_bounds);
+    RUN_TEST_P(test_valid_first_calibration_chunk);
+#else
+    TEST_IGNORE_MESSAGE("Packet buffers are host-only; firmware is built by the board matrix.");
+#endif
+}
+TEST_HARNESS(runAllTests)

--- a/test/test_serial_receive/main.cpp
+++ b/test/test_serial_receive/main.cpp
@@ -161,6 +161,11 @@ static void test_valid_first_calibration_chunk(void)
         TEST_ASSERT_EQUAL_UINT16(i * 32U, o2CalibrationTable.axis[i]);
     }
 }
+#else
+static void test_serial_receive_requires_native(void)
+{
+    TEST_IGNORE_MESSAGE("Packet buffers are host-only; firmware is built by the board matrix.");
+}
 #endif
 
 void runAllTests(void)
@@ -176,7 +181,7 @@ void runAllTests(void)
     RUN_TEST_P(test_calibration_bounds);
     RUN_TEST_P(test_valid_first_calibration_chunk);
 #else
-    TEST_IGNORE_MESSAGE("Packet buffers are host-only; firmware is built by the board matrix.");
+    RUN_TEST_P(test_serial_receive_requires_native);
 #endif
 }
 TEST_HARNESS(runAllTests)

--- a/test/test_serial_receive/main.cpp
+++ b/test/test_serial_receive/main.cpp
@@ -11,6 +11,8 @@
 #include <vector>
 #include <FastCRC.h>
 
+extern uint32_t serialReceiveStartTime;
+
 class packet_stream_t : public Stream
 {
 public:
@@ -81,6 +83,30 @@ static void test_fragmented_oversized_frame(void)
     port.frame({'C'}); port.pump(); port.expect(0);
 }
 
+static void test_bad_crc_does_not_write_and_recovers(void)
+{
+    packet_stream_t port;
+    const uint8_t previous = getPageValue(veSetPage, 0);
+    port.frame({'M', 0, veSetPage, 0, 0, 1, 0, static_cast<uint8_t>(previous ^ 0xFF)});
+    port.input.back() ^= 1U;
+    port.pump(); port.expect(0x82);
+    TEST_ASSERT_EQUAL_UINT8(previous, getPageValue(veSetPage, 0));
+    port.frame({'C'}); port.pump(); port.expect(0);
+}
+
+static void test_oversized_frame_timeout_recovers(void)
+{
+    packet_stream_t port;
+    port.frame(std::vector<uint8_t>(TS_SERIAL_BUFFER_SIZE + 1, 0xFF));
+    port.received = 66;
+    port.pump();
+    TEST_ASSERT_EQUAL(SERIAL_RECEIVE_INPROGRESS, serialStatusFlag);
+    // Expire the existing 400 ms receive timeout without a wall-clock sleep.
+    serialReceiveStartTime = millis() - 401U;
+    port.pump(); port.expect(0x80);
+    port.frame({'C'}); port.pump(); port.expect(0);
+}
+
 static void test_short_command_headers(void)
 {
     packet_stream_t port;
@@ -113,6 +139,8 @@ static void test_calibration_bounds(void)
     port.pump(); port.expect(0x84);
     port.frame({'t', 0, 2, 3, 255, 0, 2, 0x55, 0x55}); // crosses 1024
     port.pump(); port.expect(0x84);
+    port.frame({'t', 0, 2, 0, 0, 0, 0}); // empty calibration chunk
+    port.pump(); port.expect(0x84);
     port.frame({'t', 0, 2, 0, 0, 0, 32}); // absent body
     port.pump(); port.expect(0x84);
     port.frame({'t', 0, 0, 0, 0, 0, 64}); // truncated CLT calibration
@@ -141,6 +169,8 @@ void runAllTests(void)
     RUN_TEST_P(test_empty_frame);
     RUN_TEST_P(test_capacity_boundary);
     RUN_TEST_P(test_fragmented_oversized_frame);
+    RUN_TEST_P(test_bad_crc_does_not_write_and_recovers);
+    RUN_TEST_P(test_oversized_frame_timeout_recovers);
     RUN_TEST_P(test_short_command_headers);
     RUN_TEST_P(test_page_write_requires_received_bytes);
     RUN_TEST_P(test_calibration_bounds);


### PR DESCRIPTION
A declared frame length can exceed serialPayload before CRC checking. Separately, a CRC-valid short command can access stale header/body bytes, and an O2 calibration offset can exceed the table. Address all three boundaries in the receive path.

- Drain oversized payloads without storing them or calculating a CRC over unavailable buffer memory; reject zero-length frames. Preserve the existing receive timeout and consume the declared frame across ordinary fragmented reads.
- Require command headers and enough received bytes for page writes and SD/RTC write variants.
- Validate calibration body lengths and the 1024-byte O2 domain before mutating a table or storage.
- Add host-only framed-stream regression tests using real CRCs and serialReceive, including valid page writes and the first valid 256-byte O2 chunk.

The payload buffer size and persistent RAM allocation are unchanged. Valid command encodings and existing calibration CRC/storage behavior are retained; this does not add a new calibration chunk-order protocol or change the legacy parser.

Refs #1619

### Validation
- 9 end-to-end tests pass in native_base, 4x4, Windows GCC with -O1 and -Wa,-mbig-obj. Cases cover zero/exact/oversized frames, fragmented oversized input followed by a valid command, short headers, incomplete/valid M writes, invalid calibration ranges and a valid first chunk.
- Final Mega2560 build passed: RAM 6352 B (+0 B), flash 187538 B (-154 B) versus baseline cc9eb445 with the same toolchain.
- Teensy 4.1 build passed with RTC_ENABLED and SD_LOGGING enabled, compiling the SD/RTC length checks. Actual SD/RTC hardware operations remain untested.
- Follow-up commit extracts frame validation and SD/RTC minimum-length selection to keep nesting shallow; the native regression tests still pass.
- Host tests deliberately keep dynamically allocated packet buffers out of device test builds.
- Follow-up regression cases verify that a corrupted CRC cannot mutate the tune, oversized receive timeout returns TIMEOUT and accepts the next valid frame, and an empty calibration chunk is rejected. All 9 cases passed in native 4x4; this follow-up changes tests only.
- AVR test-build follow-up: move the host-only skip into its own RUN_TEST_P case. UnityIgnore uses longjmp and therefore requires UnityDefaultTestRun to initialize the abort frame. Calling it directly from runAllTests could jump through an uninitialized frame on devices/simavr. The corrected Mega2560 test firmware compiled successfully with upload and execution explicitly disabled; actual simulator execution is delegated to PR CI.

### Commit structure
- Comms: drain invalid-size frames without overflowing the receive buffer
- Comms: validate command headers and received write data
- Comms: bound calibration source bytes and O2 table offsets
- Tests: exercise framed serial validation and valid writes
- Comms: keep frame and SD write validation outside nested dispatch
- Tests: cover CRC rejection and oversized receive timeout recovery
- Tests: skip host-only serial cases inside a valid Unity test frame
