### PR TITLE
Fix VMax decoder cranking RPM threshold

### DIFF
--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -5118,7 +5118,7 @@ static uint16_t getRPM_Vmax(void)
   uint16_t tempRPM = 0;
   if (decoderStatus.syncStatus==SyncStatus::Full)
   {
-    if ( currentStatus.RPM < (unsigned int)(configPage4.crankRPM * 100) )
+    if ( currentStatus.RPM < currentStatus.crankRPM )
     {
       int tempToothAngle;
       unsigned long toothTime;

--- a/test/test_decoders/VMax/VMax.cpp
+++ b/test/test_decoders/VMax/VMax.cpp
@@ -2,6 +2,7 @@
 #include "crankMaths.h"
 #include "../test_utils.h"
 #include "globals.h"
+#include "units.h"
 
 static void test_getCrankAngle(void)
 {
@@ -44,14 +45,14 @@ static void test_getRPM(void)
   extern volatile unsigned long toothOneTime;
   extern volatile unsigned long toothOneMinusOneTime;
   extern volatile int secondaryToothCount;
-  extern uint16_t triggerToothAngle;
+  extern volatile uint16_t triggerToothAngle;
 
   auto decoder = triggerSetup_Vmax();
 
   // --- Cranking-style calculation when RPM below threshold: computes using last-tooth gap * 36
   currentStatus.setRpm(0);
-  currentStatus.crankRPM = 400;
-  configPage4.crankRPM = 4;
+  configPage4.crankRPM = 40; // 400 RPM
+  currentStatus.crankRPM = RPM_MEDIUM.toUser(configPage4.crankRPM);
   currentStatus.startRevolutions = 0; // cranking
   decoderStatus.syncStatus = SyncStatus::Full;
   currentStatus.revolutionTime = UINT32_MAX; // To trigger a change
@@ -71,8 +72,8 @@ static void test_getRPM(void)
 
   // --- Running path: use stdGetRPM via toothOne pair -> RpmFromRevolutionTimeUs
   currentStatus.setRpm(2000);
-  currentStatus.crankRPM = 100; // ensure not considered cranking
-  configPage4.crankRPM = 1;
+  configPage4.crankRPM = 10; // 100 RPM
+  currentStatus.crankRPM = RPM_MEDIUM.toUser(configPage4.crankRPM);
   currentStatus.startRevolutions = 1; // not cranking
   decoderStatus.syncStatus = SyncStatus::Full;
   toothOneMinusOneTime = 1000UL;
@@ -86,10 +87,55 @@ static void test_getRPM(void)
 
 }
 
+static void assert_getRPM_at_cranking_boundary(uint16_t rpm, uint16_t expected)
+{
+  extern decoder_status_t decoderStatus;
+  extern volatile unsigned long toothOneTime;
+  extern volatile unsigned long toothOneMinusOneTime;
+  extern volatile unsigned long toothLastToothTime;
+  extern volatile unsigned long toothLastMinusOneToothTime;
+  extern volatile uint16_t triggerToothAngle;
+
+  auto decoder = triggerSetup_Vmax();
+  configPage4.crankRPM = 40; // Stored in RPM/10, so the boundary is 400 RPM
+  currentStatus.crankRPM = RPM_MEDIUM.toUser(configPage4.crankRPM);
+  currentStatus.setRpm(rpm);
+  currentStatus.startRevolutions = 1;
+  currentStatus.revolutionTime = UINT32_MAX;
+  decoderStatus.syncStatus = SyncStatus::Full;
+
+  // Deliberately different results distinguish which calculation was selected:
+  // last-tooth angle/gap -> 1000 RPM; complete revolution -> 1500 RPM.
+  triggerToothAngle = 120;
+  toothLastMinusOneToothTime = 1000UL;
+  toothLastToothTime = 21000UL;
+  toothOneMinusOneTime = 1000UL;
+  toothOneTime = 41000UL;
+  TEST_ASSERT_EQUAL_UINT16(expected, decoder.getRPM());
+}
+
+static void test_getRPM_below_cranking_boundary(void)
+{
+  assert_getRPM_at_cranking_boundary(399, 1000);
+}
+
+static void test_getRPM_at_cranking_boundary(void)
+{
+  assert_getRPM_at_cranking_boundary(400, 1500);
+}
+
+static void test_getRPM_above_cranking_boundary(void)
+{
+  assert_getRPM_at_cranking_boundary(401, 1500);
+}
+
 void testVMax(void)
 {
   SET_UNITY_FILENAME() {
     RUN_TEST_P(test_getCrankAngle);
     RUN_TEST_P(test_getRPM);
+    RUN_TEST_P(test_getRPM_below_cranking_boundary);
+    RUN_TEST_P(test_getRPM_at_cranking_boundary);
+    RUN_TEST_P(test_getRPM_above_cranking_boundary);
   }
 }


### PR DESCRIPTION
Fixes #1613.

The VMax decoder compares engine speed against `configPage4.crankRPM * 100`, even though the configuration stores RPM divided by 10. A configured 400 RPM cranking limit therefore keeps the last-tooth cranking calculation selected until 4,000 RPM instead of switching to the complete-revolution calculation at 400 RPM.

Use `currentStatus.crankRPM`, the existing scaled threshold populated during initialization and refreshed by the timer task. This follows the threshold used by the other decoders. The production change is one comparison; it introduces no configuration fields, EEPROM/tune layout changes, or additional runtime state.

### Regression coverage

- Add cases immediately below, at, and above a configured 400 RPM threshold: 399, 400, and 401 RPM.
- Give the last-tooth and complete-revolution calculations deliberately different results (1,000 and 1,500 RPM), so the tests detect which path was selected. The existing nominal test used inputs that could give the same result through either calculation.
- Keep the test configuration and cached threshold consistent using `RPM_MEDIUM.toUser`.
- Match the test declaration of `triggerToothAngle` to its actual `volatile uint16_t` definition.

Tests and the production fix are separate commits. This PR only changes the VMax decoder; the companion decoder issue is handled independently.

### Validation

On the unchanged upstream implementation at `d023d25d507c44a504bb56a3f8249047f24d6025`, the full native decoder suite ran 109 cases: the new at/above-boundary cases failed (expected 1,500, got 1,000), and the other 107 passed.

After the fix, all **109 decoder tests passed**. The default Mega2560 firmware build also passed:

| Resource | Upstream baseline | This isolated fix | Delta |
| --- | ---: | ---: | ---: |
| Static RAM | 6,354 B | 6,354 B | 0 B |
| Flash | 187,948 B | 187,720 B | -228 B |

Native test command on Windows/MinGW:

```powershell
$env:PLATFORMIO_BUILD_FLAGS='-Wa,-mbig-obj -DINJ_CHANNELS=4 -DIGN_CHANNELS=4'
python -m platformio test -e native_code_coverage -f test_decoders
```

The Mega2560 build uses `python -m platformio run -e megaatmega2560` without the native-only flags. Memory figures compare each isolated fix against the same upstream commit with the same board environment. Static RAM totals do not measure stack use or execution timing.

Validation uses synthetic decoder inputs and a firmware build; no physical ECU/engine bench test was performed.
