### PR TITLE
Use board-specific analog mode for fuel and oil pressure inputs

### DIFF
--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -328,37 +328,24 @@ void setPinMapping(byte boardID)
   //This is a legacy mode option to revert the MAP reading behaviour to match what was in place prior to the 201905 firmware
   if(configPage2.legacyMAP > 0) { digitalWrite(pinNumbers.pinMAP, HIGH); }
 
-  //And for inputs
-  #if defined(CORE_STM32)
-    #ifdef INPUT_ANALOG
-      pinMode(pinNumbers.pinMAP, INPUT_ANALOG);
-      pinMode(pinNumbers.pinO2, INPUT_ANALOG);
-      pinMode(pinNumbers.pinO2_2, INPUT_ANALOG);
-      pinMode(pinNumbers.pinTPS, INPUT_ANALOG);
-      pinMode(pinNumbers.pinIAT, INPUT_ANALOG);
-      pinMode(pinNumbers.pinCLT, INPUT_ANALOG);
-      pinMode(pinNumbers.pinBat, INPUT_ANALOG);
-      pinMode(pinNumbers.pinBaro, INPUT_ANALOG);
-    #else
-      pinMode(pinNumbers.pinMAP, INPUT);
-      pinMode(pinNumbers.pinO2, INPUT);
-      pinMode(pinNumbers.pinO2_2, INPUT);
-      pinMode(pinNumbers.pinTPS, INPUT);
-      pinMode(pinNumbers.pinIAT, INPUT);
-      pinMode(pinNumbers.pinCLT, INPUT);
-      pinMode(pinNumbers.pinBat, INPUT);
-      pinMode(pinNumbers.pinBaro, INPUT);
-    #endif
+  // Select the board-specific mode once for the analog inputs configured here.
+  #if defined(CORE_STM32) && defined(INPUT_ANALOG)
+    constexpr auto analogInputMode = INPUT_ANALOG;
   #elif defined(CORE_TEENSY41)
-    //Teensy 4.1 has a weak pull down resistor that needs to be disabled for all analog pinNumbers. 
-    pinMode(pinNumbers.pinMAP, INPUT_DISABLE);
-    pinMode(pinNumbers.pinO2, INPUT_DISABLE);
-    pinMode(pinNumbers.pinO2_2, INPUT_DISABLE);
-    pinMode(pinNumbers.pinTPS, INPUT_DISABLE);
-    pinMode(pinNumbers.pinIAT, INPUT_DISABLE);
-    pinMode(pinNumbers.pinCLT, INPUT_DISABLE);
-    pinMode(pinNumbers.pinBat, INPUT_DISABLE);
-    pinMode(pinNumbers.pinBaro, INPUT_DISABLE);
+    constexpr auto analogInputMode = INPUT_DISABLE;
+  #else
+    constexpr auto analogInputMode = INPUT;
+  #endif
+
+  #if defined(CORE_STM32) || defined(CORE_TEENSY41)
+    pinMode(pinNumbers.pinMAP, analogInputMode);
+    pinMode(pinNumbers.pinO2, analogInputMode);
+    pinMode(pinNumbers.pinO2_2, analogInputMode);
+    pinMode(pinNumbers.pinTPS, analogInputMode);
+    pinMode(pinNumbers.pinIAT, analogInputMode);
+    pinMode(pinNumbers.pinCLT, analogInputMode);
+    pinMode(pinNumbers.pinBat, analogInputMode);
+    pinMode(pinNumbers.pinBaro, analogInputMode);
   #endif
 
   //Each of the below are only set when their relevant function is enabled. This can help prevent pin conflicts that users aren't aware of with unused functions

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -380,11 +380,11 @@ void setPinMapping(byte boardID)
   }
   if( (configPage10.fuelPressureEnable > 0)  && (!pinIsOutput(pinNumbers.pinFuelPressure)) )
   {
-    pinMode(pinNumbers.pinFuelPressure, INPUT);
+    pinMode(pinNumbers.pinFuelPressure, analogInputMode);
   }
   if( (configPage10.oilPressureEnable > 0) && (!pinIsOutput(pinNumbers.pinOilPressure)) )
   {
-    pinMode(pinNumbers.pinOilPressure, INPUT);
+    pinMode(pinNumbers.pinOilPressure, analogInputMode);
   }
 #ifdef SD_LOGGING
   if( (configPage13.onboard_log_trigger_Epin > 0) && (!pinIsOutput(pinNumbers.pinSDEnable)) )

