### PR TITLE
Refactor launch and flat-shift condition handling

### DIFF
--- a/speeduino/src/controllers/launch/launchController.cpp
+++ b/speeduino/src/controllers/launch/launchController.cpp
@@ -1,54 +1,70 @@
 #include "launchController.h"
+#include "../../../units.h"
+
+static void updateClutchState(statuses &current, uint8_t launchPin, const config6 &page6)
+{
+  current.previousClutchTrigger = current.clutchTrigger;
+  // Only read the shared clutch input when a function using it is enabled.
+  if (page6.flatSEnable || page6.launchEnabled)
+  {
+    if (page6.launchHiLo > 0) { current.clutchTrigger = digitalRead(launchPin); }
+    else { current.clutchTrigger = !digitalRead(launchPin); }
+
+    current.clutchTriggerActive = current.clutchTrigger; // TunerStudio indication
+  }
+
+  // Capture RPM on engagement, then retain it while the clutch is held or released.
+  if (current.clutchTrigger && !current.previousClutchTrigger)
+  {
+    current.clutchEngagedRPM = current.RPM;
+  }
+}
+
+static bool isLaunchArmed(const statuses &current, const config6 &page6, const config10 &page10)
+{
+  return page6.launchEnabled
+      && current.clutchTrigger
+      && (current.clutchEngagedRPM < RPM_COARSE.toUser(page6.flatSArm))
+      && (current.TPS >= page10.lnchCtrlTPS);
+}
+
+static uint16_t getHardCutRpmLimit(uint16_t baseRpm, const config2 &page2, const config15 &page15)
+{
+  if (page2.hardCutType == HARD_CUT_ROLLING)
+  {
+    baseRpm += SIGNED_RPM_MEDIUM.toUser(page15.rollingProtRPMDelta[0]);
+  }
+  return baseRpm;
+}
 
 void checkLaunchAndFlatShift(statuses &current, uint8_t launchPin, const config2 &page2, const config6 &page6, const config10 &page10, const config15 &page15)
 {
-  //Check for launching/flat shift (clutch) based on the current and previous clutch states
-  current.previousClutchTrigger = current.clutchTrigger;
-  //Only check for pinLaunch if any function using it is enabled. Else pins might break starting a board
-  if(page6.flatSEnable || page6.launchEnabled)
-  {
-    if(page6.launchHiLo > 0) { current.clutchTrigger = digitalRead(launchPin); }
-    else { current.clutchTrigger = !digitalRead(launchPin); }
+  updateClutchState(current, launchPin, page6);
 
-    current.clutchTriggerActive = current.clutchTrigger; //Stores the value to send to TunerStudio
-  }
-  if(current.clutchTrigger && (current.previousClutchTrigger != current.clutchTrigger) ) { current.clutchEngagedRPM = current.RPM; } //Check whether the clutch has been engaged or disengaged and store the current RPM if so
-
-  //Default flags to off
-  current.launchingHard = false; 
+  current.launchingHard = false;
   current.hardLaunchActive = false;
   current.flatShiftingHard = false;
 
-  if (page6.launchEnabled && current.clutchTrigger && (current.clutchEngagedRPM < ((unsigned int)(page6.flatSArm) * 100)) && (current.TPS >= page10.lnchCtrlTPS) ) 
-  { 
-    //Only enable if VSS is not used or if it is, make sure we're not above the speed limit
-    if( (page2.vssMode == 0) || ((page2.vssMode > 0) && (current.vss < page10.lnchCtrlVss)) )
+  if (isLaunchArmed(current, page6, page10))
+  {
+    // A configured vehicle speed limit applies only to launch control.
+    if ((page2.vssMode == 0) || (current.vss < page10.lnchCtrlVss))
     {
-      //Check whether RPM is above the launch limit
-      uint16_t launchRPMLimit = (page6.lnchHardLim * 100);
-      if( (page2.hardCutType == HARD_CUT_ROLLING) ) { launchRPMLimit += (page15.rollingProtRPMDelta[0] * 10); } //Add the rolling cut delta if enabled (Delta is a negative value)
-
-      if(current.RPM > launchRPMLimit)
+      const uint16_t launchRpmLimit = getHardCutRpmLimit(RPM_COARSE.toUser(page6.lnchHardLim), page2, page15);
+      if (current.RPM > launchRpmLimit)
       {
-        //HardCut rev limit for 2-step launch control.
-        current.launchingHard = true; 
+        current.launchingHard = true;
         current.hardLaunchActive = true;
       }
     }
-  } 
-  else 
-  { 
-    //If launch is not active, check whether flat shift should be active
-    if(page6.flatSEnable && current.clutchTrigger && (current.clutchEngagedRPM >= ((unsigned int)(page6.flatSArm * 100)) ) ) 
-    { 
-      uint16_t flatRPMLimit = current.clutchEngagedRPM;
-      if( (page2.hardCutType == HARD_CUT_ROLLING) ) { flatRPMLimit += (page15.rollingProtRPMDelta[0] * 10); } //Add the rolling cut delta if enabled (Delta is a negative value)
-
-      if(current.RPM > flatRPMLimit)
-      {
-        //Flat shift rev limit
-        current.flatShiftingHard = true;
-      }
+  }
+  else if (page6.flatSEnable && current.clutchTrigger
+        && (current.clutchEngagedRPM >= RPM_COARSE.toUser(page6.flatSArm)))
+  {
+    const uint16_t flatRpmLimit = getHardCutRpmLimit(current.clutchEngagedRPM, page2, page15);
+    if (current.RPM > flatRpmLimit)
+    {
+      current.flatShiftingHard = true;
     }
   }
 }

--- a/speeduino/src/controllers/launch/launchController.cpp
+++ b/speeduino/src/controllers/launch/launchController.cpp
@@ -36,6 +36,17 @@ static uint16_t getHardCutRpmLimit(uint16_t baseRpm, const config2 &page2, const
   return baseRpm;
 }
 
+static bool withinLaunchSpeedLimit(const statuses &current, const config2 &page2, const config10 &page10)
+{
+  return (page2.vssMode == VSS_MODE_OFF) || (current.vss < page10.lnchCtrlVss);
+}
+
+static bool aboveLaunchRpmLimit(const statuses &current, const config2 &page2, const config6 &page6, const config15 &page15)
+{
+  const uint16_t launchRpmLimit = getHardCutRpmLimit(RPM_COARSE.toUser(page6.lnchHardLim), page2, page15);
+  return current.RPM > launchRpmLimit;
+}
+
 void checkLaunchAndFlatShift(statuses &current, uint8_t launchPin, const config2 &page2, const config6 &page6, const config10 &page10, const config15 &page15)
 {
   updateClutchState(current, launchPin, page6);
@@ -47,14 +58,11 @@ void checkLaunchAndFlatShift(statuses &current, uint8_t launchPin, const config2
   if (isLaunchArmed(current, page6, page10))
   {
     // A configured vehicle speed limit applies only to launch control.
-    if ((page2.vssMode == VSS_MODE_OFF) || (current.vss < page10.lnchCtrlVss))
+    if (withinLaunchSpeedLimit(current, page2, page10)
+        && aboveLaunchRpmLimit(current, page2, page6, page15))
     {
-      const uint16_t launchRpmLimit = getHardCutRpmLimit(RPM_COARSE.toUser(page6.lnchHardLim), page2, page15);
-      if (current.RPM > launchRpmLimit)
-      {
-        current.launchingHard = true;
-        current.hardLaunchActive = true;
-      }
+      current.launchingHard = true;
+      current.hardLaunchActive = true;
     }
   }
   else if (page6.flatSEnable && current.clutchTrigger

--- a/speeduino/src/controllers/launch/launchController.cpp
+++ b/speeduino/src/controllers/launch/launchController.cpp
@@ -47,7 +47,7 @@ void checkLaunchAndFlatShift(statuses &current, uint8_t launchPin, const config2
   if (isLaunchArmed(current, page6, page10))
   {
     // A configured vehicle speed limit applies only to launch control.
-    if ((page2.vssMode == 0) || (current.vss < page10.lnchCtrlVss))
+    if ((page2.vssMode == VSS_MODE_OFF) || (current.vss < page10.lnchCtrlVss))
     {
       const uint16_t launchRpmLimit = getHardCutRpmLimit(RPM_COARSE.toUser(page6.lnchHardLim), page2, page15);
       if (current.RPM > launchRpmLimit)

--- a/speeduino/src/controllers/launch/launchController.cpp
+++ b/speeduino/src/controllers/launch/launchController.cpp
@@ -63,4 +63,8 @@ void checkLaunchAndFlatShift(statuses &current, uint8_t launchPin, const config2
     const uint16_t flatRpmLimit = getHardCutRpmLimit(current.clutchEngagedRPM, page2, page15);
     current.flatShiftingHard = (current.RPM > flatRpmLimit);
   }
+  else
+  {
+    // Neither function is armed; retain the cleared hard-cut flags.
+  }
 }

--- a/speeduino/src/controllers/launch/launchController.cpp
+++ b/speeduino/src/controllers/launch/launchController.cpp
@@ -7,8 +7,7 @@ static void updateClutchState(statuses &current, uint8_t launchPin, const config
   // Only read the shared clutch input when a function using it is enabled.
   if (page6.flatSEnable || page6.launchEnabled)
   {
-    if (page6.launchHiLo > 0) { current.clutchTrigger = digitalRead(launchPin); }
-    else { current.clutchTrigger = !digitalRead(launchPin); }
+    current.clutchTrigger = (page6.launchHiLo == digitalRead(launchPin));
 
     current.clutchTriggerActive = current.clutchTrigger; // TunerStudio indication
   }
@@ -62,9 +61,6 @@ void checkLaunchAndFlatShift(statuses &current, uint8_t launchPin, const config2
         && (current.clutchEngagedRPM >= RPM_COARSE.toUser(page6.flatSArm)))
   {
     const uint16_t flatRpmLimit = getHardCutRpmLimit(current.clutchEngagedRPM, page2, page15);
-    if (current.RPM > flatRpmLimit)
-    {
-      current.flatShiftingHard = true;
-    }
+    current.flatShiftingHard = (current.RPM > flatRpmLimit);
   }
 }

--- a/test/test_launchcontrol/test_launchcontrol.cpp
+++ b/test/test_launchcontrol/test_launchcontrol.cpp
@@ -128,9 +128,178 @@ static void test_checkLaunchAndFlatShift_appliesRollingCutDelta(void)
     TEST_ASSERT_TRUE(current.hardLaunchActive);
 }
 
+
+struct launch_fixture
+{
+    statuses current = {};
+    config2 page2 = {};
+    config6 page6 = {};
+    config10 page10 = {};
+    config15 page15 = {};
+    static constexpr uint8_t pin = 13;
+
+    launch_fixture()
+    {
+        setClutch(true);
+        current.clutchTrigger = true;
+        current.clutchEngagedRPM = 3000;
+        current.RPM = 5000;
+        current.TPS = 50;
+        page6.launchEnabled = 1;
+        page6.flatSEnable = 1;
+        page6.launchHiLo = 1;
+        page6.flatSArm = 40;
+        page6.lnchHardLim = 45;
+        page10.lnchCtrlTPS = 50;
+        page10.lnchCtrlVss = 50;
+        page15.rollingProtRPMDelta[0] = -5;
+    }
+
+    void setClutch(bool engaged)
+    {
+        pinMode(pin, OUTPUT);
+        digitalWrite(pin, engaged ? HIGH : LOW);
+        pinMode(pin, INPUT);
+    }
+
+    void update()
+    {
+        checkLaunchAndFlatShift(current, pin, page2, page6, page10, page15);
+    }
+
+    void assertState(bool launch, bool flatShift)
+    {
+        TEST_ASSERT_EQUAL(launch, current.launchingHard);
+        TEST_ASSERT_EQUAL(launch, current.hardLaunchActive);
+        TEST_ASSERT_EQUAL(flatShift, current.flatShiftingHard);
+    }
+};
+
+static void assert_rpm_boundary(launch_fixture &fixture, uint16_t limit, bool flatShift)
+{
+    fixture.current.RPM = limit - 1U;
+    fixture.update();
+    fixture.assertState(false, false);
+    fixture.current.RPM = limit;
+    fixture.update();
+    fixture.assertState(false, false);
+    fixture.current.RPM = limit + 1U;
+    fixture.update();
+    fixture.assertState(!flatShift, flatShift);
+    fixture.current.RPM = limit;
+    fixture.update();
+    fixture.assertState(false, false); // Clear an already active cut at equality
+}
+
+static void test_launch_rpm_boundaries(void)
+{
+    launch_fixture fixture;
+    fixture.page2.hardCutType = HARD_CUT_FULL;
+    assert_rpm_boundary(fixture, 4500, false); // Full cut ignores the configured delta
+    fixture.page2.hardCutType = HARD_CUT_ROLLING;
+    assert_rpm_boundary(fixture, 4450, false);
+}
+
+static void test_flat_shift_rpm_boundaries(void)
+{
+    launch_fixture fixture;
+    fixture.current.clutchEngagedRPM = 6000;
+    fixture.page2.hardCutType = HARD_CUT_FULL;
+    assert_rpm_boundary(fixture, 6000, true);
+    fixture.page2.hardCutType = HARD_CUT_ROLLING;
+    assert_rpm_boundary(fixture, 5950, true);
+}
+
+static void test_launch_tps_boundary(void)
+{
+    launch_fixture fixture;
+    fixture.current.TPS = 49;
+    fixture.update();
+    fixture.assertState(false, false);
+    fixture.current.TPS = 50;
+    fixture.update();
+    fixture.assertState(true, false);
+    fixture.current.TPS = 51;
+    fixture.update();
+    fixture.assertState(true, false);
+}
+
+static void test_launch_speed_boundary(void)
+{
+    launch_fixture fixture;
+    for (uint8_t mode = 1; mode <= 3; ++mode)
+    {
+        fixture.page2.vssMode = mode;
+        fixture.current.vss = 49;
+        fixture.update();
+        fixture.assertState(true, false);
+        fixture.current.vss = 50;
+        fixture.update();
+        fixture.assertState(false, false);
+        fixture.current.vss = 51;
+        fixture.update();
+        fixture.assertState(false, false);
+    }
+    fixture.page2.vssMode = 0;
+    fixture.update();
+    fixture.assertState(true, false); // Ignore vehicle speed when VSS is disabled
+}
+
+static void test_clutch_arming_boundary(void)
+{
+    launch_fixture fixture;
+    fixture.current.clutchEngagedRPM = 3999;
+    fixture.update();
+    fixture.assertState(true, false);
+    fixture.current.clutchEngagedRPM = 4000;
+    fixture.update();
+    fixture.assertState(false, true); // Equality belongs to flat shift
+    fixture.current.clutchEngagedRPM = 4001;
+    fixture.update();
+    fixture.assertState(false, true);
+}
+
+static void test_clutch_rpm_is_captured_on_engagement(void)
+{
+    launch_fixture fixture;
+    fixture.current.clutchTrigger = false;
+    fixture.current.RPM = 3000;
+    fixture.update();
+    TEST_ASSERT_FALSE(fixture.current.previousClutchTrigger);
+    TEST_ASSERT_TRUE(fixture.current.clutchTriggerActive);
+    TEST_ASSERT_EQUAL_UINT16(3000, fixture.current.clutchEngagedRPM);
+
+    fixture.current.RPM = 5000;
+    fixture.update();
+    TEST_ASSERT_TRUE(fixture.current.previousClutchTrigger);
+    TEST_ASSERT_EQUAL_UINT16(3000, fixture.current.clutchEngagedRPM);
+    fixture.assertState(true, false);
+
+    fixture.setClutch(false);
+    fixture.update();
+    TEST_ASSERT_FALSE(fixture.current.clutchTriggerActive);
+    TEST_ASSERT_EQUAL_UINT16(3000, fixture.current.clutchEngagedRPM);
+    fixture.assertState(false, false);
+
+    fixture.setClutch(true);
+    fixture.current.RPM = 6000;
+    fixture.update();
+    TEST_ASSERT_EQUAL_UINT16(6000, fixture.current.clutchEngagedRPM);
+    fixture.assertState(false, false); // No full cut at the newly captured RPM
+    fixture.current.RPM = 6001;
+    fixture.update();
+    fixture.assertState(false, true);
+}
+
 void testLaunchControl(void)
 {
     SET_UNITY_FILENAME() {
+        RUN_TEST_P(test_launch_rpm_boundaries);
+        RUN_TEST_P(test_flat_shift_rpm_boundaries);
+        RUN_TEST_P(test_launch_tps_boundary);
+        RUN_TEST_P(test_launch_speed_boundary);
+        RUN_TEST_P(test_clutch_arming_boundary);
+        RUN_TEST_P(test_clutch_rpm_is_captured_on_engagement);
         RUN_TEST_P(test_checkLaunchAndFlatShift_enablesHardLaunchWhenConditionsAreMet);
         RUN_TEST_P(test_checkLaunchAndFlatShift_enablesFlatShiftWhenLaunchIsDisabled);
         RUN_TEST_P(test_checkLaunchAndFlatShift_usesInvertedLaunchInput);


### PR DESCRIPTION
Launch and flat-shift control currently mix clutch input sampling, engagement-RPM capture, eligibility checks and cut activation in one function. The rolling-cut RPM adjustment is also implemented separately for the two modes. Extract these responsibilities into small internal helpers so the conditions and their shared arithmetic can be reviewed independently.

`updateClutchState()` retains the enabled-only input read, polarity handling, previous-state tracking and rising-edge RPM capture. `isLaunchArmed()` names the launch eligibility conditions. `withinLaunchSpeedLimit()` uses `VSS_MODE_OFF`; its result is combined with `aboveLaunchRpmLimit()` using short-circuit evaluation, while retaining the outer launch/flat-shift priority. `getHardCutRpmLimit()` applies the rolling-cut adjustment for both launch and flat shift, using the existing `RPM_COARSE` and `SIGNED_RPM_MEDIUM` conversions instead of local scale factors. The clutch polarity and flat-shift flag use direct boolean comparisons. A documented final else branch explicitly retains the cleared flags when neither function is armed, addressing Sonar rule cpp:M23_112. The public interface and stored status/configuration layout are unchanged.

The existing behavior is retained:

- Engagement RPM is captured when the clutch is pressed and held until the next engagement.
- Launch requires engagement RPM below the arming threshold and TPS at or above its threshold.
- Equality at the arming RPM belongs to flat shift.
- With VSS enabled, launch requires speed strictly below the configured limit. Disabled VSS imposes no speed restriction.
- Full cut ignores the configured rolling delta; rolling cut applies the signed RPM/10 delta.
- Both cuts require RPM strictly above the resulting limit; flags clear when RPM returns to equality.

Six new characterization tests cover those boundaries and clutch transitions through the public controller function, alongside the four existing tests. Tests and implementation are in separate commits. The test fixture holds its own configuration/status objects and adds no firmware state.

Validation:

- All 10 `test_launchcontrol` native tests pass on upstream before the refactor and on the final implementation (4 injector / 4 ignition channels).
- Mega2560 firmware builds pass before and after, using upstream `d023d25d` and the same local toolchain/settings.
- `git diff --check` passes.

| Mega2560 occupied memory | Before | After | Delta |
| --- | ---: | ---: | ---: |
| RAM | 6,354 bytes | 6,354 bytes | 0 |
| Flash | 187,948 bytes | 187,950 bytes | +2 bytes |

Commands: `platformio test -e native_code_coverage -f test_launchcontrol` and `platformio run -e megaatmega2560`. Local Windows native tests used `-Wa,-mbig-obj -DINJ_CHANNELS=4 -DIGN_CHANNELS=4` through `PLATFORMIO_BUILD_FLAGS`. The AVR size comparison used a separate build directory to avoid interference from native test cleanup. Hardware/engine testing was not performed.

Review follow-ups are separate commits: 95cdef5e simplifies the boolean assignments; 7c41b986 adds the explicit inactive branch. All 10 native tests and the Mega build were rerun successfully on 7c41b986; the memory table above describes that revision. Remote CI/Sonar results for the update are separate from the local checks.

The subsequent review updates use VSS_MODE_OFF (2d2d4492) and extract the speed/RPM predicates (b45820d1). All 10 native tests and the Mega2560 build passed again on b45820d1, with the same memory figures shown above.
