### PR TITLE
Protection: handle oil and AFR deadlines across millis rollover

### DIFF
--- a/speeduino/engineProtection.cpp
+++ b/speeduino/engineProtection.cpp
@@ -1,5 +1,6 @@
 #include "globals.h"
 #include "engineProtection.h"
+#include "elapsed_time.h"
 #include "maths.h"
 #include "units.h"
 #include "unit_testing.h"
@@ -9,12 +10,21 @@
 #include "preprocessor.h"
 
 TESTABLE_STATIC uint32_t oilProtEndTime;
+TESTABLE_STATIC bool oilProtTimerStarted = false;
 TESTABLE_CONSTEXPR table2D_u8_u8_4 oilPressureProtectTable(&configPage10.oilPressureProtRPM, &configPage10.oilPressureProtMins);
 TESTABLE_CONSTEXPR table2D_u8_u8_6 coolantProtectTable(&configPage9.coolantProtTemp, &configPage9.coolantProtRPM);
 
 /* AFR protection state moved to file scope so unit tests can control/reset it */
 TESTABLE_STATIC bool checkAFRLimitActive = false;
 TESTABLE_STATIC unsigned long afrProtectedActivateTime = 0;
+TESTABLE_STATIC bool afrProtTimerStarted = false;
+
+// Protection delays are much shorter than half the uint32_t counter period.
+// A future deadline has a large modular distance; an expired one a small distance.
+static inline bool protectionDeadlineReached(uint32_t now, uint32_t deadline)
+{
+  return timeElapsed(now, deadline) < UINT32_C(0x80000000);
+}
 
 TESTABLE_INLINE_STATIC bool checkOilPressureLimit(const statuses &current, const config6 &page6, const config10 &page10, uint32_t currMillis)
 {
@@ -28,13 +38,18 @@ TESTABLE_INLINE_STATIC bool checkOilPressureLimit(const statuses &current, const
     if(current.oilPressure < oilLimit)
     {
       //Check if this is the first time we've been below the limit
-      if(oilProtEndTime == 0U) { oilProtEndTime = currMillis + TIME_TEN_MILLIS.toUser(page10.oilPressureProtTime); }
+      if ((oilProtEndTime == 0U) && !oilProtTimerStarted)
+      {
+        oilProtEndTime = currMillis + TIME_TEN_MILLIS.toUser(page10.oilPressureProtTime);
+        oilProtTimerStarted = true;
+      }
       /* Check if countdown has reached its target, if so then instruct to cut */
-      engineProtectOil = (currMillis >= oilProtEndTime) || (current.engineProtect.oil);
+      engineProtectOil = protectionDeadlineReached(currMillis, oilProtEndTime) || (current.engineProtect.oil);
     }
     else 
     { 
       oilProtEndTime = 0; //Reset the timer
+      oilProtTimerStarted = false;
     }
   }
 
@@ -106,13 +121,14 @@ TESTABLE_INLINE_STATIC bool checkAFRLimit(const statuses &current, const config6
     if (isAfrLimitCondtionActive(current, page9))
     {
       // All conditions fulfilled - start counter for 'protection delay'
-      if(afrProtectedActivateTime==0U) 
+      if ((afrProtectedActivateTime == 0U) && !afrProtTimerStarted)
       {
         afrProtectedActivateTime = currMillis + TIME_TEN_MILLIS.toUser(page9.afrProtectCutTime);
+        afrProtTimerStarted = true;
       }
 
       // Check if countdown has reached its target, if so then instruct to cut
-      checkAFRLimitActive = currMillis >= afrProtectedActivateTime;
+      checkAFRLimitActive = checkAFRLimitActive || protectionDeadlineReached(currMillis, afrProtectedActivateTime);
     } 
     else 
     {
@@ -128,6 +144,7 @@ TESTABLE_INLINE_STATIC bool checkAFRLimit(const statuses &current, const config6
     {
       checkAFRLimitActive = false;
       afrProtectedActivateTime = 0U;
+      afrProtTimerStarted = false;
     }
   }
   else

--- a/test/test_engineprotect/main.cpp
+++ b/test/test_engineprotect/main.cpp
@@ -10,6 +10,8 @@
 extern bool checkOilPressureLimit(const statuses &current, const config6 &page6, const config10 &page10, uint32_t currMillis);
 extern table2D_u8_u8_4 oilPressureProtectTable;
 extern uint32_t oilProtEndTime;
+extern bool oilProtTimerStarted;
+extern bool afrProtTimerStarted;
 
 extern bool checkBoostLimit(const statuses &current, const config6 &page6);
 extern bool checkRpmLimit(const statuses &current, const config4 &page4, const config6 &page6, const config9 &page9);
@@ -68,6 +70,8 @@ extern uint16_t applyFlatShiftRevLimit(uint16_t curLimit, const statuses &curren
 static void resetInternalState(void)
 {
     oilProtEndTime = 0;
+    oilProtTimerStarted = false;
+    afrProtTimerStarted = false;
     checkAFRLimitActive = false;
     afrProtectedActivateTime = 0;
     softLimitTime = 0;
@@ -206,6 +210,34 @@ struct engineProtection_test_context_t
     }
 };
 
+static void test_protection_deadlines_wrap(void)
+{
+    const uint32_t starts[] = {UINT32_MAX - 49U, UINT32_MAX - 99U, 0U};
+    for (uint32_t start : starts)
+    {
+        engineProtection_test_context_t context;
+        context.setOilPressureActive();
+        context.page10.oilPressureProtTime = 1; // 100ms
+        TEST_ASSERT_FALSE(checkOilPressureLimit(context.current, context.page6, context.page10, start));
+        TEST_ASSERT_FALSE(checkOilPressureLimit(context.current, context.page6, context.page10, start + 99U));
+        TEST_ASSERT_TRUE(checkOilPressureLimit(context.current, context.page6, context.page10, start + 100U));
+        context.current.oilPressure = 255;
+        TEST_ASSERT_FALSE(checkOilPressureLimit(context.current, context.page6, context.page10, start + 101U));
+        TEST_ASSERT_FALSE(oilProtTimerStarted);
+
+        context.setAfrActive();
+        afrProtectedActivateTime = 0;
+        context.page9.afrProtectCutTime = 1;
+        TEST_ASSERT_FALSE(checkAFRLimit(context.current, context.page6, context.page9, start));
+        TEST_ASSERT_FALSE(checkAFRLimit(context.current, context.page6, context.page9, start + 99U));
+        TEST_ASSERT_TRUE(checkAFRLimit(context.current, context.page6, context.page9, start + 100U));
+        TEST_ASSERT_TRUE(checkAFRLimit(context.current, context.page6, context.page9, start + 101U));
+        context.current.TPS = 0;
+        TEST_ASSERT_FALSE(checkAFRLimit(context.current, context.page6, context.page9, start + 102U));
+        TEST_ASSERT_FALSE(afrProtTimerStarted);
+    }
+}
+
 static void test_checkOilPressureLimit_basic(void) {
     engineProtection_test_context_t context;
     
@@ -259,6 +291,8 @@ static void test_checkOilPressureLimit_activate_when_time_expires(void) {
     context.setOilPressureActive(); 
 
     oilProtEndTime = 0;
+    oilProtTimerStarted = false;
+    afrProtTimerStarted = false;
     TEST_ASSERT_TRUE(checkOilPressureLimit(context.current, context.page6, context.page10, millis()));
 
     oilProtEndTime = 10000;
@@ -275,6 +309,8 @@ static void test_checkOilPressureLimit_timer_and_activation(void)
     // Set a non-zero delay (2 -> 200ms)
     context.page10.oilPressureProtTime = 2;
     oilProtEndTime = 0;
+    oilProtTimerStarted = false;
+    afrProtTimerStarted = false;
 
     unsigned long now = 12345UL;
     // First call should arm the timer but not yet activate
@@ -309,6 +345,8 @@ static void test_checkOilPressureLimit_timer_resets_when_pressure_recovers(void)
     context.page10.oilPressureProtTime = 5;
     unsigned long now = 30000UL;
     oilProtEndTime = 0;
+    oilProtTimerStarted = false;
+    afrProtTimerStarted = false;
 
     // Arm the timer
     TEST_ASSERT_FALSE(checkOilPressureLimit(context.current, context.page6, context.page10, now));
@@ -1585,6 +1623,7 @@ static void test_RollingCut_masks_unused(void)
     SET_UNITY_FILENAME() {
 
     RUN_TEST_P(test_checkOilPressureLimit_basic);
+    RUN_TEST_P(test_protection_deadlines_wrap);
     RUN_TEST_P(test_checkOilPressureLimit_activate_when_time_expires);
     RUN_TEST_P(test_checkOilPressureLimit_timer_and_activation)
     RUN_TEST_P(test_checkOilPressureLimit_existing_engineProtect_forces_cut);


### PR DESCRIPTION
Oil-pressure and AFR protection compare absolute 32-bit millis deadlines. If a 100 ms delay starts 50 ms before rollover, its deadline wraps to a small value and protection can activate immediately. A deadline equal to zero also collides with the inactive marker.

Compare modular elapsed time against the deadline using elapsed_time.h and explicit timer-started state. Preserve oil protection latching, retain an activated AFR cut until its existing TPS reactivation condition, and reset timer state on the existing recovery paths. No tune fields or EEPROM layout changes are introduced. The two new state flags cost two bytes of static RAM.

This is limited to main-loop oil/AFR timers; it does not change interrupt-shared ignition or overdwell timing.

Fixes #1624

### Validation
- Native 4x4 test_engineprotect: 62/62 cases passed, including new before/at-expiry, wrap-to-nonzero, wrap-to-zero, zero-start, oil recovery and AFR latch/reactivation assertions.
- Mega2560 firmware build succeeded. Static RAM: 6,352 -> 6,354 B (+2 B); flash: 187,692 -> 187,924 B (+232 B), compared with cc9eb445 using the same local toolchain.
- git diff --check passed. No physical ECU/engine test performed.

### Commit structure
- Protection: compare deadlines across rollover and track zero deadlines
- Tests: cover protection expiry and recovery across millis rollover
