### PR TITLE
CI: report occupied memory and preserve build diagnostics

### DIFF
--- a/.github/workflows/pr-memory-deltas-report.yml
+++ b/.github/workflows/pr-memory-deltas-report.yml
@@ -15,7 +15,7 @@ jobs:
         SOURCE_ARTIFACT: sketches-report-all
 
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     permissions:
       pull-requests: write
     
@@ -27,6 +27,23 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ./
+
+      - name: Mark report from failed build
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        env:
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          report = Path(os.environ["SIZE_REPORT_FILE"])
+          warning = (
+              "> **Build failed:** [View build logs](" + os.environ["SOURCE_RUN_URL"] + "). "
+              "The measurements below may be incomplete; N/A is not zero.\n\n"
+          )
+          report.write_text(warning + report.read_text(encoding="utf-8"), encoding="utf-8")
+          PY
 
       - name: Extract PR Number
         id: extract-pr-id

--- a/.github/workflows/pr-memory-deltas.py
+++ b/.github/workflows/pr-memory-deltas.py
@@ -2,6 +2,20 @@
 import sys
 import re
 
+def teensy_used_bytes(section, regions):
+    """Sum named occupied regions, never the free-space figures."""
+    values = {}
+    for region, body in re.findall(r"teensy_size:\s+(FLASH|RAM1|RAM2):([^\r\n]+)", section):
+        if region in regions:
+            body = body.split("free for", 1)[0]
+            fields = dict(re.findall(r"\b(code|data|headers|variables|padding):\s*(\d+)", body))
+            required = regions[region]
+            values[region] = sum(int(fields[key]) for key in required) if all(key in fields for key in required) else None
+    if all(values.get(region) is not None for region in regions):
+        return sum(values[region] for region in regions)
+    return None
+
+
 def parse_multi_env_log(log_path):
     """Parses a multi-environment PlatformIO log into an environment map."""
     env_data = {}
@@ -13,7 +27,7 @@ def parse_multi_env_log(log_path):
         return env_data
 
     # Split output log by PlatformIO environment target headers
-    sections = content.split("Processing ")
+    sections = re.sub(r"\x1b\[[0-9;]*m", "", content).split("Processing ")
     for section in sections[1:]:
         lines = section.split('\n')
         if not lines:
@@ -22,17 +36,14 @@ def parse_multi_env_log(log_path):
         # Extract environment tag name (e.g. 'uno' or 'esp32')
         env_name = lines[0].split()[0].strip()
         
-        # Capture raw used byte figures using regex
-        if env_name.casefold().startswith("Teensy".casefold()):
-            ram_match = re.search(r"teensy_size:\s+RAM1:.+free for local variables:(\d+)", section)
-            flash_match = re.search(r"teensy_size:\s+FLASH:.+free for files:(\d+)", section)
-        else:
-            ram_match = re.search(r"RAM:\s+\[.*\]\s+[\d.]+\%\s+\(used\s+(\d+)\s+bytes", section)
-            flash_match = re.search(r"Flash:\s+\[.*\]\s+[\d.]+\%\s+\(used\s+(\d+)\s+bytes", section)
-        
+        # Prefer PlatformIO's ordinary used-byte format when available.
+        ram_match = re.search(r"RAM:\s+\[.*\]\s+[\d.]+\%\s+\(used\s+(\d+)\s+bytes", section)
+        flash_match = re.search(r"Flash:\s+\[.*\]\s+[\d.]+\%\s+\(used\s+(\d+)\s+bytes", section)
         env_data[env_name] = {
-            'ram': int(ram_match.group(1)) if ram_match else 0,
-            'flash': int(flash_match.group(1)) if flash_match else 0
+            'ram': int(ram_match.group(1)) if ram_match else teensy_used_bytes(section, {
+                'RAM1': ('variables', 'code', 'padding'), 'RAM2': ('variables',)}),
+            'flash': int(flash_match.group(1)) if flash_match else teensy_used_bytes(section, {
+                'FLASH': ('code', 'data', 'headers')})
         }
     return env_data
 
@@ -44,6 +55,10 @@ def format_bytes(bytes_value):
     return f"{sign}{bytes_value:,} B"
 
 def format_delta_cols(base_size, pr_size):