--- a/test/test_init/main.cpp
+++ b/test/test_init/main.cpp
@@ -29,10 +29,12 @@ void runAllInitTests(void)
     extern void testInitialisation(void);
     extern void testIgnitionScheduleInit(void);
     extern void testPinMapping(void);
+    extern void testPressureInputs(void);
 
     testInitialisation();
     testIgnitionScheduleInit();
     testPinMapping();
+    testPressureInputs();
 }
 
 TEST_HARNESS(runAllInitTests)

--- a/test/test_init/test_pressure_inputs.cpp
+++ b/test/test_init/test_pressure_inputs.cpp
@@ -1,0 +1,84 @@
+#include "globals.h"
+#include "init.h"
+#include "../test_utils.h"
+
+void prepareForInitialiseAll(uint8_t boardId);
+uint8_t getPinMode(uint8_t pin);
+
+#if defined(CORE_AVR) || defined(NATIVE_BOARD)
+static void prepare_pressure_inputs(void)
+{
+  prepareForInitialiseAll(3);
+  configPage10.fuelPressurePin = 8; // A8 on Mega2560
+  configPage10.oilPressurePin = 9; // A9 on Mega2560
+  // A sentinel catches unwanted mode changes when disabled or conflicting.
+  pinMode(A8, OUTPUT);
+  pinMode(A9, OUTPUT);
+}
+#endif
+
+static void test_enabled_pressure_inputs(void)
+{
+#if defined(CORE_AVR) || defined(NATIVE_BOARD)
+  prepare_pressure_inputs();
+  configPage10.fuelPressureEnable = true;
+  configPage10.oilPressureEnable = true;
+  setPinMapping(3);
+
+  TEST_ASSERT_EQUAL_UINT8(A8, pinNumbers.pinFuelPressure);
+  TEST_ASSERT_EQUAL_UINT8(A9, pinNumbers.pinOilPressure);
+  TEST_ASSERT_EQUAL_UINT8(INPUT, getPinMode(A8));
+  TEST_ASSERT_EQUAL_UINT8(INPUT, getPinMode(A9));
+#else
+  TEST_IGNORE_MESSAGE("Pin-mode readback uses Mega2560 registers");
+#endif
+}
+
+static void test_disabled_pressure_inputs_leave_pins_unchanged(void)
+{
+#if defined(CORE_AVR) || defined(NATIVE_BOARD)
+  prepare_pressure_inputs();
+  configPage10.fuelPressureEnable = false;
+  configPage10.oilPressureEnable = false;
+  setPinMapping(3);
+
+  TEST_ASSERT_EQUAL_UINT8(OUTPUT, getPinMode(A8));
+  TEST_ASSERT_EQUAL_UINT8(OUTPUT, getPinMode(A9));
+#else
+  TEST_IGNORE_MESSAGE("Pin-mode readback uses Mega2560 registers");
+#endif
+}
+
+static void test_pressure_inputs_do_not_override_outputs(void)
+{
+#if defined(CORE_AVR) || defined(NATIVE_BOARD)
+  prepare_pressure_inputs();
+  configPage10.fuelPressureEnable = true;
+  configPage10.oilPressureEnable = true;
+  // Out-of-range analog indices are passed through as physical pin numbers.
+  // Even a bad pressure-pin assignment must not reconfigure active outputs.
+  configPage10.fuelPressurePin = 17;
+  configPage2.tachoPin = 17;
+  configPage10.oilPressurePin = 18;
+  configPage4.fuelPumpPin = 18;
+  pinMode(17, OUTPUT);
+  pinMode(18, OUTPUT);
+  setPinMapping(3);
+
+  TEST_ASSERT_EQUAL_UINT8(pinNumbers.pinTachOut, pinNumbers.pinFuelPressure);
+  TEST_ASSERT_EQUAL_UINT8(pinNumbers.pinFuelPump, pinNumbers.pinOilPressure);
+  TEST_ASSERT_EQUAL_UINT8(OUTPUT, getPinMode(17));
+  TEST_ASSERT_EQUAL_UINT8(OUTPUT, getPinMode(18));
+#else
+  TEST_IGNORE_MESSAGE("Pin-mode readback uses Mega2560 registers");
+#endif
+}
+
+void testPressureInputs(void)
+{
+  SET_UNITY_FILENAME() {
+    RUN_TEST_P(test_enabled_pressure_inputs);
+    RUN_TEST_P(test_disabled_pressure_inputs_leave_pins_unchanged);
+    RUN_TEST_P(test_pressure_inputs_do_not_override_outputs);
+  }
+}


