### PR TITLE
CAN: validate auxiliary input width against received frame length

### DIFF
--- a/speeduino/can_input.h
+++ b/speeduino/can_input.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <stdint.h>
+
+/** @brief Decode an auxiliary value only when all its bytes were received.
+ * @param data Classic CAN payload storage.
+ * @param length Number of received data bytes.
+ * @param start First byte of the configured value.
+ * @param twoBytes Whether the configured value is two bytes wide.
+ * @param littleEndian Whether a two-byte value is little-endian.
+ * @param value Updated on success; unchanged on invalid input.
+ * @return Whether a complete value was available.
+ */
+static inline bool readCanInputValue(const uint8_t (&data)[8], uint8_t length,
+                                    uint8_t start, bool twoBytes, bool littleEndian,
+                                    uint16_t &value)
+{
+    if ((length > sizeof(data)) || (start >= length) ||
+        (twoBytes && (static_cast<uint16_t>(start) + 1U >= length)))
+    {
+        return false;
+    }
+    uint16_t decoded = data[start];
+    if (twoBytes)
+    {
+        const uint16_t next = data[start + 1U];
+        decoded = littleEndian ? decoded | (next << 8U) : (decoded << 8U) | next;
+    }
+    value = decoded;
+    return true;
+}

--- a/speeduino/comms_CAN.cpp
+++ b/speeduino/comms_CAN.cpp
@@ -11,6 +11,7 @@ This is for handling the data broadcasted to various CAN dashes and instrument c
 
 #if defined(NATIVE_CAN_AVAILABLE)
 #include "comms_CAN.h"
+#include "can_input.h"
 #include "maths.h"
 #include "units.h"
 #include "src/controllers/progammableIO/programmableIOControl.h"
@@ -790,25 +791,11 @@ void readAuxCanBus()
     if (inMsg.id == channelAddress ) //Filters frame ID
     {
 
-      if (!BIT_CHECK(configPage9.caninput_source_num_bytes, i))
-      {
-        // Gets the one-byte value from the Data Field.
-        currentStatus.canin[i] = inMsg.buf[configPage9.caninput_source_start_byte[i]];
-      }
-      else if (configPage9.caninput_source_start_byte[i] < (_countof(inMsg.buf) - 1U)) // a 2-byte value can't start at the last byte of the CAN payload
-      {
-        if (configPage9.caninputEndianess == 1)
-        {
-          //Gets the two-byte value from the Data Field in Litlle Endian.
-          currentStatus.canin[i] = ((inMsg.buf[configPage9.caninput_source_start_byte[i]]) | (inMsg.buf[configPage9.caninput_source_start_byte[i] + 1] << 8));
-        }
-        else
-        {
-          //Gets the two-byte value from the Data Field in Big Endian.
-          currentStatus.canin[i] = ((inMsg.buf[configPage9.caninput_source_start_byte[i]] << 8) | (inMsg.buf[configPage9.caninput_source_start_byte[i] + 1]));
-        }
-      }
-      else { /* Misconfigured: 2-byte value can't start at byte 7. Leave canin[i] unchanged. */ }
+      (void)readCanInputValue(inMsg.buf, inMsg.len,
+                              configPage9.caninput_source_start_byte[i],
+                              BIT_CHECK(configPage9.caninput_source_num_bytes, i),
+                              configPage9.caninputEndianess == 1,
+                              currentStatus.canin[i]);
     }
   } 
 }

--- a/test/test_can_input/main.cpp
+++ b/test/test_can_input/main.cpp
@@ -1,0 +1,41 @@
+#include "../test_harness_device.h"
+#include "../test_harness_native.h"
+#include "../test_utils.h"
+#include "can_input.h"
+
+static void test_lengths_and_indices(void)
+{
+    const uint8_t data[8] = {0x12, 0x34, 2, 3, 4, 5, 0x56, 0x78};
+    for (uint8_t length = 0; length <= 9; ++length)
+    {
+        for (uint16_t index = 0; index <= 255; ++index)
+        {
+            for (uint8_t width = 1; width <= 2; ++width)
+            {
+                uint16_t value = 0xABCD;
+                const bool valid = length <= 8 && index + width <= length;
+                TEST_ASSERT_EQUAL(valid, readCanInputValue(data, length, index, width == 2, true, value));
+                if (!valid) { TEST_ASSERT_EQUAL_UINT16(0xABCD, value); }
+            }
+        }
+    }
+}
+
+static void test_endianness_and_last_byte(void)
+{
+    const uint8_t data[8] = {0x12, 0x34, 2, 3, 4, 5, 0x56, 0x78};
+    uint16_t value = 0;
+    TEST_ASSERT_TRUE(readCanInputValue(data, 8, 6, true, true, value));
+    TEST_ASSERT_EQUAL_UINT16(0x7856, value);
+    TEST_ASSERT_TRUE(readCanInputValue(data, 8, 6, true, false, value));
+    TEST_ASSERT_EQUAL_UINT16(0x5678, value);
+    TEST_ASSERT_TRUE(readCanInputValue(data, 8, 7, false, false, value));
+    TEST_ASSERT_EQUAL_UINT16(0x78, value);
+}
+
+void runAllTests(void)
+{
+    RUN_TEST_P(test_lengths_and_indices);
+    RUN_TEST_P(test_endianness_and_last_byte);
+}
+TEST_HARNESS(runAllTests)


### PR DESCRIPTION
Auxiliary CAN decoding checked the physical eight-byte array only for two-byte values, but did not check the actual received length. A short frame could therefore replace a channel with unavailable trailing bytes. Extract a small inline decoder that validates both frame length and configured index before reading, and use it in readAuxCanBus. Invalid or incomplete input leaves the previous channel value unchanged.

The helper preserves byte order and one/two-byte semantics. It adds no persistent buffers or state. Other CAN protocol readers are not changed by this PR.

Fixes #1623

### Validation
- Native 4x4 tests pass: lengths 0..9, all 256 start indices and both widths (5120 combinations), plus endian and last-byte value checks.
- Teensy 4.1 firmware builds with the CAN implementation enabled. Reported occupied FLASH regions total 248828 bytes; RAM1 variables/code/padding total 266144 bytes and RAM2 variables 12416 bytes. These are occupied regions, not the free-byte values shown by the currently incorrect size-report parser (#1637).
- Hardware frame reception and STM32 integration remain for hardware/CI validation. Mega does not enable this native-CAN path.

### Commit structure
- CAN: decode auxiliary inputs only from received payload bytes
- Tests: cover CAN payload lengths, byte indices and endianness
