### PR TITLE
Fan: honor cranking inhibition inside the hysteresis band

### DIFF
--- a/speeduino/src/controllers/fan/fanController.cpp
+++ b/speeduino/src/controllers/fan/fanController.cpp
@@ -49,11 +49,9 @@ void fanControl(void)
   {
     int onTemp = temperatureRemoveOffset(configPage6.fanSP);
     int offTemp = onTemp - configPage6.fanHyster;
-    bool fanPermit = false;
-
-    
-    if ( configPage2.fanWhenOff == true) { fanPermit = true; }
-    else { fanPermit = currentStatus.rotationStatus==EngineRotationStatus::Running; }
+    // Cranking inhibition must also override a held-on state in the hysteresis band.
+    const bool fanPermit = (configPage2.fanWhenOff || currentStatus.rotationStatus == EngineRotationStatus::Running)
+                        && (currentStatus.rotationStatus != EngineRotationStatus::Cranking || configPage2.fanWhenCranking);
 
     if ( (fanPermit == true) &&
          ((currentStatus.coolant >= onTemp) || 
@@ -61,17 +59,8 @@ void fanControl(void)
            currentStatus.acStatus.turningOn == true)) )
     {
       //Fan needs to be turned on - either by high coolant temp, or from an A/C request (to ensure there is airflow over the A/C radiator).
-      if((currentStatus.rotationStatus==EngineRotationStatus::Cranking) && (configPage2.fanWhenCranking == 0))
-      {
-        //If the user has elected to disable the fan during cranking, make sure it's off 
-        fanOff();
-        currentStatus.fanOn = false;
-      }
-      else 
-      {
-        fanOn();
-        currentStatus.fanOn = true;
-      }
+      fanOn();
+      currentStatus.fanOn = true;
     }
     else if ( (currentStatus.coolant <= offTemp) || (!fanPermit) )
     {

--- a/test/test_fancontrol/test_fancontrol.cpp
+++ b/test/test_fancontrol/test_fancontrol.cpp
@@ -311,10 +311,88 @@ static void test_fanControl_pwm_aircon_request_turns_fan_on(void)
 #endif
 }
 
+static void assert_fan_pin_state(bool active)
+{
+  TEST_ASSERT_EQUAL(active, currentStatus.fanOn);
+  TEST_ASSERT_EQUAL(active != (configPage6.fanInv != 0U), fan_pin._pin.isPinHigh());
+}
+
+static void assert_cranking_overrides_hysteresis(bool inverted)
+{
+  setup_nopwm_tune();
+  configPage6.fanInv = inverted;
+  configPage2.fanWhenOff = 1U;
+  configPage2.fanWhenCranking = 0U;
+  initialiseFan(TEST_FAN_PIN);
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
+  currentStatus.acStatus.turningOn = false;
+
+  const int16_t onTemp = temperatureRemoveOffset(configPage6.fanSP);
+  const int16_t holdTemp = onTemp - configPage6.fanHyster / 2U;
+  currentStatus.coolant = onTemp;
+  fanControl();
+  assert_fan_pin_state(true);
+  currentStatus.coolant = holdTemp;
+  fanControl();
+  assert_fan_pin_state(true);
+
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  fanControl();
+  assert_fan_pin_state(false);
+
+  // A/C demand must not bypass the configured cranking inhibit either.
+  configPage15.airConTurnsFanOn = 1U;
+  currentStatus.acStatus.turningOn = true;
+  fanControl();
+  assert_fan_pin_state(false);
+
+  // Resume normal hysteresis once cranking ends.
+  currentStatus.acStatus.turningOn = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
+  fanControl();
+  assert_fan_pin_state(false);
+  currentStatus.coolant = onTemp;
+  fanControl();
+  assert_fan_pin_state(true);
+}
+
+static void test_fanControl_cranking_overrides_hysteresis(void)
+{
+  assert_cranking_overrides_hysteresis(false);
+}
+
+static void test_fanControl_cranking_overrides_hysteresis_inverted(void)
+{
+  assert_cranking_overrides_hysteresis(true);
+}
+
+static void test_fanControl_cranking_preserves_hysteresis_when_permitted(void)
+{
+  setup_nopwm_tune();
+  configPage2.fanWhenOff = 1U;
+  configPage2.fanWhenCranking = 1U;
+  initialiseFan(TEST_FAN_PIN);
+  currentStatus.acStatus.turningOn = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
+  const int16_t onTemp = temperatureRemoveOffset(configPage6.fanSP);
+  currentStatus.coolant = onTemp - configPage6.fanHyster / 2U;
+  fanControl();
+  assert_fan_pin_state(false);
+  currentStatus.coolant = onTemp;
+  fanControl();
+  assert_fan_pin_state(true);
+  currentStatus.coolant = onTemp - configPage6.fanHyster / 2U;
+  fanControl();
+  assert_fan_pin_state(true);
+}
+
 void tesFanControl(void)
 {
   SET_UNITY_FILENAME()
   {
+    RUN_TEST_P(test_fanControl_cranking_overrides_hysteresis);
+    RUN_TEST_P(test_fanControl_cranking_overrides_hysteresis_inverted);
+    RUN_TEST_P(test_fanControl_cranking_preserves_hysteresis_when_permitted);
     RUN_TEST_P(test_fanControl_disabled_does_nothing);
     RUN_TEST_P(test_fanControl_nopwm_on_when_engine_running_and_hot);
     RUN_TEST_P(test_fanControl_pwm_on_when_engine_running_and_hot);


### PR DESCRIPTION
Fixes #1643.

An already-on radiator fan can remain on during cranking despite `fanWhenCranking = 0` when `fanWhenOff = 1` and coolant is inside the on/off hysteresis band. For example, with an 80 C on threshold and 5 C hysteresis, the fan turns on at 80 C, remains on at 78 C, and incorrectly remains on when the engine status changes to Cranking.

Move cranking inhibition into the regular on/off fan permission decision. The existing fan-off path then clears the output and status regardless of temperature hysteresis or A/C demand. Normal hysteresis is retained after cranking ends and when cranking fan operation is explicitly allowed. PWM logic, tune layout, public interfaces and output polarity handling are unchanged.

The regression tests drive the fan on through `fanControl()` before entering the hysteresis band, then check both `fanOn` and the logical output pin. They cover normal and inverted polarity, A/C demand during inhibited cranking, return to normal hysteresis, and explicitly permitted cranking operation. Tests and the firmware fix are separate commits.

Validation:

- Before the fix: 2 new regression tests fail (`Expected 0 Was 1`) and 25 fan-suite cases pass.
- After the fix: all 27 `test_fancontrol` native cases pass (4 injector / 4 ignition channels).
- Mega2560 firmware builds pass before and after using upstream `d023d25d` and identical toolchain/settings.
- `git diff --check` passes.

| Mega2560 occupied memory | Before | After | Delta |
| --- | ---: | ---: | ---: |
| RAM | 6,354 bytes | 6,354 bytes | 0 |
| Flash | 187,948 bytes | 187,912 bytes | -36 bytes |

Commands: `platformio test -e native_code_coverage -f test_fancontrol` and `platformio run -e megaatmega2560`. Local Windows native testing used `-Wa,-mbig-obj -DINJ_CHANNELS=4 -DIGN_CHANNELS=4` through `PLATFORMIO_BUILD_FLAGS`. An isolated AVR build directory prevented interference from native test cleanup. No hardware/engine reproduction is claimed.
