### PR TITLE
Fix Harley decoder cranking RPM threshold

### DIFF
--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -3744,7 +3744,7 @@ static uint16_t getRPM_Harley(void)
   uint16_t tempRPM = 0;
   if (decoderStatus.syncStatus==SyncStatus::Full)
   {
-    if ( currentStatus.RPM < (unsigned int)(configPage4.crankRPM * 100) )
+    if ( currentStatus.RPM < currentStatus.crankRPM )
     {
       // No difference with this option?
       int tempToothAngle;

--- a/test/test_decoders/Harley/Harley.cpp
+++ b/test/test_decoders/Harley/Harley.cpp
@@ -2,6 +2,7 @@
 #include "crankMaths.h"
 #include "../test_utils.h"
 #include "globals.h"
+#include "units.h"
 
 static void test_getCrankAngle(void)
 {
@@ -67,14 +68,15 @@ static void test_getRPM(void)
   extern volatile unsigned long toothLastToothTime;
   extern volatile unsigned long toothLastMinusOneToothTime;
   extern decoder_status_t decoderStatus;
-  extern unsigned int triggerToothAngle;
+  extern volatile uint16_t triggerToothAngle;
 
   // Ensure sync present
   decoderStatus.syncStatus = SyncStatus::Full;
 
-  // --- Cranking-like branch: currentStatus.RPM < configPage4.crankRPM*100
+  // --- Cranking calculation below the configured RPM/10 threshold
   currentStatus.setRpm(0);
-  configPage4.crankRPM = 100; // 100*100 = 10000 > 0 -> take special branch
+  configPage4.crankRPM = 100; // 1000 RPM
+  currentStatus.crankRPM = RPM_MEDIUM.toUser(configPage4.crankRPM);
   // Choose tempToothAngle = 120 and gap such that final RPM = 1000
   triggerToothAngle = 120;
   toothLastMinusOneToothTime = 1000UL;
@@ -86,7 +88,8 @@ static void test_getRPM(void)
 
   // --- Running path: should call stdGetRPM(CRANK_SPEED)
   currentStatus.setRpm(2000);
-  configPage4.crankRPM = 10; // 10*100 = 1000 < 2000 -> use stdGetRPM
+  configPage4.crankRPM = 10; // 100 RPM
+  currentStatus.crankRPM = RPM_MEDIUM.toUser(configPage4.crankRPM);
   // Set toothOne* so stdGetRPM will compute 1000 RPM (revTime = 60000)
   currentStatus.revolutionTime = 12345UL; // ensure SetRevolutionTime will change
   toothOneMinusOneTime = 1000UL;
@@ -98,10 +101,55 @@ static void test_getRPM(void)
   TEST_ASSERT_EQUAL_UINT16(0, decoder.getRPM());
 }
 
+static void assert_getRPM_at_cranking_boundary(uint16_t rpm, uint16_t expected)
+{
+  extern decoder_status_t decoderStatus;
+  extern volatile unsigned long toothOneTime;
+  extern volatile unsigned long toothOneMinusOneTime;
+  extern volatile unsigned long toothLastToothTime;
+  extern volatile unsigned long toothLastMinusOneToothTime;
+  extern volatile uint16_t triggerToothAngle;
+
+  auto decoder = triggerSetup_Harley();
+  configPage4.crankRPM = 40; // Stored in RPM/10, so the boundary is 400 RPM
+  currentStatus.crankRPM = RPM_MEDIUM.toUser(configPage4.crankRPM);
+  currentStatus.setRpm(rpm);
+  currentStatus.startRevolutions = 1;
+  currentStatus.revolutionTime = UINT32_MAX;
+  decoderStatus.syncStatus = SyncStatus::Full;
+
+  // Deliberately different results distinguish which calculation was selected:
+  // last-tooth angle/gap -> 1000 RPM; complete revolution -> 1500 RPM.
+  triggerToothAngle = 120;
+  toothLastMinusOneToothTime = 1000UL;
+  toothLastToothTime = 21000UL;
+  toothOneMinusOneTime = 1000UL;
+  toothOneTime = 41000UL;
+  TEST_ASSERT_EQUAL_UINT16(expected, decoder.getRPM());
+}
+
+static void test_getRPM_below_cranking_boundary(void)
+{
+  assert_getRPM_at_cranking_boundary(399, 1000);
+}
+
+static void test_getRPM_at_cranking_boundary(void)
+{
+  assert_getRPM_at_cranking_boundary(400, 1500);
+}
+
+static void test_getRPM_above_cranking_boundary(void)
+{
+  assert_getRPM_at_cranking_boundary(401, 1500);
+}
+
 void testHarley(void)
 {
   SET_UNITY_FILENAME() {
     RUN_TEST_P(test_getCrankAngle);
     RUN_TEST_P(test_getRPM);
+    RUN_TEST_P(test_getRPM_below_cranking_boundary);
+    RUN_TEST_P(test_getRPM_at_cranking_boundary);
+    RUN_TEST_P(test_getRPM_above_cranking_boundary);
   }
 }


### PR DESCRIPTION
Fixes #1612.

The Harley decoder compares engine speed against `configPage4.crankRPM * 100`, even though the configuration stores RPM divided by 10. A configured 400 RPM cranking limit therefore keeps the last-tooth cranking calculation selected until 4,000 RPM instead of switching to the complete-revolution calculation at 400 RPM.

Use `currentStatus.crankRPM`, the existing scaled threshold populated during initialization and refreshed by the timer task. This follows the threshold used by the other decoders. The production change is one comparison; it introduces no configuration fields, EEPROM/tune layout changes, or additional runtime state.

### Regression coverage

- Add cases immediately below, at, and above a configured 400 RPM threshold: 399, 400, and 401 RPM.
- Give the last-tooth and complete-revolution calculations deliberately different results (1,000 and 1,500 RPM), so the tests detect which path was selected. The existing nominal test used inputs that could give the same result through either calculation.
- Keep the test configuration and cached threshold consistent using `RPM_MEDIUM.toUser`.
- Match the test declaration of `triggerToothAngle` to its actual `volatile uint16_t` definition.

Tests and the production fix are separate commits. This PR only changes the Harley decoder; the companion decoder issue is handled independently.

### Validation

On the unchanged upstream implementation at `d023d25d507c44a504bb56a3f8249047f24d6025`, the full native decoder suite ran 109 cases: the new at/above-boundary cases failed (expected 1,500, got 1,000), and the other 107 passed.

After the fix, all **109 decoder tests passed**. The default Mega2560 firmware build also passed:

| Resource | Upstream baseline | This isolated fix | Delta |
| --- | ---: | ---: | ---: |
| Static RAM | 6,354 B | 6,354 B | 0 B |
| Flash | 187,948 B | 187,720 B | -228 B |

Native test command on Windows/MinGW:

```powershell
$env:PLATFORMIO_BUILD_FLAGS='-Wa,-mbig-obj -DINJ_CHANNELS=4 -DIGN_CHANNELS=4'
python -m platformio test -e native_code_coverage -f test_decoders
```

The Mega2560 build uses `python -m platformio run -e megaatmega2560` without the native-only flags. Memory figures compare each isolated fix against the same upstream commit with the same board environment. Static RAM totals do not measure stack use or execution timing.

Validation uses synthetic decoder inputs and a firmware build; no physical ECU/engine bench test was performed.