### PR DESCRIPTION
Fixes #1500. Fixes #1501.

Fuel- and oil-pressure initialization always passes `INPUT` to `pinMode`, while the main analog sensors select `INPUT_DISABLE` on Teensy 4.1 or `INPUT_ANALOG` on STM32 cores that provide it. This makes the two enabled pressure inputs inconsistent with the board-specific analog initialization policy.

Select the analog mode once, at compile time, within `setPinMapping()` and use it for both pressure inputs as well as the existing main analog-input block. The main block remains restricted to STM32 and Teensy 4.1, so this does not add initialization calls for the primary sensors on AVR or other boards.

| Target | Pressure-input mode after the fix |
| --- | --- |
| STM32 with `INPUT_ANALOG` | `INPUT_ANALOG` |
| STM32 without `INPUT_ANALOG` | `INPUT` (existing fallback) |
| Teensy 4.1 | `INPUT_DISABLE` |
| Mega2560 / other targets | `INPUT` (unchanged) |

The existing enable checks, analog pin translation, and `pinIsOutput()` guards remain in place. No new configuration fields, EEPROM/INI layout, runtime state or periodic work are introduced. This is a pin-initialization fix; it does not change pressure conversion, filtering or protection thresholds, and does not introduce pin-conflict arbitration.

### Commits

1. Add pressure-input initialization tests for enabled/disabled inputs and conflicts with tacho/fuel-pump outputs.
2. Consolidate the existing board-specific analog mode selection and remove repeated main-sensor calls.
3. Apply that mode to fuel and oil pressure.

### Validation

- Native `test_init` before and after: **48 passed, 6 existing skips, 0 failed** (54 total). This includes all three new enabled/disabled/conflicting-pressure-input cases.
- Default Mega2560 and Teensy 4.1 firmware builds succeeded before and after, using the same toolchains/settings and upstream `d023d25d` baseline.
- Mega2560 HEX files are byte-for-byte identical (SHA-256 `39937fc2efbf8bc18384f798f0dd9c961c9b2cea87cd3688f44db7b296a4c3dc`).
- Teensy `init.cpp` object disassembly differs only in the two pressure-input mode instructions: the `pinMode` argument changes from zero (`INPUT`) to five (`INPUT_DISABLE`). This confirms the intended ARM code path without claiming a physical sensor test.

| Target/resource | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Mega2560 static RAM | 6,354 B | 6,354 B | 0 B |
| Mega2560 flash | 187,948 B | 187,948 B | 0 B |
| Teensy 4.1 flash (code + data + headers) | 248,828 B | 248,828 B | 0 B |
| Teensy 4.1 RAM1 (variables + code + padding) | 266,144 B | 266,144 B | 0 B |
| Teensy 4.1 RAM2 variables | 12,416 B | 12,416 B | 0 B |

Native command on Windows/MinGW:

```powershell
$env:PLATFORMIO_BUILD_FLAGS='-Wa,-mbig-obj -DINJ_CHANNELS=4 -DIGN_CHANNELS=4'
python -m platformio test -e native_code_coverage -f test_init
```

Firmware command, without the native-only flags:

```text
python -m platformio run -e megaatmega2560 -e teensy41
```

The new register-readback tests run on AVR and the native Mega mock. They protect unchanged Mega input/ownership behavior; they do not emulate ARM GPIO registers or establish analog measurement quality. ARM validation is described separately above. No physical ECU or sensor bench test was performed.

A local STM32 build was attempted with the compatible `platform = ststm32@19.5.0` override from #1640, but its required ARM toolchain installation stalled and was stopped. No successful local STM32 build or test result is claimed. The override is uncommitted and this PR does not duplicate the platform change.
