### PR TITLE
Refactor secondary fuel and spark table switch conditions

### DIFF
--- a/speeduino/secondaryTables.cpp
+++ b/speeduino/secondaryTables.cpp
@@ -27,19 +27,10 @@ static_assert(FUEL2_CONDITION_RPM == SPARK2_CONDITION_RPM
 
 static inline bool isSecondarySwitchActive(uint8_t variable, uint16_t threshold, const statuses &current)
 {
-  switch (variable)
-  {
-    case FUEL2_CONDITION_RPM:
-      return current.RPM > threshold;
-    case FUEL2_CONDITION_MAP:
-      return current.MAP > threshold;
-    case FUEL2_CONDITION_TPS:
-      return current.TPS > threshold;
-    case FUEL2_CONDITION_ETH:
-      return current.ethanolPct > threshold;
-    default:
-      return false;
-  }
+  return ((variable == FUEL2_CONDITION_RPM) && (current.RPM > threshold))
+      || ((variable == FUEL2_CONDITION_MAP) && (current.MAP > threshold))
+      || ((variable == FUEL2_CONDITION_TPS) && (current.TPS > threshold))
+      || ((variable == FUEL2_CONDITION_ETH) && (current.ethanolPct > threshold));
 }
 
 static inline bool fuelModeCondSwitchActive(const config10 &page10, const statuses &current) {

--- a/speeduino/secondaryTables.cpp
+++ b/speeduino/secondaryTables.cpp
@@ -17,32 +17,34 @@ static inline uint8_t lookupVE2(const config10 &page10, const table3d16RpmLoad &
   return get3DTableValue(&veLookupTable, getLoad(page10.fuel2Algorithm, current), current.RPM); //Perform lookup into fuel map for RPM vs MAP value
 }
 
-static inline bool fuelModeCondSwitchRpmActive(const config10 &page10, const statuses &current) {
-  return (page10.fuel2SwitchVariable == FUEL2_CONDITION_RPM)
-      && (current.RPM > page10.fuel2SwitchValue);
-}
+// Both tune fields use the same selector encoding. Keep that assumption checked
+// if either set of constants changes in the future.
+static_assert(FUEL2_CONDITION_RPM == SPARK2_CONDITION_RPM
+           && FUEL2_CONDITION_MAP == SPARK2_CONDITION_MAP
+           && FUEL2_CONDITION_TPS == SPARK2_CONDITION_TPS
+           && FUEL2_CONDITION_ETH == SPARK2_CONDITION_ETH,
+              "Secondary table switch selectors must match");
 
-static inline bool fuelModeCondSwitchMapActive(const config10 &page10, const statuses &current) {
-  return (page10.fuel2SwitchVariable == FUEL2_CONDITION_MAP)
-      && (current.MAP > page10.fuel2SwitchValue);
-}
-
-static inline bool fuelModeCondSwitchTpsActive(const config10 &page10, const statuses &current) {
-  return (page10.fuel2SwitchVariable == FUEL2_CONDITION_TPS)
-      && (current.TPS > page10.fuel2SwitchValue);
-}
-
-static inline bool fuelModeCondSwitchEthanolActive(const config10 &page10, const statuses &current) {
-  return (page10.fuel2SwitchVariable == FUEL2_CONDITION_ETH)
-      && (current.ethanolPct > page10.fuel2SwitchValue);
+static inline bool isSecondarySwitchActive(uint8_t variable, uint16_t threshold, const statuses &current)
+{
+  switch (variable)
+  {
+    case FUEL2_CONDITION_RPM:
+      return current.RPM > threshold;
+    case FUEL2_CONDITION_MAP:
+      return current.MAP > threshold;
+    case FUEL2_CONDITION_TPS:
+      return current.TPS > threshold;
+    case FUEL2_CONDITION_ETH:
+      return current.ethanolPct > threshold;
+    default:
+      return false;
+  }
 }
 
 static inline bool fuelModeCondSwitchActive(const config10 &page10, const statuses &current) {
   return (page10.fuel2Mode == FUEL2_MODE_CONDITIONAL_SWITCH)
-      && ( fuelModeCondSwitchRpmActive(page10, current)
-        || fuelModeCondSwitchMapActive(page10, current) 
-        || fuelModeCondSwitchTpsActive(page10, current)
-        || fuelModeCondSwitchEthanolActive(page10, current));
+      && isSecondarySwitchActive(page10.fuel2SwitchVariable, page10.fuel2SwitchValue, current);
 }
 
 static inline bool fuelModeInputSwitchActive(const config10 &page10) {
@@ -95,32 +97,9 @@ static inline int8_t constrainAdvance(int16_t advance)
   return (int8_t)clamp(advance, (int16_t)INT8_MIN, (int16_t)INT8_MAX);
 }
 
-static inline bool sparkModeCondSwitchRpmActive(const config10 &page10, const statuses &current) {
-  return (page10.spark2SwitchVariable == SPARK2_CONDITION_RPM)
-      && (current.RPM > page10.spark2SwitchValue);
-}
-
-static inline bool sparkModeCondSwitchMapActive(const config10 &page10, const statuses &current) {
-  return (page10.spark2SwitchVariable == SPARK2_CONDITION_MAP)
-      && (current.MAP > page10.spark2SwitchValue);
-}
-
-static inline bool sparkModeCondSwitchTpsActive(const config10 &page10, const statuses &current) {
-  return (page10.spark2SwitchVariable == SPARK2_CONDITION_TPS)
-      && (current.TPS > page10.spark2SwitchValue);
-}
-
-static inline bool sparkModeCondSwitchEthanolActive(const config10 &page10, const statuses &current) {
-return (page10.spark2SwitchVariable == SPARK2_CONDITION_ETH)
-    && (current.ethanolPct > page10.spark2SwitchValue);
-}
-
 static inline bool sparkModeCondSwitchActive(const config10 &page10, const statuses &current) {
   return (page10.spark2Mode == SPARK2_MODE_CONDITIONAL_SWITCH)
-      && ( sparkModeCondSwitchRpmActive(page10, current)
-        || sparkModeCondSwitchMapActive(page10, current) 
-        || sparkModeCondSwitchTpsActive(page10, current)
-        || sparkModeCondSwitchEthanolActive(page10, current));
+      && isSecondarySwitchActive(page10.spark2SwitchVariable, page10.spark2SwitchValue, current);
 }
 
 static inline bool sparkModeInputSwitchActive(const config10 &page10) {

--- a/test/test_secondary/test_secondary_fuel.cpp
+++ b/test/test_secondary/test_secondary_fuel.cpp
@@ -113,8 +113,8 @@ static void __attribute__((noinline)) setup_test_fuel_mode_cond_switch(config10 
 
     current.MAP = SWITCHED_LOAD; //Load source value
     current.setRpm( 3500U);
-    current.TPS = 50;
-    current.ethanolPct = 50;
+    current.TPS = 75;
+    current.ethanolPct = 85;
 }
 
 static void __attribute__((noinline)) test_fuel_mode_cond_switch_negative(uint8_t cond, uint16_t trigger) {
@@ -140,27 +140,35 @@ static void __attribute__((noinline)) test_fuel_mode_cond_switch_positive(uint8_
 }
 
 static void __attribute__((noinline)) test_fuel_mode_cond_switch_rpm(void) {
-    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_RPM, 3499);    
-    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_RPM, 3501);    
-    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_RPM, 3499);    
+    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_RPM, 3499);
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_RPM, 3500); // Equality must not activate the table
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_RPM, 3501);
+    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_RPM, 0);
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_RPM, UINT16_MAX);
 }
 
 static void __attribute__((noinline)) test_fuel_mode_cond_switch_tps(void) {
-    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_TPS, 49);    
-    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_TPS, 51);    
-    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_TPS, 49);    
+    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_TPS, 74);
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_TPS, 75); // Equality must not activate the table
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_TPS, 76);
+    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_TPS, 0);
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_TPS, UINT16_MAX);
 }
 
 static void __attribute__((noinline)) test_fuel_mode_cond_switch_map(void) {
-    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_MAP, 49);    
-    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_MAP, 51);    
-    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_MAP, 49);    
+    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_MAP, 49);
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_MAP, 50); // Equality must not activate the table
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_MAP, 51);
+    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_MAP, 0);
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_MAP, UINT16_MAX);
 }
 
 static void __attribute__((noinline)) test_fuel_mode_cond_switch_ethanol_pct(void) {
-    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_ETH, 49);    
-    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_ETH, 51);    
-    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_ETH, 49);    
+    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_ETH, 84);
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_ETH, 85); // Equality must not activate the table
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_ETH, 86);
+    test_fuel_mode_cond_switch_positive(FUEL2_CONDITION_ETH, 0);
+    test_fuel_mode_cond_switch_negative(FUEL2_CONDITION_ETH, UINT16_MAX);
 }
 
 static void __attribute__((noinline)) test_fuel_mode_input_switch(void) {

--- a/test/test_secondary/test_secondary_spark.cpp
+++ b/test/test_secondary/test_secondary_spark.cpp
@@ -174,8 +174,8 @@ static void __attribute__((noinline)) setup_test_mode_cond_switch(config2 &page2
     page10.spark2SwitchValue = trigger;
     current.MAP = 50; //Load source value
     current.setRpm( 3500U);
-    current.TPS = 50;
-    current.ethanolPct = 50;
+    current.TPS = 75;
+    current.ethanolPct = 85;
 }
 
 static void __attribute__((noinline)) test_sparkmode_cond_switch_negative(uint8_t cond, uint16_t trigger) {
@@ -205,27 +205,35 @@ static void __attribute__((noinline)) test_sparkmode_cond_switch_positive(uint8_
 }
 
 static void __attribute__((noinline)) test_sparkmode_cond_switch_rpm(void) {
-    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_RPM, 3499);    
-    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_RPM, 3501);    
-    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_RPM, 3499);    
+    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_RPM, 3499);
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_RPM, 3500); // Equality must not activate the table
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_RPM, 3501);
+    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_RPM, 0);
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_RPM, UINT16_MAX);
 }
 
 static void __attribute__((noinline)) test_sparkmode_cond_switch_tps(void) {
-    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_TPS, 49);    
-    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_TPS, 51);    
-    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_TPS, 49);    
+    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_TPS, 74);
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_TPS, 75); // Equality must not activate the table
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_TPS, 76);
+    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_TPS, 0);
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_TPS, UINT16_MAX);
 }
 
 static void __attribute__((noinline)) test_sparkmode_cond_switch_map(void) {
-    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_MAP, 49);    
-    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_MAP, 51);    
-    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_MAP, 49);    
+    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_MAP, 49);
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_MAP, 50); // Equality must not activate the table
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_MAP, 51);
+    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_MAP, 0);
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_MAP, UINT16_MAX);
 }
 
 static void __attribute__((noinline)) test_sparkmode_cond_switch_ethanol_pct(void) {
-    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_ETH, 49);    
-    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_ETH, 51);    
-    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_ETH, 49);    
+    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_ETH, 84);
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_ETH, 85); // Equality must not activate the table
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_ETH, 86);
+    test_sparkmode_cond_switch_positive(SPARK2_CONDITION_ETH, 0);
+    test_sparkmode_cond_switch_negative(SPARK2_CONDITION_ETH, UINT16_MAX);
 }
 
 static void __attribute__((noinline)) test_sparkmode_input_switch(void) {


### PR DESCRIPTION
Secondary fuel and spark table switching currently duplicate four sensor comparisons and the selector dispatch. This makes the two implementations easy to change inconsistently. Share the conditional-switch evaluation while retaining each table's mode gate and configured threshold.

The shared helper compares only the selected RPM, MAP, TPS or ethanol reading, preserves the strict `reading > threshold` boundary, and keeps the threshold as `uint16_t`. A compile-time assertion checks that the fuel and spark selector encodings match. Table lookup, fuel/spark combination, ignition corrections, input-pin switching and tune storage layout are unchanged.

The tests now use distinct MAP/TPS/ethanol readings so a sensor-selection mix-up is observable. For every selector in both fuel and spark paths, they exercise thresholds immediately below, equal to and above the reading, plus zero and `UINT16_MAX`. The previous repeated positive case was replaced with meaningful boundary checks.

Commits separate behavior tests, the production refactor, and a follow-up retaining short-circuit predicates so all implementation lines are reachable through the two-bit tune selectors.

Validation:

- All 27 `test_secondary` native tests pass on the original implementation and the refactor (4 injector / 4 ignition channels).
- `platformio run -e megaatmega2560` passes before and after, using upstream `d023d25d` as the baseline and identical toolchain/settings.
- `git diff --check` passes.

| Mega2560 occupied memory | Before | After | Change |
| --- | ---: | ---: | ---: |
| RAM | 6,354 bytes | 6,354 bytes | 0 |
| Flash | 187,948 bytes | 187,884 bytes | -64 bytes |

Local native testing used Windows MinGW with `-Wa,-mbig-obj` to accommodate the existing FakeMega translation unit. Hardware/engine testing was not performed; the change is limited to sharing the existing conditional comparison logic.