+        if base_size is None or pr_size is None:
+            base = "N/A" if base_size is None else f"{base_size:,} B"
+            pr = "N/A" if pr_size is None else f"{pr_size:,} B"
+            return f"| {base} | {pr} | N/A | Unknown |"
         delta = pr_size - base_size
         emoji = "🟢" if delta <= 0 else "🔴"
 
@@ -75,13 +90,14 @@ def main():
         report.append("| :--- | :--- | :--- | :--- | :--- | :---: |")
 
         for env in all_envs:
-            base = base_data.get(env, {'ram': 0, 'flash': 0})
-            pr = pr_data.get(env, {'ram': 0, 'flash': 0})
+            base = base_data.get(env, {'ram': None, 'flash': None})
+            pr = pr_data.get(env, {'ram': None, 'flash': None})
 
             report.append(f"| **{env}** | RAM {format_delta_cols(base['ram'], pr['ram'])}")
             report.append(f"| | Flash {format_delta_cols(base['flash'], pr['flash'])}")
 
-        report.append("\n*Negative delta values represent optimized or reduced resource usage.*")
+        report.append("\n*Negative deltas indicate reduced used memory. N/A means no matching measurement was available.*")
+        report.append("*Teensy RAM includes RAM1 variables/code/padding and RAM2 variables; flash includes code/data/headers.*")
 
     print("\n".join(report))
 

--- a/.github/workflows/pr-memory-deltas.yml
+++ b/.github/workflows/pr-memory-deltas.yml
@@ -45,6 +45,9 @@ jobs:
       run: python -m unittest discover -s "${{ env.PR_FOLDER }}/.github/workflows/tests"
 
     - name: Build PR Envs
+      id: build_pr
+      # Preserve measurements and logs before failing the final build check.
+      continue-on-error: true
       run: |
         set -o pipefail
         source PIO/bin/activate
@@ -53,10 +56,13 @@ jobs:
     - name: Checkout Base Branch
       uses: actions/checkout@v4
       with:
-        ref: master
+        ref: ${{ github.event.pull_request.base.sha }}
         path: ${{ env.BASE_FOLDER }}
 
     - name: Build Base Envs
+      id: build_base
+      # Preserve measurements and logs before failing the final build check.
+      continue-on-error: true
       run: |
         set -o pipefail
         source PIO/bin/activate
@@ -73,11 +79,13 @@ jobs:
         fi
 
     - name: Upload build logs
-      if: ${{ env.ACT }}
+      if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
+        name: memory-build-logs
         path: |
-            **/*.log
+          ${{ env.PR_LOG_FILE }}
+          ${{ env.BASE_LOG_FILE }}
 
       # This step is needed to pass the size data to the report job.
     - name: Upload sketches report to workflow artifact
@@ -87,3 +95,9 @@ jobs:
         path: |
           ${{ env.SIZE_REPORT_FILE }}
           ${{ env.PR_NUM_FILE }}
+
+    - name: Check build results
+      if: ${{ always() && (steps.build_pr.outcome == 'failure' || steps.build_base.outcome == 'failure') }}
+      run: |
+        echo "At least one firmware build failed; see memory-build-logs and the partial size report."
+        exit 1

--- a/.github/workflows/pr-memory-deltas.yml
+++ b/.github/workflows/pr-memory-deltas.yml
@@ -30,6 +30,12 @@ jobs:
         source PIO/bin/activate
         pip install platformio
 
+    # Use the same compatible STM32 toolchain for the PR and an unpinned base.
+    - name: Install compatible STM32 platform
+      run: |
+        source PIO/bin/activate
+        platformio pkg install --global --platform "platformio/ststm32@19.5.0"
+
     - name: Build command line
       if: ${{ env.PIO_ENVS }}
       id: build_command_line

--- a/.github/workflows/pr-memory-deltas.yml
+++ b/.github/workflows/pr-memory-deltas.yml
@@ -30,12 +30,6 @@ jobs:
         source PIO/bin/activate
         pip install platformio
 
-    # Use the same compatible STM32 toolchain for the PR and an unpinned base.
-    - name: Install compatible STM32 platform
-      run: |
-        source PIO/bin/activate
-        platformio pkg install --global --platform "platformio/ststm32@19.5.0"
-
     - name: Build command line
       if: ${{ env.PIO_ENVS }}
       id: build_command_line

--- a/.github/workflows/pr-memory-deltas.yml
+++ b/.github/workflows/pr-memory-deltas.yml
@@ -41,8 +41,12 @@ jobs:
       with:
         path: ${{ env.PR_FOLDER }}
 
+    - name: Test memory report parsing
+      run: python -m unittest discover -s "${{ env.PR_FOLDER }}/.github/workflows/tests"
+
     - name: Build PR Envs
       run: |
+        set -o pipefail
         source PIO/bin/activate
         platformio run -d ${{ env.PR_FOLDER }} ${{ steps.build_command_line.outputs.CMD_PIO_ENVS }} 2>&1 | tee ${{ env.PR_LOG_FILE }}
     
@@ -54,6 +58,7 @@ jobs:
 
     - name: Build Base Envs
       run: |
+        set -o pipefail
         source PIO/bin/activate
         platformio run -d ${{ env.BASE_FOLDER }} ${{ steps.build_command_line.outputs.CMD_PIO_ENVS }} 2>&1 | tee ${{ env.BASE_LOG_FILE }}
 

--- a/.github/workflows/pr-memory-deltas.yml
+++ b/.github/workflows/pr-memory-deltas.yml
@@ -46,6 +46,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: ${{ env.PR_FOLDER }}
+        fetch-depth: 2
+
+    - name: Identify comparison base
+      id: comparison_base
+      working-directory: ${{ env.PR_FOLDER }}
+      run: |
+        # Compare the tested merge with its actual base, which may be newer
+        # than the base SHA retained in the pull request event.
+        git rev-parse --verify HEAD^2 > /dev/null
+        echo "sha=$(git rev-parse HEAD^1)" >> "$GITHUB_OUTPUT"
 
     - name: Test memory report parsing
       run: python -m unittest discover -s "${{ env.PR_FOLDER }}/.github/workflows/tests"
@@ -62,7 +72,7 @@ jobs:
     - name: Checkout Base Branch
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.base.sha }}
+        ref: ${{ steps.comparison_base.outputs.sha }}
         path: ${{ env.BASE_FOLDER }}
 
     - name: Build Base Envs

--- a/.github/workflows/tests/test_pr_memory_deltas.py
+++ b/.github/workflows/tests/test_pr_memory_deltas.py
@@ -1,0 +1,70 @@
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "pr-memory-deltas.py"
+spec = importlib.util.spec_from_file_location("memory_report", SCRIPT)
+report = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(report)
+
+TEENSY = """Processing teensy41 (platform: teensy)
+teensy_size:   FLASH: code:20, data:3, headers:2   free for files:1000
+teensy_size:    RAM1: variables:2, code:3, padding:4   free for local variables:2000
+teensy_size:    RAM2: variables:5  free for malloc/new:3000
+"""
+
+
+class MemoryReportTests(unittest.TestCase):
+    def parse(self, text):
+        with tempfile.TemporaryDirectory() as folder:
+            log = Path(folder) / "build.log"
+            log.write_text(text, encoding="utf-8")
+            return report.parse_multi_env_log(log)
+
+    def test_teensy_uses_occupied_regions(self):
+        self.assertEqual({'ram': 14, 'flash': 25}, self.parse(TEENSY)['teensy41'])
+
+    def test_teensy_growth_has_positive_delta(self):
+        base = self.parse(TEENSY)['teensy41']
+        changed = TEENSY.replace('data:3', 'data:7').replace('files:1000', 'files:996')
+        pr = self.parse(changed)['teensy41']
+        self.assertIn('+4 B', report.format_delta_cols(base['flash'], pr['flash']))
+        self.assertIn('-4 B', report.format_delta_cols(pr['flash'], base['flash']))
+
+    def test_standard_teensy_format_and_real_zero(self):
+        log = "Processing teensy35 (platform: teensy)\nRAM: [] 0.0% (used 0 bytes from 100 bytes)\nFlash: [=] 23.0% (used 23 bytes from 100 bytes)\n"
+        self.assertEqual({'ram': 0, 'flash': 23}, self.parse(log)['teensy35'])
+
+    def test_missing_metrics_are_unknown(self):
+        self.assertEqual({'ram': None, 'flash': None}, self.parse('Processing board (platform: test)\n')['board'])
+        self.assertIn('N/A', report.format_delta_cols(None, 10))
+        self.assertIn('Unknown', report.format_delta_cols(10, None))
+        self.assertNotIn('N/A', report.format_delta_cols(0, 0))
+
+    def test_incomplete_teensy_ram_is_unknown(self):
+        log = '\n'.join(line for line in TEENSY.splitlines() if 'RAM2:' not in line)
+        self.assertIsNone(self.parse(log)['teensy41']['ram'])
+        self.assertEqual(25, self.parse(log)['teensy41']['flash'])
+
+    def test_ansi_color_codes(self):
+        log = 'Processing board (platform: test)\n\x1b[32mRAM: [] 1.0% (used 1 bytes from 100 bytes)\x1b[0m\nFlash: [] 2.0% (used 2 bytes from 100 bytes)\n'
+        self.assertEqual({'ram': 1, 'flash': 2}, self.parse(log)['board'])
+
+    def test_missing_environment_does_not_get_a_zero_baseline(self):
+        with tempfile.TemporaryDirectory() as folder:
+            base = Path(folder) / 'base.log'
+            pr = Path(folder) / 'pr.log'
+            base.write_text('', encoding='utf-8')
+            pr.write_text(TEENSY, encoding='utf-8')
+            env = dict(os.environ, PYTHONIOENCODING='utf-8')
+            output = subprocess.check_output([sys.executable, str(SCRIPT), str(base), str(pr)], encoding='utf-8', env=env)
+            self.assertIn('| N/A | 14 B | N/A | Unknown |', output)
+            self.assertIn('| N/A | 25 B | N/A | Unknown |', output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/platformio.ini
+++ b/platformio.ini
@@ -102,8 +102,7 @@ extra_scripts = post:post_extra_script.py
 
 ;STM32 Official core
 [env:black_F407VE]
-; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
-platform = ststm32@19.5.0
+platform = ststm32
 framework = arduino
 board = black_f407ve
 ; RTC library fixed to 1.2.0, because in newer than that the RTC fails to keep up time. At least up to 1.3.7 version
@@ -147,8 +146,7 @@ build_flags = ${env:black_F407VE.build_flags} -DFRAM_AS_EEPROM
 ;STM32 Official core - FCR Micro F4 (STM32F429VIT6, 2MB flash, 8MHz HSE)
 ; W25Q16 SPI flash on SPI3 (CS=PA15) as EEPROM, CAN1 on ALT_2 (PD0/PD1), USB CDC with VBUS sense on PA9.
 [env:FCR_Micro_F4]
-; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
-platform = ststm32@19.5.0
+platform = ststm32
 framework = arduino
 ; Project-local board def (boards/fcr_micro_f4.json) wrapping the stm32duino F429VITx variant
 board = fcr_micro_f4
@@ -167,8 +165,7 @@ monitor_speed = 115200
 
 ;STM32 Official core
 [env:BlackPill_F401CC]
-; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
-platform = ststm32@19.5.0
+platform = ststm32
 framework = arduino
 board = blackpill_f401cc
 lib_deps = 
@@ -182,8 +179,7 @@ monitor_speed = 115200
 
 ;STM32 Official core
 [env:BlackPill_F411CE_UART]
-; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
-platform = ststm32@19.5.0
+platform = ststm32
 framework = arduino
 board = blackpill_f411ce
 lib_deps = 
@@ -197,8 +193,7 @@ monitor_speed = 115200
 
 ;STM32 Official core
 [env:BlackPill_F411CE_USB]
-; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
-platform = ststm32@19.5.0
+platform = ststm32
 framework = arduino
 board = blackpill_f411ce
 lib_deps = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -102,7 +102,8 @@ extra_scripts = post:post_extra_script.py
 
 ;STM32 Official core
 [env:black_F407VE]
-platform = ststm32
+; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
+platform = ststm32@19.5.0
 framework = arduino
 board = black_f407ve
 ; RTC library fixed to 1.2.0, because in newer than that the RTC fails to keep up time. At least up to 1.3.7 version
@@ -146,7 +147,8 @@ build_flags = ${env:black_F407VE.build_flags} -DFRAM_AS_EEPROM
 ;STM32 Official core - FCR Micro F4 (STM32F429VIT6, 2MB flash, 8MHz HSE)
 ; W25Q16 SPI flash on SPI3 (CS=PA15) as EEPROM, CAN1 on ALT_2 (PD0/PD1), USB CDC with VBUS sense on PA9.
 [env:FCR_Micro_F4]
-platform = ststm32
+; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
+platform = ststm32@19.5.0
 framework = arduino
 ; Project-local board def (boards/fcr_micro_f4.json) wrapping the stm32duino F429VITx variant
 board = fcr_micro_f4
@@ -165,7 +167,8 @@ monitor_speed = 115200
 
 ;STM32 Official core
 [env:BlackPill_F401CC]
-platform = ststm32
+; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
+platform = ststm32@19.5.0
 framework = arduino
 board = blackpill_f401cc
 lib_deps = 
@@ -179,7 +182,8 @@ monitor_speed = 115200
 
 ;STM32 Official core
 [env:BlackPill_F411CE_UART]
-platform = ststm32
+; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
+platform = ststm32@19.5.0
 framework = arduino
 board = blackpill_f411ce
 lib_deps = 
@@ -193,7 +197,8 @@ monitor_speed = 115200
 
 ;STM32 Official core
 [env:BlackPill_F411CE_USB]
-platform = ststm32
+; Core 3.0 conflicts with STM32duino RTC 1.2.0 callback typedefs.
+platform = ststm32@19.5.0
 framework = arduino
 board = blackpill_f411ce
 lib_deps = 


### PR DESCRIPTION
The memory report treated Teensy free space as occupied memory, omitted RAM2, and replaced missing measurements with zero. Report occupied FLASH and RAM regions, prefer standard PlatformIO used-byte metrics, and distinguish missing measurements from a measured zero.

Keep both build logs and the partial report when a build fails, then fail the job after uploading diagnostics. Compare the tested merge commit against its actual first parent: pull-request metadata can retain an older base SHA after master advances, otherwise attributing unrelated upstream firmware growth to the PR.

Fixes #1637. Refs #1629.

### Scope

Only the memory-report parser, its seven regression tests, and the size build/report workflows change. There are no firmware, calibration-layout, or `platformio.ini` changes. PlatformIO resolves the platform configured by each checkout; this workflow does not preinstall or force a particular STM32 version.

The independently observed fresh-build STM32 core/RTC incompatibility is tracked in #1649 for specialist review. When a completed build fails and has uploaded the report artifact, the reporting workflow also publishes that available partial report with a Build failed banner and a link to the source run, instead of leaving a previous success table in place. This PR preserves diagnostics and reports build failures; it does not fix that dependency conflict or substitute zero measurements for failed builds.

### Validation

- All seven parser tests pass; six failed against the original parser. Coverage includes the supported formats, ANSI escapes, real zero values, incomplete/missing measurements, and delta direction.
- Actual Teensy 4.1 output was checked against occupied-region sums: RAM 278,560 bytes and flash 248,828 bytes.
- Prior live size run [34491323597](https://github.com/speeduino/speeduino/actions/runs/34491323597) validated the actual-merge-parent comparison and reported zero RAM/flash delta on all three boards at revision `aa8554de`. That run included the former STM32 workaround, which is no longer part of this PR; it is not a passing build claim for the latest revision.
- After the review updates: `python -m unittest discover -s .github/workflows/tests -v`, actionlint (external shellcheck/pyflakes disabled locally), and `git diff --check` pass.
- New GitHub checks run on the updated revision. Fresh STM32 builds may still encounter the independently tracked #1649 conflict until the supported dependency combination is agreed.

### Commit structure

Tests, occupied-memory parsing, build-failure propagation, diagnostic retention, and actual merge-base selection are separate commits. The review follow-ups separately remove the workflow-wide STM32 installation and revert the platform pin, leaving both out of the final diff.

### Latest review follow-up

Run [34534504103](https://github.com/speeduino/speeduino/actions/runs/34534504103) failed on the STM32/RTC callback conflict tracked in #1649; the other nine PR checks passed at 6cdeb026. Both `memory-build-logs` and `sketches-report-all` artifacts were uploaded. The existing reporting workflow runs only on successful source builds, explaining why the older all-green table remained visible.

Commit 1b897220 enables reporting for completed success/failure runs and labels reports from failed builds explicitly. All seven parser tests, actionlint for both workflows, and diff checks pass. The exact embedded annotation script was also executed locally: it preserves the original report and prepends the failure status and source-run link.

GitHub loads this `workflow_run` reporting workflow from the default branch, so the changed comment behavior can take effect after merge; it cannot be demonstrated by the PR's own reporter run before then. Missing artifacts from an earlier infrastructure failure are not fabricated. The STM32 build failure remains separate and is not suppressed.